### PR TITLE
Add GQL query for latest round match/prediction data

### DIFF
--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -20,7 +20,7 @@ html5lib
 # App packages
 django
 whitenoise
-graphene>=2.0
+graphene>=2.1.5
 graphene-django>=2.0
 psycopg2-binary
 dj-database-url

--- a/backend/server/schema.py
+++ b/backend/server/schema.py
@@ -37,6 +37,16 @@ class MatchType(DjangoObjectType):
 
     winner = graphene.Field(TeamType)
     year = graphene.Int()
+    home_team = graphene.Field(TeamType)
+    away_team = graphene.Field(TeamType)
+
+    @staticmethod
+    def resolve_home_team(root, _info):
+        return root.teammatch_set.get(at_home=True).team
+
+    @staticmethod
+    def resolve_away_team(root, _info):
+        return root.teammatch_set.get(at_home=False).team
 
 
 class TeamMatchType(DjangoObjectType):

--- a/backend/server/tests/unit/test_schema.py
+++ b/backend/server/tests/unit/test_schema.py
@@ -133,6 +133,26 @@ class TestSchema(TestCase):
 
         self.assertLessEqual(sum(earlier_round_counts), sum(later_round_counts))
 
+    def test_latest_round_predictions(self):
+        executed = self.client.execute(
+            """
+            query QueryType {
+                latestRoundPredictions(mlModelName: "accurate_af") {
+                    roundNumber
+                    matches {
+                        predictionSet { predictedWinner { name }, predictedMargin }
+                        teammatchSet { team { name } }
+                    }
+                }
+            }
+            """
+        )
+
+        data = executed["data"]["latestRoundPredictions"]
+        max_match_round = max([match.round_number for match in self.matches])
+
+        self.assertEqual(data["roundNumber"], max_match_round)
+
     def _assert_correct_prediction_results(self, results, expected_results):
         # graphene returns OrderedDicts instead of dicts, which makes asserting
         # on results a little more complicated

--- a/backend/server/tests/unit/test_schema.py
+++ b/backend/server/tests/unit/test_schema.py
@@ -154,7 +154,9 @@ class TestSchema(TestCase):
                     roundNumber
                     matches {
                         predictionSet { predictedWinner { name }, predictedMargin }
-                        teammatchSet { team { name } }
+                        winner { name }
+                        homeTeam { name }
+                        awayTeam { name }
                     }
                 }
             }


### PR DESCRIPTION
For one of the data widgets, we want to display predictions for matches from the upcoming/current/most-recent round (depending on day of week & availability of data). This required some reorganisation of existing types, which were a bit haphazard, into a structure that hopefully makes more sense. I also figured out some things about how `graphene` works along the way, which allowed me to simplify & clean up the schema code a little.