### PR TITLE
Remove unnecessary pull of afl_data image

### DIFF
--- a/deploy.sh
+++ b/deploy.sh
@@ -12,5 +12,4 @@ sudo chmod 755 ~/.ssh
 scp -i ~/.ssh/deploy_rsa docker-compose.prod.yml ${DEPLOY_USER}@${IP_ADDRESS}:~/tipresias/docker-compose.yml
 
 ssh -i ~/.ssh/deploy_rsa ${DEPLOY_USER}@${IP_ADDRESS} "docker pull cfranklin11/tipresias_app:latest \
-  && docker pull cfranklin11/tipresias_afl_data:latest \
   && docker-compose -f ./tipresias/docker-compose.yml up -d --build"

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -11,7 +11,6 @@ services:
     tty: true
     depends_on:
       - db
-      - afl_data
     env_file: .env
     environment:
       - DJANGO_SETTINGS_MODULE=project.settings.production


### PR DESCRIPTION
No need to pull an image that we're no longer using. Also, the deploy broke, because a reference to `afl_data` was still in the prod `docker-compose.yml`.