### PR TITLE
Fix graphql bugs

### DIFF
--- a/backend/project/urls.py
+++ b/backend/project/urls.py
@@ -24,7 +24,9 @@ urlpatterns = [  # pylint: disable=C0103
     path("admin/", admin.site.urls),
     re_path(
         "^graphql",
-        csrf_exempt(GraphQLView.as_view(graphiql=os.getenv("GRAPHIQL", default=False))),
+        csrf_exempt(GraphQLView.as_view(graphiql=(os.getenv("GRAPHIQL") or False))),
     ),
-    re_path(".*", TemplateView.as_view(template_name="index.html")),
 ]
+
+if os.getenv("DJANGO_SETTINGS_MODULE") == "project.settings.production":
+    urlpatterns.append(re_path(".*", TemplateView.as_view(template_name="index.html")))

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -18,13 +18,13 @@ bs4
 html5lib
 
 # App packages
-django>=2.2
+django>=2.2,<2.99
 whitenoise
-graphene>=2.1.5
-graphene-django>=2.0
+graphene>=2.1.5,<2.1.99
+graphene-django==2.2.0 # Can't upgrade to 2.3.x, due to weird graphiql.js bug
 psycopg2-binary
 dj-database-url
-sendgrid>=6.0
+sendgrid>=6.0,<6.99
 django_cron
 
 # Testing/Linting

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -18,7 +18,7 @@ bs4
 html5lib
 
 # App packages
-django
+django>=2.2
 whitenoise
 graphene>=2.1.5
 graphene-django>=2.0

--- a/backend/server/schema.py
+++ b/backend/server/schema.py
@@ -158,7 +158,7 @@ class SeasonType(graphene.ObjectType):
 
         return (
             pd.DataFrame(list(query_set))
-            .assign(cumulative_correct=calculate_cumulative_correct)
+            .assign(cumulative_correct_count=calculate_cumulative_correct)
             .groupby(["match__round_number", "ml_model__name"])
             .mean()
             .pipe(round_predictions)


### PR DESCRIPTION
A recent release of `graphene-django` is broken five ways to Sunday, so I fixed our version to `2.2.0`. While figuring out the source of the issue, I went ahead and fixes a Django template error in dev that wasn't breaking anything, and updated package version limits to reflect actual pip syntax rather than what I imagined the syntax was.

There was also a bug in calculating cumulative correct values, so I fixed that too.