### PR TITLE
Script to load db dumps from prod into local db

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,9 @@ Child of [Footy Tipper](https://github.com/cfranklin11/footy-tipper), Tipresias,
 - To build and run the app: `docker-compose up --build`
 - Migrate the DB: `docker-compose run --rm backend python3 manage.py migrate`
 - Seed the DB: `docker-compose run --rm backend python3 manage.py seed_db`
+- Reset the DB to match production: `./reset_db.sh`
+  - This requires ability to `ssh` into the prod server
+  - `PROD_USER` and `IP_ADDRESS` environment variables have to be set in the current bash session, and their values have to be applicable to the relevant server
 
 ### Run the app
 

--- a/reset_db.sh
+++ b/reset_db.sh
@@ -1,0 +1,15 @@
+#!/bin/bash
+
+DB_FILE=dump_`date +%d-%m-%Y"_"%H_%M_%S`.sql
+
+ssh ${PROD_USER}@${IP_ADDRESS} "docker exec -t -u postgres tipresias_db_1 pg_dumpall -c > ~/backups/${DB_FILE}"
+scp ${PROD_USER}@${IP_ADDRESS}:~/backups/${DB_FILE} $PWD
+ssh ${PROD_USER}@${IP_ADDRESS} "rm ~/backups/${DB_FILE}"
+
+docker-compose rm -s -v db
+docker-compose up -d db
+# Not ideal, but wait-for-it was listening for the port to be ready, but that
+# wasn't enough time for the DB to be ready to accept commands,
+# so we're sleeping instead
+sleep 3
+cat ${DB_FILE} | docker exec -i tipresias_db_1 psql -Upostgres


### PR DESCRIPTION
Sometimes we need up-to-date data to properly develop and test features, and manually resetting the local DB, then exporting & downloading the prod DB was a bit of a pain, so I wrote a script for that.