### PR TITLE
Decouple machine_learning from server

### DIFF
--- a/backend/machine_learning/api.py
+++ b/backend/machine_learning/api.py
@@ -31,6 +31,8 @@ PredictionData = TypedDict(
     },
 )
 
+MlModel = TypedDict("MlModel", {"name": str, "filepath": str})
+
 # We calculate rolling sums/means for some features that can span over 5 seasons
 # of data, so we're setting it to 10 to be on the safe side.
 N_SEASONS_FOR_PREDICTION = 10
@@ -213,3 +215,9 @@ def fetch_match_results_data(
         .pipe(clean_match_data)
         .to_dict("records")
     )
+
+
+def fetch_ml_model_info() -> List[MlModel]:
+    """Fetch general info about all saved ML models"""
+
+    return ML_MODELS

--- a/backend/machine_learning/api.py
+++ b/backend/machine_learning/api.py
@@ -16,6 +16,7 @@ from machine_learning.data_transformation.data_cleaning import (
     clean_fixture_data,
 )
 from machine_learning.settings import ML_MODELS, BASE_DIR
+from machine_learning.data_config import TEAM_NAMES, DEFUNCT_TEAM_NAMES, VENUES
 
 
 PredictionData = TypedDict(
@@ -32,6 +33,11 @@ PredictionData = TypedDict(
 )
 
 MlModel = TypedDict("MlModel", {"name": str, "filepath": str})
+
+DataConfig = TypedDict(
+    "DataConfig",
+    {"team_names": List[str], "defunct_team_names": List[str], "venues": List[str]},
+)
 
 # We calculate rolling sums/means for some features that can span over 5 seasons
 # of data, so we're setting it to 10 to be on the safe side.
@@ -221,3 +227,11 @@ def fetch_ml_model_info() -> List[MlModel]:
     """Fetch general info about all saved ML models"""
 
     return ML_MODELS
+
+
+def fetch_data_config() -> DataConfig:
+    return {
+        "team_names": TEAM_NAMES,
+        "defunct_team_names": DEFUNCT_TEAM_NAMES,
+        "venues": VENUES,
+    }

--- a/backend/machine_learning/api.py
+++ b/backend/machine_learning/api.py
@@ -1,13 +1,15 @@
-from typing import List, Optional, Dict
+from typing import List, Optional, Dict, Tuple
 import os
 from datetime import date
 from functools import partial
+import itertools
 
 import pandas as pd
 from sklearn.externals import joblib
 from mypy_extensions import TypedDict
 
-from machine_learning.ml_data import JoinedMLData
+from machine_learning.ml_data import JoinedMLData, BaseMLData
+from machine_learning.ml_estimators import BaseMLEstimator
 from machine_learning.settings import ML_MODELS, BASE_DIR
 
 
@@ -33,18 +35,42 @@ N_SEASONS_FOR_PREDICTION = 10
 PREDICTION_DATA_START_DATE = f"{date.today().year - N_SEASONS_FOR_PREDICTION}-01-01"
 
 
+def _train_model(ml_model: BaseMLEstimator, data: BaseMLData) -> BaseMLEstimator:
+    X_train, y_train = data.train_data()
+
+    # On the off chance that we try to run predictions for years that have no relevant
+    # prediction data
+    if X_train.empty or y_train.empty:
+        raise ValueError(
+            "Some required data was missing for training for year range "
+            f"{data.train_years}.\n"
+            f"{'X_train is empty' if X_train.empty else ''}"
+            f"{'and ' if X_train.empty and y_train.empty else ''}"
+            f"{'y_train is empty' if y_train.empty else ''}"
+        )
+
+    ml_model.fit(X_train, y_train)
+
+    return ml_model
+
+
 def _make_model_predictions(
     year: int,
-    data: pd.DataFrame,
+    data: BaseMLData,
     ml_model: Dict[str, str],
     round_number: Optional[int] = None,
     verbose=1,
-) -> List[pd.DataFrame]:
+    train=False,
+) -> pd.DataFrame:
     if verbose == 1:
         print(f"Making predictions with {ml_model['name']}")
 
     loaded_model = joblib.load(os.path.join(BASE_DIR, ml_model["filepath"]))
+    data.train_years = (None, year - 1)
     data.test_years = (year, year)
+
+    trained_model = _train_model(loaded_model, data) if train else loaded_model
+
     X_test, _ = data.test_data(test_round=round_number)
 
     if not X_test.any().any():
@@ -53,7 +79,7 @@ def _make_model_predictions(
             "upcoming round not being available yet."
         )
 
-    y_pred = loaded_model.predict(X_test)
+    y_pred = trained_model.predict(X_test)
 
     data_row_slice = (slice(None), year, slice(round_number, round_number))
 
@@ -61,29 +87,6 @@ def _make_model_predictions(
         data.data.loc[data_row_slice, :]
         .assign(predicted_margin=y_pred, ml_model=ml_model["name"])
         .set_index("ml_model", append=True, drop=False)
-    )
-
-
-def make_predictions(
-    year: int,
-    round_number: Optional[int] = None,
-    ml_models: List[Dict[str, str]] = ML_MODELS,
-    data: pd.DataFrame = JoinedMLData(
-        fetch_data=True, start_date=PREDICTION_DATA_START_DATE
-    ),
-    verbose=1,
-) -> List[PredictionData]:
-    if not any(ml_models):
-        raise ValueError("Could not find any ML models in to make predictions.\n")
-
-    data.verbose = verbose
-
-    partial_make_model_predictions = partial(
-        _make_model_predictions, year, data, round_number=round_number, verbose=verbose
-    )
-
-    return (
-        pd.concat([partial_make_model_predictions(ml_model) for ml_model in ml_models])
         .loc[
             :,
             [
@@ -96,5 +99,52 @@ def make_predictions(
                 "predicted_margin",
             ],
         ]
-        .to_dict("records")
+    )
+
+
+def _make_predictions_by_year(
+    year: int,
+    data: BaseMLData,
+    ml_models: List[Dict[str, str]],
+    round_number: Optional[int] = None,
+    verbose=1,
+    train=False,
+) -> pd.DataFrame:
+    partial_make_model_predictions = partial(
+        _make_model_predictions,
+        year,
+        data,
+        round_number=round_number,
+        verbose=verbose,
+        train=train,
+    )
+
+    return [partial_make_model_predictions(ml_model) for ml_model in ml_models]
+
+
+def make_predictions(
+    year_range: Tuple[int, int],
+    round_number: Optional[int] = None,
+    data: BaseMLData = JoinedMLData(
+        fetch_data=True, start_date=PREDICTION_DATA_START_DATE
+    ),
+    ml_models: List[Dict[str, str]] = ML_MODELS,
+    verbose=1,
+    train=False,
+) -> List[PredictionData]:
+    partial_make_predictions_by_year = partial(
+        _make_predictions_by_year,
+        data,
+        ml_models,
+        round_number=round_number,
+        verbose=verbose,
+        train=train,
+    )
+
+    predictions = [
+        partial_make_predictions_by_year(year) for year in range(*year_range)
+    ]
+
+    return pd.concat(list(itertools.chain.from_iterable(predictions))).to_dict(
+        "records"
     )

--- a/backend/machine_learning/api.py
+++ b/backend/machine_learning/api.py
@@ -38,8 +38,10 @@ def _make_model_predictions(
     data: pd.DataFrame,
     ml_model: Dict[str, str],
     round_number: Optional[int] = None,
+    verbose=1,
 ) -> List[pd.DataFrame]:
-    print(f"Making predictions with {ml_model['name']}")
+    if verbose == 1:
+        print(f"Making predictions with {ml_model['name']}")
 
     loaded_model = joblib.load(os.path.join(BASE_DIR, ml_model["filepath"]))
     data.test_years = (year, year)
@@ -69,12 +71,15 @@ def make_predictions(
     data: pd.DataFrame = JoinedMLData(
         fetch_data=True, start_date=PREDICTION_DATA_START_DATE
     ),
+    verbose=1,
 ) -> List[PredictionData]:
     if not any(ml_models):
         raise ValueError("Could not find any ML models in to make predictions.\n")
 
+    data.verbose = verbose
+
     partial_make_model_predictions = partial(
-        _make_model_predictions, year, data, round_number=round_number
+        _make_model_predictions, year, data, round_number=round_number, verbose=verbose
     )
 
     return (

--- a/backend/machine_learning/api.py
+++ b/backend/machine_learning/api.py
@@ -11,7 +11,10 @@ from mypy_extensions import TypedDict
 from machine_learning.ml_data import JoinedMLData, BaseMLData
 from machine_learning.ml_estimators import BaseMLEstimator
 from machine_learning.data_import import FitzroyDataImporter
-from machine_learning.data_transformation.data_cleaning import clean_match_data
+from machine_learning.data_transformation.data_cleaning import (
+    clean_match_data,
+    clean_fixture_data,
+)
 from machine_learning.settings import ML_MODELS, BASE_DIR
 
 
@@ -171,8 +174,10 @@ def fetch_fixture_data(
 
     data_import.verbose = verbose
 
-    return data_import.fetch_fixtures(start_date=start_date, end_date=end_date).to_dict(
-        "records"
+    return (
+        data_import.fetch_fixtures(start_date=start_date, end_date=end_date)
+        .pipe(clean_fixture_data)
+        .to_dict("records")
     )
 
 

--- a/backend/machine_learning/api.py
+++ b/backend/machine_learning/api.py
@@ -11,6 +11,7 @@ from mypy_extensions import TypedDict
 from machine_learning.ml_data import JoinedMLData, BaseMLData
 from machine_learning.ml_estimators import BaseMLEstimator
 from machine_learning.data_import import FitzroyDataImporter
+from machine_learning.data_transformation.data_cleaning import clean_match_data
 from machine_learning.settings import ML_MODELS, BASE_DIR
 
 
@@ -155,7 +156,7 @@ def fetch_fixture_data(
     start_date: str, end_date: str, data_import=FitzroyDataImporter(), verbose: int = 1
 ) -> pd.DataFrame:
     """
-    Fetch fixture data (doesn't include match results)
+    Fetch fixture data (doesn't include match results) from afl_data service.
 
     Args:
         start_date (str): Stringified date of form yyy-mm-dd that determines
@@ -172,4 +173,38 @@ def fetch_fixture_data(
 
     return data_import.fetch_fixtures(start_date=start_date, end_date=end_date).to_dict(
         "records"
+    )
+
+
+def fetch_match_results_data(
+    start_date: str,
+    end_date: str,
+    fetch_data: bool = False,
+    data_import=FitzroyDataImporter(),
+    verbose: int = 1,
+) -> pd.DataFrame:
+    """
+    Fetch results data for past matches from afl_data service.
+
+    Args:
+        start_date (str): Stringified date of form yyy-mm-dd that determines
+            the earliest date for which to fetch data.
+        end_date (str): Stringified date of form yyy-mm-dd that determines
+            the latest date for which to fetch data.
+        fetch_data (bool): Whether to fetch fresh data or use saved data
+            (usually a few weeks old).
+        verbose (0 or 1): Whether to print info messages while fetching data.
+
+    Returns:
+        List of match results data dictionaries.
+    """
+
+    data_import.verbose = verbose
+
+    return (
+        data_import.match_results(
+            start_date=start_date, end_date=end_date, fetch_data=fetch_data
+        )
+        .pipe(clean_match_data)
+        .to_dict("records")
     )

--- a/backend/machine_learning/api.py
+++ b/backend/machine_learning/api.py
@@ -1,0 +1,95 @@
+from typing import List, Optional, Dict
+import os
+from datetime import date
+from functools import partial
+
+import pandas as pd
+from sklearn.externals import joblib
+from mypy_extensions import TypedDict
+
+from machine_learning.ml_data import JoinedMLData
+from machine_learning.settings import ML_MODELS, BASE_DIR
+
+
+PredictionData = TypedDict(
+    "PredictionData",
+    {
+        "team": str,
+        "year": int,
+        "round_number": int,
+        "at_home": int,
+        "oppo_team": str,
+        "ml_model": str,
+        "predicted_margin": float,
+    },
+)
+
+# We calculate rolling sums/means for some features that can span over 5 seasons
+# of data, so we're setting it to 10 to be on the safe side.
+N_SEASONS_FOR_PREDICTION = 10
+# We want to limit the amount of data loaded as much as possible,
+# because we only need the full data set for model training and data analysis,
+# and we want to limit memory usage and speed up data processing for tipping
+PREDICTION_DATA_START_DATE = f"{date.today().year - N_SEASONS_FOR_PREDICTION}-01-01"
+
+
+def _make_model_predictions(
+    year: int,
+    data: pd.DataFrame,
+    ml_model: Dict[str, str],
+    round_number: Optional[int] = None,
+) -> List[pd.DataFrame]:
+    print(f"Making predictions with {ml_model['name']}")
+
+    loaded_model = joblib.load(os.path.join(BASE_DIR, ml_model["filepath"]))
+    data.test_years = (year, year)
+    X_test, _ = data.test_data(test_round=round_number)
+
+    if not X_test.any().any():
+        raise ValueError(
+            "X_test doesn't have any rows, likely due to some data for the "
+            "upcoming round not being available yet."
+        )
+
+    y_pred = loaded_model.predict(X_test)
+
+    data_row_slice = (slice(None), year, slice(round_number, round_number))
+
+    return (
+        data.data.loc[data_row_slice, :]
+        .assign(predicted_margin=y_pred, ml_model=ml_model["name"])
+        .set_index("ml_model", append=True, drop=False)
+    )
+
+
+def make_predictions(
+    year: int,
+    round_number: Optional[int] = None,
+    ml_models: List[Dict[str, str]] = ML_MODELS,
+    data: pd.DataFrame = JoinedMLData(
+        fetch_data=True, start_date=PREDICTION_DATA_START_DATE
+    ),
+) -> List[PredictionData]:
+    if not any(ml_models):
+        raise ValueError("Could not find any ML models in to make predictions.\n")
+
+    partial_make_model_predictions = partial(
+        _make_model_predictions, year, data, round_number=round_number
+    )
+
+    return (
+        pd.concat([partial_make_model_predictions(ml_model) for ml_model in ml_models])
+        .loc[
+            :,
+            [
+                "team",
+                "year",
+                "round_number",
+                "oppo_team",
+                "at_home",
+                "ml_model",
+                "predicted_margin",
+            ],
+        ]
+        .to_dict("records")
+    )

--- a/backend/machine_learning/api.py
+++ b/backend/machine_learning/api.py
@@ -10,6 +10,7 @@ from mypy_extensions import TypedDict
 
 from machine_learning.ml_data import JoinedMLData, BaseMLData
 from machine_learning.ml_estimators import BaseMLEstimator
+from machine_learning.data_import import FitzroyDataImporter
 from machine_learning.settings import ML_MODELS, BASE_DIR
 
 
@@ -146,5 +147,29 @@ def make_predictions(
     ]
 
     return pd.concat(list(itertools.chain.from_iterable(predictions))).to_dict(
+        "records"
+    )
+
+
+def fetch_fixture_data(
+    start_date: str, end_date: str, data_import=FitzroyDataImporter(), verbose: int = 1
+) -> pd.DataFrame:
+    """
+    Fetch fixture data (doesn't include match results)
+
+    Args:
+        start_date (str): Stringified date of form yyy-mm-dd that determines
+            the earliest date for which to fetch data.
+        end_date (str): Stringified date of form yyy-mm-dd that determines
+            the latest date for which to fetch data.
+        verbose (0 or 1): Whether to print info messages while fetching data.
+
+    Returns:
+        List of fixture data dictionaries.
+    """
+
+    data_import.verbose = verbose
+
+    return data_import.fetch_fixtures(start_date=start_date, end_date=end_date).to_dict(
         "records"
     )

--- a/backend/machine_learning/data_transformation/data_cleaning.py
+++ b/backend/machine_learning/data_transformation/data_cleaning.py
@@ -136,9 +136,6 @@ def _map_round_type(year: int, round_number: int) -> str:
     )
 
     if year <= 1994:
-        import pdb
-
-        pdb.set_trace()
         raise ValueError(
             f"Tried to get fixtures for {year}, but fixture data is meant for "
             "upcoming matches, not historical match data. Try getting fixture data "

--- a/backend/machine_learning/ml_models.yml
+++ b/backend/machine_learning/ml_models.yml
@@ -1,0 +1,5 @@
+models:
+  - name: tipresias
+    filepath: machine_learning/ml_estimators/bagging_estimator/tipresias.pkl
+  - name: benchmark_estimator
+    filepath: machine_learning/ml_estimators/benchmark_estimator/benchmark_estimator.pkl

--- a/backend/machine_learning/settings.py
+++ b/backend/machine_learning/settings.py
@@ -9,5 +9,5 @@ DATA_DIR = os.path.abspath(os.path.join(os.path.dirname(__file__), "../../", "da
 HOURS_FROM_UTC_TO_MELBOURNE = 11
 MELBOURNE_TIMEZONE = timezone(timedelta(hours=HOURS_FROM_UTC_TO_MELBOURNE))
 
-with open(os.path.join(BASE_DIR, "ml_models.yml"), "r") as file:
+with open(os.path.join(BASE_DIR, "machine_learning/ml_models.yml"), "r") as file:
     ML_MODELS = yaml.safe_load(file).get("models", [])

--- a/backend/machine_learning/settings.py
+++ b/backend/machine_learning/settings.py
@@ -1,0 +1,13 @@
+import os
+from datetime import timezone, timedelta
+import yaml
+
+
+BASE_DIR = os.path.abspath(os.path.join(os.path.dirname(__file__), "../"))
+DATA_DIR = os.path.abspath(os.path.join(os.path.dirname(__file__), "../../", "data"))
+
+HOURS_FROM_UTC_TO_MELBOURNE = 11
+MELBOURNE_TIMEZONE = timezone(timedelta(hours=HOURS_FROM_UTC_TO_MELBOURNE))
+
+with open(os.path.join(BASE_DIR, "ml_models.yml"), "r") as file:
+    ML_MODELS = yaml.safe_load(file).get("models", [])

--- a/backend/project/settings/data.py
+++ b/backend/project/settings/data.py
@@ -1,0 +1,7 @@
+from server import data_import
+
+CONFIG = data_import.fetch_data_config()
+
+TEAM_NAMES = CONFIG["team_names"]
+DEFUNCT_TEAM_NAMES = CONFIG["defunct_team_names"]
+VENUES = CONFIG["venues"]

--- a/backend/server/data_import.py
+++ b/backend/server/data_import.py
@@ -1,0 +1,12 @@
+"""Module for functions that fetch data"""
+
+from typing import List
+
+from server.types import PredictionData
+from machine_learning import api
+
+
+def fetch_prediction_data(year: int, round_number: int) -> List[PredictionData]:
+    """Fetch prediction data from machine_learning module"""
+
+    return api.make_predictions(year, round_number=round_number)

--- a/backend/server/data_import.py
+++ b/backend/server/data_import.py
@@ -3,9 +3,16 @@
 from typing import Tuple, Optional, List
 
 import pandas as pd
+from mypy_extensions import TypedDict
 
 from machine_learning import api
 from server.types import MlModel
+
+
+DataConfig = TypedDict(
+    "DataConfig",
+    {"team_names": List[str], "defunct_team_names": List[str], "venues": List[str]},
+)
 
 
 def fetch_prediction_data(
@@ -75,3 +82,9 @@ def fetch_ml_model_info() -> List[MlModel]:
     """Fetch general info about all saved ML models"""
 
     return api.fetch_ml_model_info()
+
+
+def fetch_data_config() -> DataConfig:
+    """Fetch general data config info"""
+
+    return api.fetch_data_config()

--- a/backend/server/data_import.py
+++ b/backend/server/data_import.py
@@ -31,7 +31,7 @@ def fetch_fixture_data(
     start_date: str, end_date: str, verbose: int = 1
 ) -> pd.DataFrame:
     """
-    Fetch fixture data (doesn't include match results)
+    Fetch fixture data (doesn't include match results) from machine_learning module.
 
     Args:
         start_date (str): Stringified date of form yyy-mm-dd that determines
@@ -45,3 +45,25 @@ def fetch_fixture_data(
     """
 
     return pd.DataFrame(api.fetch_fixture_data(start_date, end_date, verbose=verbose))
+
+
+def fetch_match_results_data(
+    start_date: str, end_date: str, verbose: int = 1
+) -> pd.DataFrame:
+    """
+    Fetch results data for past matches from machine_learning module.
+
+    Args:
+        start_date (str): Stringified date of form yyy-mm-dd that determines
+            the earliest date for which to fetch data.
+        end_date (str): Stringified date of form yyy-mm-dd that determines
+            the latest date for which to fetch data.
+        verbose (0 or 1): Whether to print info messages while fetching data.
+
+    Returns:
+        pandas.DataFrame with fixture data.
+    """
+
+    return pd.DataFrame(
+        api.fetch_match_results_data(start_date, end_date, verbose=verbose)
+    )

--- a/backend/server/data_import.py
+++ b/backend/server/data_import.py
@@ -6,7 +6,9 @@ from server.types import PredictionData
 from machine_learning import api
 
 
-def fetch_prediction_data(year: int, round_number: int) -> List[PredictionData]:
+def fetch_prediction_data(
+    year: int, round_number: int, verbose=1
+) -> List[PredictionData]:
     """Fetch prediction data from machine_learning module"""
 
-    return api.make_predictions(year, round_number=round_number)
+    return api.make_predictions(year, round_number=round_number, verbose=verbose)

--- a/backend/server/data_import.py
+++ b/backend/server/data_import.py
@@ -2,6 +2,8 @@
 
 from typing import List, Tuple, Optional
 
+import pandas as pd
+
 from server.types import PredictionData
 from machine_learning import api
 
@@ -9,6 +11,37 @@ from machine_learning import api
 def fetch_prediction_data(
     year_range: Tuple[int, int], round_number: Optional[int] = None, verbose=1
 ) -> List[PredictionData]:
-    """Fetch prediction data from machine_learning module"""
+    """
+    Fetch prediction data from machine_learning module
+
+    Args:
+        year_range (Tuple(int, int)): Min (inclusive) and max (exclusive) years
+            for which to fetch data.
+        round_number (int): Specify a particular round for which to fetch data.
+        verbose (0 or 1): Whether to print info messages while fetching data.
+
+    Returns:
+        List of prediction data dictionaries
+    """
 
     return api.make_predictions(year_range, round_number=round_number, verbose=verbose)
+
+
+def fetch_fixture_data(
+    start_date: str, end_date: str, verbose: int = 1
+) -> pd.DataFrame:
+    """
+    Fetch fixture data (doesn't include match results)
+
+    Args:
+        start_date (str): Stringified date of form yyy-mm-dd that determines
+            the earliest date for which to fetch data.
+        end_date (str): Stringified date of form yyy-mm-dd that determines
+            the latest date for which to fetch data.
+        verbose (0 or 1): Whether to print info messages while fetching data.
+
+    Returns:
+        pandas.DataFrame with fixture data.
+    """
+
+    return pd.DataFrame(api.fetch_fixture_data(start_date, end_date, verbose=verbose))

--- a/backend/server/data_import.py
+++ b/backend/server/data_import.py
@@ -1,10 +1,11 @@
 """Module for functions that fetch data"""
 
-from typing import Tuple, Optional
+from typing import Tuple, Optional, List
 
 import pandas as pd
 
 from machine_learning import api
+from server.types import MlModel
 
 
 def fetch_prediction_data(
@@ -68,3 +69,9 @@ def fetch_match_results_data(
     return pd.DataFrame(
         api.fetch_match_results_data(start_date, end_date, verbose=verbose)
     )
+
+
+def fetch_ml_model_info() -> List[MlModel]:
+    """Fetch general info about all saved ML models"""
+
+    return api.fetch_ml_model_info()

--- a/backend/server/data_import.py
+++ b/backend/server/data_import.py
@@ -1,14 +1,14 @@
 """Module for functions that fetch data"""
 
-from typing import List
+from typing import List, Tuple, Optional
 
 from server.types import PredictionData
 from machine_learning import api
 
 
 def fetch_prediction_data(
-    year: int, round_number: int, verbose=1
+    year_range: Tuple[int, int], round_number: Optional[int] = None, verbose=1
 ) -> List[PredictionData]:
     """Fetch prediction data from machine_learning module"""
 
-    return api.make_predictions(year, round_number=round_number, verbose=verbose)
+    return api.make_predictions(year_range, round_number=round_number, verbose=verbose)

--- a/backend/server/data_import.py
+++ b/backend/server/data_import.py
@@ -1,16 +1,15 @@
 """Module for functions that fetch data"""
 
-from typing import List, Tuple, Optional
+from typing import Tuple, Optional
 
 import pandas as pd
 
-from server.types import PredictionData
 from machine_learning import api
 
 
 def fetch_prediction_data(
     year_range: Tuple[int, int], round_number: Optional[int] = None, verbose=1
-) -> List[PredictionData]:
+) -> pd.DataFrame:
     """
     Fetch prediction data from machine_learning module
 
@@ -24,7 +23,9 @@ def fetch_prediction_data(
         List of prediction data dictionaries
     """
 
-    return api.make_predictions(year_range, round_number=round_number, verbose=verbose)
+    return pd.DataFrame(
+        api.make_predictions(year_range, round_number=round_number, verbose=verbose)
+    )
 
 
 def fetch_fixture_data(

--- a/backend/server/helpers.py
+++ b/backend/server/helpers.py
@@ -1,0 +1,51 @@
+"""Helper functions"""
+
+from typing import Dict
+import pandas as pd
+
+
+def _replace_col_names(team_type: str) -> Dict[str, str]:
+    oppo_team_type = "away" if team_type == "home" else "home"
+
+    return {
+        "team": team_type + "_team",
+        "oppo_team": oppo_team_type + "_team",
+        "predicted_margin": team_type + "_predicted_margin",
+    }
+
+
+def _home_away_data_frame(data_frame: pd.DataFrame, team_type: str) -> pd.DataFrame:
+    is_at_home = team_type == "home"
+    at_home_query = 1 if is_at_home else 0  # pylint: disable=W0612
+
+    return (
+        data_frame.query("at_home == @at_home_query")
+        .drop("at_home", axis=1)
+        .rename(columns=_replace_col_names(team_type))
+        .reset_index()
+    )
+
+
+def pivot_team_matches_to_matches(team_match_df: pd.DataFrame):
+    """
+    Pivots per at_home column to change team-match rows with team and oppo_ columns
+    to match rows with home_ and away_ columns. Due to how columns are renamed,
+    currently only works for prediction data frames.
+
+    Args:
+        team_match_df (pd.DataFrame): DataFrame structured to have two rows per match
+            (one for each participating team) with team & oppo_team columns
+
+    Returns:
+        pd.DataFrame: Reshaped to have one row per match, with columns for home_team
+            and away_team.
+    """
+
+    home_data_frame = _home_away_data_frame(team_match_df, "home")
+    away_data_frame = _home_away_data_frame(team_match_df, "away")
+
+    return home_data_frame.merge(
+        away_data_frame,
+        on=["home_team", "away_team", "year", "round_number", "ml_model"],
+        how="inner",
+    )

--- a/backend/server/management/commands/seed_db.py
+++ b/backend/server/management/commands/seed_db.py
@@ -174,7 +174,7 @@ class Command(BaseCommand):
         predictions = self.data_importer.fetch_prediction_data(
             year_range, verbose=self.verbose
         )
-        home_away_df = pivot_team_matches_to_matches(pd.DataFrame(predictions))
+        home_away_df = pivot_team_matches_to_matches(predictions)
 
         for pred in home_away_df.to_dict("records"):
             Prediction.update_or_create_from_data(pred)

--- a/backend/server/management/commands/seed_db.py
+++ b/backend/server/management/commands/seed_db.py
@@ -1,8 +1,7 @@
 """Django command for seeding the DB with match & prediction data"""
 
 import itertools
-from functools import partial
-from typing import Tuple, List, Optional, Union
+from typing import Tuple, List, Union
 from datetime import datetime
 from mypy_extensions import TypedDict
 import pandas as pd
@@ -11,9 +10,9 @@ from django import utils
 from django.core.management.base import BaseCommand
 
 from server.models import Team, Match, TeamMatch, MLModel, Prediction
+from server import data_import
 from machine_learning.data_import import FitzroyDataImporter
 from machine_learning.ml_estimators import BaseMLEstimator
-from machine_learning.ml_data import BaseMLData, JoinedMLData
 from machine_learning.ml_estimators import BenchmarkEstimator, BaggingEstimator
 from machine_learning.data_transformation.data_cleaning import clean_match_data
 
@@ -50,14 +49,14 @@ class Command(BaseCommand):
         *args,
         data_reader=FitzroyDataImporter(),
         estimators: List[BaseMLEstimator] = ESTIMATORS,
-        data=JoinedMLData(fetch_data=True),
+        prediction_data=data_import,
         **kwargs,
     ) -> None:
         super().__init__(*args, **kwargs)
 
         self.data_reader = data_reader
         self.estimators = estimators
-        self.data = data
+        self.prediction_data = prediction_data
 
     def handle(  # pylint: disable=W0221
         self, *_args, year_range: str = YEAR_RANGE, verbose: int = 1, **_kwargs
@@ -90,9 +89,9 @@ class Command(BaseCommand):
         # if an error is raised
         try:
             self.__create_teams(match_data_frame)
-            ml_models = self.__create_ml_models()
+            self.__create_ml_models()
             self.__create_matches(match_data_frame.to_dict("records"))
-            self.__make_predictions(year_range_tuple, ml_models=ml_models)
+            self.__make_predictions(year_range_tuple)
 
             if self.verbose == 1:
                 print("\n...DB seeded!\n")
@@ -175,129 +174,47 @@ class Command(BaseCommand):
 
         return self.__build_team_match(match, match_data)
 
-    def __make_predictions(
-        self,
-        year_range: Tuple[int, int],
-        ml_models: Optional[List[MLModel]] = None,
-        round_number: Optional[int] = None,
-    ) -> None:
-        ml_models = ml_models or MLModel.objects.all()
-
-        if ml_models is None or not any(ml_models):
-            if self.verbose == 1:
-                raise ValueError(
-                    "\tCould not find any ML models in DB to make predictions."
-                )
-
-        # Loading the data here, because it makes for a weird set of messages to do it
-        # in the middle of loading models & making predictions
-        self.data.data  # pylint: disable=W0104
-
-        make_model_predictions = partial(
-            self.__make_model_predictions, year_range, round_number=round_number
+    def __make_predictions(self, year_range: Tuple[int, int]) -> None:
+        predictions = self.prediction_data.fetch_prediction_data(
+            year_range, verbose=self.verbose
         )
-        model_predictions_list = [
-            make_model_predictions(ml_model_record) for ml_model_record in ml_models
-        ]
-        model_predictions = list(itertools.chain.from_iterable(model_predictions_list))
 
-        if not any(model_predictions):
-            raise ValueError("Could not find any predictions to save to the DB.")
+        predictions_df = pd.DataFrame(predictions)
 
-        Prediction.objects.bulk_create(model_predictions)
+        home_df = (
+            predictions_df.query("at_home == 1")
+            .rename(
+                columns={
+                    "team": "home_team",
+                    "oppo_team": "away_team",
+                    "predicted_margin": "home_margin",
+                }
+            )
+            .drop("at_home", axis=1)
+        )
+        away_df = (
+            predictions_df.query("at_home == 0")
+            .rename(
+                columns={
+                    "team": "away_team",
+                    "oppo_team": "home_team",
+                    "predicted_margin": "away_margin",
+                }
+            )
+            .drop("at_home", axis=1)
+        )
+
+        home_away_df = home_df.merge(
+            away_df,
+            on=["home_team", "away_team", "year", "round_number", "ml_model"],
+            how="inner",
+        )
+
+        for pred in home_away_df.to_dict("records"):
+            Prediction.update_or_create_from_data(pred)
 
         if self.verbose == 1:
             print("\nPredictions saved!")
-
-    def __make_model_predictions(
-        self,
-        year_range: Tuple[int, int],
-        ml_model_record: MLModel,
-        round_number: Optional[int] = None,
-    ) -> List[Prediction]:
-        if self.verbose == 1:
-            print(f"\nMaking predictions with {ml_model_record.name}...")
-
-        estimator = ml_model_record.load_estimator()
-
-        make_year_predictions = partial(
-            self.__make_year_predictions,
-            ml_model_record,
-            estimator,
-            round_number=round_number,
-        )
-
-        year_prediction_lists = [
-            make_year_predictions(year) for year in range(*year_range)
-        ]
-
-        return list(itertools.chain.from_iterable(year_prediction_lists))
-
-    # TODO: Got the following error when trying to implement multiprocessing:
-    # TypeError: cannot serialize '_io.TextIOWrapper' object
-    # Not too sure on the cause, but it works okay for now (it's just slow).
-    def __make_year_predictions(
-        self,
-        ml_model_record: MLModel,
-        estimator: BaseMLEstimator,
-        year: int,
-        round_number: Optional[int] = None,
-    ) -> List[Prediction]:
-        if self.verbose == 1:
-            print(f"\tMaking predictions for {year}...")
-
-        matches_to_predict = Match.objects.filter(start_date_time__year=year)
-
-        if matches_to_predict is None or not any(matches_to_predict):
-            if self.verbose == 1:
-                print(
-                    f"\tCould not find any matches from season {year} to make predictions for."
-                )
-
-            return []
-
-        self.data.train_years = (None, year - 1)
-        self.data.test_years = (year, year)
-        data_row_slice = (slice(None), year, slice(round_number, round_number))
-        prediction_data = self.__predict(estimator, self.data, data_row_slice)
-
-        if prediction_data is None:
-            return []
-
-        build_match_prediction = partial(
-            self.__build_match_prediction, ml_model_record, prediction_data
-        )
-
-        return [build_match_prediction(match) for match in matches_to_predict]
-
-    def __predict(
-        self,
-        estimator: BaseMLEstimator,
-        data: BaseMLData,
-        data_row_slice: Tuple[slice, int, slice],
-    ) -> Optional[pd.DataFrame]:
-        X_train, y_train = data.train_data()
-        X_test, _ = data.test_data()
-
-        # On the off chance that we try to run predictions for years that have no relevant
-        # prediction data
-        if X_train.empty or y_train.empty or X_test.empty:
-            if self.verbose == 1:
-                print(
-                    "Some required data was missing for predicting for season "
-                    f"{data.test_years[0]}.\n"
-                    f"{'X_train is empty' if X_train.empty else ''}"
-                    f"{', y_train is empty' if y_train.empty else ''}"
-                    f"{', and y_test is empty.' if X_train.empty else ''}"
-                )
-
-            return None
-
-        estimator.fit(X_train, y_train)
-
-        y_pred = estimator.predict(X_test)
-
-        return data.data.loc[data_row_slice, :].assign(predicted_margin=y_pred)
 
     @staticmethod
     def __build_ml_model(estimator: BaseMLEstimator) -> MLModel:

--- a/backend/server/management/commands/seed_db.py
+++ b/backend/server/management/commands/seed_db.py
@@ -12,10 +12,8 @@ from django.core.management.base import BaseCommand
 from server.models import Team, Match, TeamMatch, MLModel, Prediction
 from server import data_import
 from server.helpers import pivot_team_matches_to_matches
-from machine_learning.data_import import FitzroyDataImporter
 from machine_learning.ml_estimators import BaseMLEstimator
 from machine_learning.ml_estimators import BenchmarkEstimator, BaggingEstimator
-from machine_learning.data_transformation.data_cleaning import clean_match_data
 
 MatchData = TypedDict(
     "MatchData",
@@ -48,22 +46,19 @@ class Command(BaseCommand):
     def __init__(
         self,
         *args,
-        data_reader=FitzroyDataImporter(),
         estimators: List[BaseMLEstimator] = ESTIMATORS,
-        prediction_data=data_import,
+        data_importer=data_import,
         **kwargs,
     ) -> None:
         super().__init__(*args, **kwargs)
 
-        self.data_reader = data_reader
         self.estimators = estimators
-        self.prediction_data = prediction_data
+        self.data_importer = data_importer
 
     def handle(  # pylint: disable=W0221
         self, *_args, year_range: str = YEAR_RANGE, verbose: int = 1, **_kwargs
     ) -> None:  # pylint: disable=W0613
         self.verbose = verbose  # pylint: disable=W0201
-        self.data_reader.verbose = verbose
 
         if self.verbose == 1:
             print("\nSeeding DB...\n")
@@ -82,9 +77,9 @@ class Command(BaseCommand):
         # which is open-ended, then try to use a restricted tuple type
         year_range_tuple = (years_list[0], years_list[1])
 
-        match_data_frame = self.data_reader.match_results(
+        match_data_frame = self.data_importer.fetch_match_results_data(
             start_date=f"{years_list[0]}-01-01", end_date=f"{years_list[1] - 1}-12-31"
-        ).pipe(clean_match_data)
+        )
 
         # Putting saving records in a try block, so we can go back and delete everything
         # if an error is raised
@@ -176,7 +171,7 @@ class Command(BaseCommand):
         return self.__build_team_match(match, match_data)
 
     def __make_predictions(self, year_range: Tuple[int, int]) -> None:
-        predictions = self.prediction_data.fetch_prediction_data(
+        predictions = self.data_importer.fetch_prediction_data(
             year_range, verbose=self.verbose
         )
         home_away_df = pivot_team_matches_to_matches(pd.DataFrame(predictions))

--- a/backend/server/management/commands/seed_db.py
+++ b/backend/server/management/commands/seed_db.py
@@ -1,9 +1,8 @@
 """Django command for seeding the DB with match & prediction data"""
 
 import itertools
-from typing import Tuple, List, Union
+from typing import Tuple, List
 from datetime import datetime
-from mypy_extensions import TypedDict
 import pandas as pd
 import numpy as np
 from django import utils

--- a/backend/server/management/commands/tip.py
+++ b/backend/server/management/commands/tip.py
@@ -6,11 +6,10 @@ from typing import List, Optional
 from django.core.management.base import BaseCommand
 from django import utils
 import pandas as pd
-import numpy as np
 
 from project.settings.common import MELBOURNE_TIMEZONE
-from server.models import Match, TeamMatch, Team, MLModel, Prediction
-from server.types import CleanedFixtureData, CleanPredictionData
+from server.models import Match, TeamMatch, Team, Prediction
+from server.types import CleanedFixtureData
 from server import data_import
 from machine_learning.data_import import FitzroyDataImporter
 from machine_learning.ml_data import JoinedMLData
@@ -195,7 +194,7 @@ class Command(BaseCommand):
 
     def __make_predictions(self, year: int, round_number: int) -> None:
         predictions = self.prediction_data.fetch_prediction_data(
-            year, round_number, verbose=self.verbose
+            (year, year), round_number=round_number, verbose=self.verbose
         )
         predictions_df = pd.DataFrame(predictions)
 

--- a/backend/server/management/commands/tip.py
+++ b/backend/server/management/commands/tip.py
@@ -9,13 +9,29 @@ from django import utils
 import pandas as pd
 import numpy as np
 from sklearn.externals import joblib
+from mypy_extensions import TypedDict
 
 from project.settings.common import BASE_DIR, MELBOURNE_TIMEZONE
 from server.models import Match, TeamMatch, Team, MLModel, Prediction
-from server.types import CleanedFixtureData
+from server.types import CleanedFixtureData, PredictionData
+from server import data_import
 from machine_learning.data_import import FitzroyDataImporter
 from machine_learning.ml_data import JoinedMLData
 from machine_learning.data_transformation.data_cleaning import clean_fixture_data
+
+
+CleanPredictionData = TypedDict(
+    "CleanPredictionData",
+    {
+        "home_team": str,
+        "year": int,
+        "round_number": int,
+        "away_team": str,
+        "ml_model": str,
+        "home_margin": float,
+        "away_margin": float,
+    },
+)
 
 NO_SCORE = 0
 # We calculate rolling sums/means for some features that can span over 5 seasons
@@ -94,7 +110,7 @@ class Command(BaseCommand):
         if self.verbose == 1:
             print("Saving prediction records...")
 
-        self.__make_predictions(upcoming_round_year, round_number=upcoming_round)
+        self.__make_predictions(upcoming_round_year, upcoming_round)
 
         return None
 
@@ -191,107 +207,92 @@ class Command(BaseCommand):
 
         return self.__build_team_match(match, match_data)
 
-    def __make_predictions(
-        self,
-        year: int,
-        ml_models: Optional[List[MLModel]] = None,
-        round_number: Optional[int] = None,
-    ) -> None:
-        matches_to_predict = Match.objects.filter(
-            start_date_time__gt=self.right_now, round_number=round_number
-        )
+    def __make_predictions(self, year: int, round_number: int) -> None:
+        predictions = data_import.fetch_prediction_data(year, round_number)
+        predictions_df = pd.DataFrame(predictions)
 
-        ml_models = ml_models or MLModel.objects.all()
-
-        if ml_models is None:
-            raise ValueError(
-                "Could not find any ML models in DB to make predictions.\n"
+        home_df = (
+            predictions_df.query("at_home == 1")
+            .rename(
+                columns={
+                    "team": "home_team",
+                    "oppo_team": "away_team",
+                    "margin": "home_margin",
+                }
             )
-
-        make_model_predictions = partial(
-            self.__make_model_predictions,
-            year,
-            matches_to_predict,
-            round_number=round_number,
+            .drop("at_home", axis=1)
+        )
+        away_df = (
+            predictions_df.query("at_home == 0")
+            .rename(
+                columns={
+                    "team": "away_team",
+                    "oppo_team": "home_team",
+                    "margin": "away_margin",
+                }
+            )
+            .drop("at_home", axis=1)
         )
 
-        prediction_lists = [make_model_predictions(ml_model) for ml_model in ml_models]
-        predictions: List[Optional[Prediction]] = reduce(
-            lambda acc_list, curr_list: acc_list + curr_list, prediction_lists, []
+        home_away_df = home_df.merge(
+            away_df,
+            on=["home_team", "away_team", "year", "round_number", "ml_model"],
+            how="inner",
         )
-        predictions_to_save = [pred for pred in predictions if pred is not None]
+
+        predictions_to_save = [
+            self.__build_match_prediction(pred)
+            for pred in home_away_df.to_dict("records")
+        ]
+        predictions_to_save = [pred for pred in predictions_to_save if pred is not None]
 
         Prediction.objects.bulk_create(predictions_to_save)
 
         if self.verbose == 1:
             print("Predictions saved!\n")
 
-    def __make_model_predictions(
-        self,
-        year: int,
-        matches: List[Match],
-        ml_model_record: MLModel,
-        round_number: Optional[int] = None,
-    ) -> List[Optional[Prediction]]:
-        if self.verbose == 1:
-            print(f"\tMaking predictions with {ml_model_record.name}")
-
-        loaded_model = joblib.load(os.path.join(BASE_DIR, ml_model_record.filepath))
-        self.data.test_years = (year, year)
-        X_test, _ = self.data.test_data(test_round=round_number)
-
-        if not X_test.any().any():
-            raise ValueError(
-                "X_test doesn't have any rows, likely due to some data for the "
-                "upcoming round not being available yet."
-            )
-
-        y_pred = loaded_model.predict(X_test)
-
-        data_row_slice = (slice(None), year, slice(round_number, round_number))
-        prediction_data = self.data.data.loc[data_row_slice, :].assign(
-            predicted_margin=y_pred
-        )
-
-        build_match_prediction = partial(
-            self.__build_match_prediction, ml_model_record, prediction_data
-        )
-
-        return [build_match_prediction(match) for match in matches]
-
     @staticmethod
     def __build_match_prediction(
-        ml_model_record: MLModel, prediction_data: pd.DataFrame, match: Match
-    ) -> Optional[Prediction]:
-        home_team = match.teammatch_set.get(at_home=True).team
-        away_team = match.teammatch_set.get(at_home=False).team
+        prediction_data: CleanPredictionData
+    ) -> List[Optional[Prediction]]:
+        home_team = prediction_data["home_team"]
+        away_team = prediction_data["away_team"]
 
-        predicted_home_margin = prediction_data.xs(home_team.name, level=0)[
-            "predicted_margin"
-        ].iloc[0]
-        predicted_away_margin = prediction_data.xs(away_team.name, level=0)[
-            "predicted_margin"
-        ].iloc[0]
+        home_margin = prediction_data["home_margin"]
+        away_margin = prediction_data["away_margin"]
 
         # predicted_margin is always positive as its always associated with predicted_winner
-        predicted_margin = np.mean(
-            np.abs([predicted_home_margin, predicted_away_margin])
-        )
+        predicted_margin = np.mean(np.abs([home_margin, away_margin]))
 
-        if predicted_home_margin > predicted_away_margin:
+        if predicted_margin > away_margin:
             predicted_winner = home_team
-        elif predicted_away_margin > predicted_home_margin:
+        elif away_margin > predicted_margin:
             predicted_winner = away_team
         else:
             raise ValueError(
-                "Predicted home and away margins are equal, which is basically impossible, "
-                "so figure out what's going on:\n"
-                f"home_team = {home_team.name}\n"
-                f"away_team = {away_team.name}\n"
-                f"data = {prediction_data}"
+                "Predicted home and away margins are equal, which is basically "
+                "impossible, so figure out what's going on:\n"
+                f"{prediction_data}"
             )
 
-        prediction_attributes = {"match": match, "ml_model": ml_model_record}
+        matches = Match.objects.get(
+            start_date_time__year=prediction_data["year"],
+            round_number=prediction_data["round_number"],
+            teammatch__team__name__in=[home_team, away_team],
+        )
+
+        if len(matches) != 2 or matches[0] != matches[1]:
+            raise ValueError(
+                "Prediction data should have yielded a unique match, with duplicates "
+                "returned from the DB, but we got the following instead:\n"
+                f"{matches.values('round_number', 'start_date_time')}\n\n"
+                f"{prediction_data}"
+            )
+
+        match = matches.first()
+        ml_model = MLModel.objects.get(name=prediction_data["ml_model"])
+
+        prediction_attributes = {"match": match, "ml_model": ml_model}
 
         try:
             prediction = Prediction.objects.get(**prediction_attributes)

--- a/backend/server/management/commands/tip.py
+++ b/backend/server/management/commands/tip.py
@@ -194,7 +194,7 @@ class Command(BaseCommand):
         predictions = self.data_importer.fetch_prediction_data(
             (year, year), round_number=round_number, verbose=self.verbose
         )
-        home_away_df = pivot_team_matches_to_matches(pd.DataFrame(predictions))
+        home_away_df = pivot_team_matches_to_matches(predictions)
 
         for pred in home_away_df.to_dict("records"):
             Prediction.update_or_create_from_data(pred)

--- a/backend/server/models.py
+++ b/backend/server/models.py
@@ -4,12 +4,10 @@ from datetime import datetime, timedelta
 from django.db import models, transaction
 from django.core.exceptions import ValidationError
 from django.utils.translation import gettext_lazy as _
-from sklearn.externals import joblib
 import numpy as np
 
-from machine_learning.ml_estimators import BaseMLEstimator
-from machine_learning.data_config import TEAM_NAMES
 from project.settings.common import MELBOURNE_TIMEZONE
+from project.settings.data import TEAM_NAMES
 from server.types import CleanPredictionData
 
 # Rough estimate, but exactitude isn't necessary here
@@ -100,9 +98,6 @@ class MLModel(models.Model):
     data_class_path = models.CharField(
         max_length=500, null=True, blank=True, validators=[validate_module_path]
     )
-
-    def load_estimator(self) -> BaseMLEstimator:
-        return joblib.load(self.filepath)
 
 
 class Prediction(models.Model):

--- a/backend/server/models.py
+++ b/backend/server/models.py
@@ -156,8 +156,8 @@ class Prediction(models.Model):
         home_team = prediction_data["home_team"]
         away_team = prediction_data["away_team"]
 
-        home_margin = prediction_data["home_margin"]
-        away_margin = prediction_data["away_margin"]
+        home_margin = prediction_data["home_predicted_margin"]
+        away_margin = prediction_data["away_predicted_margin"]
 
         # predicted_margin is always positive as its always associated with predicted_winner
         predicted_margin = np.mean(np.abs([home_margin, away_margin]))

--- a/backend/server/models.py
+++ b/backend/server/models.py
@@ -1,13 +1,16 @@
 from functools import reduce
 from datetime import datetime, timedelta
-from django.db import models
+
+from django.db import models, transaction
 from django.core.exceptions import ValidationError
 from django.utils.translation import gettext_lazy as _
 from sklearn.externals import joblib
+import numpy as np
 
 from machine_learning.ml_estimators import BaseMLEstimator
 from machine_learning.data_config import TEAM_NAMES
 from project.settings.common import MELBOURNE_TIMEZONE
+from server.types import CleanPredictionData
 
 # Rough estimate, but exactitude isn't necessary here
 GAME_LENGTH_HRS = 3
@@ -133,6 +136,72 @@ class Prediction(models.Model):
         return match.has_been_played and (
             match.is_draw or predicted_winner == match.winner
         )
+
+    @classmethod
+    def update_or_create_from_data(cls, prediction_data: CleanPredictionData) -> None:
+        """
+        Convert raw prediction data to a Prediction model instance. Tries to find
+        and update existing prediction for the given match/model combination,
+        and creates new one if none is found.
+
+        Args:
+            prediction_data (CleanPredictionData): Dictionary that include
+                prediction data for two teams that are playing each other
+                in a given match.
+
+        Returns:
+            prediction (Prediction): Unsaved Prediction model instance.
+        """
+
+        home_team = prediction_data["home_team"]
+        away_team = prediction_data["away_team"]
+
+        home_margin = prediction_data["home_margin"]
+        away_margin = prediction_data["away_margin"]
+
+        # predicted_margin is always positive as its always associated with predicted_winner
+        predicted_margin = np.mean(np.abs([home_margin, away_margin]))
+
+        if predicted_margin > away_margin:
+            predicted_winner = Team.objects.get(name=home_team)
+        elif away_margin > predicted_margin:
+            predicted_winner = Team.objects.get(name=away_team)
+        else:
+            raise ValueError(
+                "Predicted home and away margins are equal, which is basically "
+                "impossible, so figure out what's going on:\n"
+                f"{prediction_data}"
+            )
+
+        matches = Match.objects.filter(
+            start_date_time__year=prediction_data["year"],
+            round_number=prediction_data["round_number"],
+            teammatch__team__name__in=[home_team, away_team],
+        )
+
+        if len(matches) != 2 or matches[0] != matches[1]:
+            raise ValueError(
+                "Prediction data should have yielded a unique match, with duplicates "
+                "returned from the DB, but we got the following instead:\n"
+                f"{matches.values('round_number', 'start_date_time')}\n\n"
+                f"{prediction_data}"
+            )
+
+        match = matches.first()
+        ml_model = MLModel.objects.get(name=prediction_data["ml_model"])
+        prediction_attributes = {"match": match, "ml_model": ml_model}
+
+        with transaction.atomic():
+            prediction, was_created = cls.objects.update_or_create(
+                **prediction_attributes,
+                defaults={
+                    "predicted_margin": predicted_margin,
+                    "predicted_winner": predicted_winner,
+                },
+            )
+
+            if was_created:
+                prediction.full_clean()
 
     def clean(self):
         # Judgement call, but I want to avoid 0 predicted margin values for the cases

--- a/backend/server/tests/fixtures/data_factories.py
+++ b/backend/server/tests/fixtures/data_factories.py
@@ -1,6 +1,9 @@
+"""Module for factory functions that create raw data objects"""
+
 from typing import List, Dict, Any, Tuple, Union
 from datetime import datetime
 import itertools
+
 from faker import Faker
 import numpy as np
 import pandas as pd
@@ -9,6 +12,7 @@ from machine_learning.data_config import TEAM_NAMES, DEFUNCT_TEAM_NAMES
 from server.types import RawFixtureData, MatchData, PredictionData
 from server.models import Match
 from project.settings.common import MELBOURNE_TIMEZONE
+
 
 FIRST = 1
 SECOND = 2
@@ -43,7 +47,7 @@ def _min_max_datetimes_by_year(year: int) -> Dict[str, datetime]:
     }
 
 
-def _match_data(year: int, team_names: Tuple[str, str]) -> MatchData:
+def _raw_match_data(year: int, team_names: Tuple[str, str]) -> MatchData:
     return {
         "date": FAKE.date_time_between_dates(
             **_min_max_datetimes_by_year(year), tzinfo=MELBOURNE_TIMEZONE
@@ -60,28 +64,32 @@ def _match_data(year: int, team_names: Tuple[str, str]) -> MatchData:
     }
 
 
-def _match_by_round(row_count: int, year: int) -> List[MatchData]:
+def _matches_by_round(row_count: int, year: int) -> List[MatchData]:
     team_names = CyclicalTeamNames()
 
     return [
-        _match_data(year, (team_names.next(), team_names.next()))
-        for idx in range(row_count)
+        _raw_match_data(year, (team_names.next(), team_names.next()))
+        for _ in range(row_count)
     ]
 
 
-def _match_by_year(
+def _matches_by_year(
     row_count: int, year_range: Tuple[int, int]
 ) -> List[List[MatchData]]:
-    return [_match_by_round(row_count, year) for year in range(*year_range)]
+    return [_matches_by_round(row_count, year) for year in range(*year_range)]
 
 
 def fake_match_results_data(
-    row_count: int, year_range: Tuple[int, int]
+    row_count: int, year_range: Tuple[int, int], clean=False
 ) -> pd.DataFrame:
-    data = _match_by_year(row_count, year_range)
+    data = _matches_by_year(row_count, year_range)
     reduced_data = list(itertools.chain.from_iterable(data))
+    data_frame = pd.DataFrame(list(reduced_data))
 
-    return pd.DataFrame(list(reduced_data))
+    if clean:
+        return data_frame.rename(columns={"season": "year"})
+
+    return data_frame
 
 
 def _fixture_data(year: int, team_names: Tuple[str, str]) -> RawFixtureData:

--- a/backend/server/tests/fixtures/data_factories.py
+++ b/backend/server/tests/fixtures/data_factories.py
@@ -6,7 +6,7 @@ import numpy as np
 import pandas as pd
 
 from machine_learning.data_config import TEAM_NAMES, DEFUNCT_TEAM_NAMES
-from server.types import RawFixtureData, MatchData
+from server.types import RawFixtureData, MatchData, PredictionData
 from project.settings.common import MELBOURNE_TIMEZONE
 
 FIRST = 1
@@ -171,3 +171,26 @@ def fake_footywire_betting_data(
     reduced_data = list(itertools.chain.from_iterable(data))
 
     return pd.DataFrame(list(reduced_data))
+
+
+def fake_prediction_data(match_data: RawFixtureData) -> List[PredictionData]:
+    return [
+        {
+            "team": match_data["home_team"],
+            "year": match_data["season"],
+            "round_number": match_data["round"],
+            "at_home": 1,
+            "oppo_team": match_data["away_team"],
+            "ml_model": "test_estimator",
+            "predicted_margin": np.random.randint(1, 50),
+        },
+        {
+            "team": match_data["away_team"],
+            "year": match_data["season"],
+            "round_number": match_data["round"],
+            "at_home": 0,
+            "oppo_team": match_data["home_team"],
+            "ml_model": "test_estimator",
+            "predicted_margin": np.random.randint(1, 50),
+        },
+    ]

--- a/backend/server/tests/fixtures/data_factories.py
+++ b/backend/server/tests/fixtures/data_factories.py
@@ -8,11 +8,10 @@ from faker import Faker
 import numpy as np
 import pandas as pd
 
-from machine_learning.data_config import TEAM_NAMES, DEFUNCT_TEAM_NAMES
 from server.types import CleanFixtureData, MatchData
 from server.models import Match
 from project.settings.common import MELBOURNE_TIMEZONE
-
+from project.settings.data import TEAM_NAMES, DEFUNCT_TEAM_NAMES
 
 FIRST = 1
 SECOND = 2
@@ -61,6 +60,7 @@ def _raw_match_data(year: int, team_names: Tuple[str, str]) -> MatchData:
         "home_score": np.random.randint(50, 150),
         "away_score": np.random.randint(50, 150),
         "match_id": FAKE.ean(),
+        "crowd": np.random.randint(10000, 30000),
     }
 
 

--- a/backend/server/tests/fixtures/factories.py
+++ b/backend/server/tests/fixtures/factories.py
@@ -5,9 +5,8 @@ from factory.django import DjangoModelFactory
 from faker import Faker
 
 from server.models import Team, Prediction, Match, MLModel, TeamMatch
-from machine_learning.data_config import TEAM_NAMES, VENUES
-from machine_learning.tests.fixtures import TestEstimator
 from project.settings.common import MELBOURNE_TIMEZONE
+from project.settings.data import TEAM_NAMES, VENUES
 
 FAKE = Faker()
 THIS_YEAR = date.today().year
@@ -59,7 +58,7 @@ class MLModelFactory(DjangoModelFactory):
 
     name = factory.Faker("company")
     description = factory.Faker("paragraph", nb_sentences=4)
-    filepath = TestEstimator().pickle_filepath()
+    filepath = "some/filepath/to/model.pkl"
     data_class_path = ""
 
 

--- a/backend/server/tests/integration/management/commands/test_seed_db.py
+++ b/backend/server/tests/integration/management/commands/test_seed_db.py
@@ -3,6 +3,7 @@ from datetime import datetime
 
 from django.test import TestCase
 from sklearn.externals import joblib
+import pandas as pd
 
 from server.models import Match, TeamMatch, Team, MLModel, Prediction
 from server.management.commands import seed_db
@@ -51,13 +52,15 @@ class TestSeedDb(TestCase):
                 "round": match_result["round_number"],
             }
 
-            prediction_data.extend(
+            prediction_data.append(
                 fake_prediction_data(
                     match_data=match_data, ml_model_name="test_estimator"
                 )
             )
 
-        data_import.fetch_prediction_data = Mock(return_value=prediction_data)
+        data_import.fetch_prediction_data = Mock(
+            return_value=pd.concat(prediction_data).reset_index()
+        )
         data_import.fetch_match_results_data = Mock(
             side_effect=self.__match_results_side_effect
         )

--- a/backend/server/tests/integration/management/commands/test_seed_db.py
+++ b/backend/server/tests/integration/management/commands/test_seed_db.py
@@ -12,7 +12,6 @@ from server.tests.fixtures.data_factories import (
     fake_prediction_data,
 )
 from server import data_import
-from machine_learning.tests.fixtures import TestEstimator
 from project.settings.common import MELBOURNE_TIMEZONE
 
 
@@ -48,8 +47,8 @@ class TestSeedDb(TestCase):
             match_data = {
                 "home_team": match_result["home_team"],
                 "away_team": match_result["away_team"],
-                "season": match_result["year"],
-                "round": match_result["round_number"],
+                "year": match_result["year"],
+                "round_number": match_result["round_number"],
             }
 
             prediction_data.append(
@@ -64,10 +63,13 @@ class TestSeedDb(TestCase):
         data_import.fetch_match_results_data = Mock(
             side_effect=self.__match_results_side_effect
         )
-
-        self.seed_command = seed_db.Command(
-            estimators=[TestEstimator()], data_importer=data_import
+        data_import.fetch_ml_model_info = Mock(
+            return_value=[
+                {"name": "test_estimator", "filepath": "some/filepath/model.pkl"}
+            ]
         )
+
+        self.seed_command = seed_db.Command(data_importer=data_import)
 
     def test_handle(self):
         self.seed_command.handle(

--- a/backend/server/tests/integration/management/commands/test_tip.py
+++ b/backend/server/tests/integration/management/commands/test_tip.py
@@ -9,7 +9,6 @@ from server.management.commands import tip
 from server.tests.fixtures.data_factories import fake_fixture_data, fake_prediction_data
 from server.tests.fixtures.factories import MLModelFactory, TeamFactory
 from server import data_import
-from machine_learning.data_import import FitzroyDataImporter
 from machine_learning.ml_data import BettingMLData
 
 
@@ -25,9 +24,6 @@ class TestTip(TestCase):
 
         # Mock footywire fixture data
         fixture_data = fake_fixture_data(ROW_COUNT, (year, year + 1))
-
-        fitzroy = FitzroyDataImporter()
-        fitzroy.fetch_fixtures = Mock(return_value=fixture_data)
 
         # Mock update_or_create_from_data to make assertions on calls
         update_or_create_from_data = copy.copy(Prediction.update_or_create_from_data)
@@ -50,13 +46,11 @@ class TestTip(TestCase):
             )
 
         data_import.fetch_prediction_data = Mock(return_value=prediction_data)
+        data_import.fetch_fixture_data = Mock(return_value=fixture_data)
 
         # Not fetching data, because it takes forever
         self.tip_command = tip.Command(
-            data_reader=fitzroy,
-            fetch_data=False,
-            data=BettingMLData(),
-            prediction_data=data_import,
+            fetch_data=False, data=BettingMLData(), data_importer=data_import
         )
 
     def test_handle(self):

--- a/backend/server/tests/unit/models/test_ml_model.py
+++ b/backend/server/tests/unit/models/test_ml_model.py
@@ -1,16 +1,13 @@
 from django.test import TestCase
 from django.core.exceptions import ValidationError
-from sklearn.base import BaseEstimator
 
 from server.models import MLModel
-from machine_learning.tests.fixtures import TestEstimator
 
 
 class TestMLModel(TestCase):
     def setUp(self):
-        self.estimator = TestEstimator()
         self.ml_model = MLModel(
-            name=self.estimator.name, filepath=self.estimator.pickle_filepath()
+            name="test_estimator", filepath="path/to/test_estimator.pkl"
         )
 
     def test_validation(self):
@@ -24,12 +21,7 @@ class TestMLModel(TestCase):
             self.ml_model.data_class_path = "some.perfectly.fine.path"
             self.ml_model.save()
 
-            duplicate_model = MLModel(name=self.estimator.name)
+            duplicate_model = MLModel(name="test_estimator")
 
             with self.assertRaises(ValidationError):
                 duplicate_model.full_clean()
-
-    def test_load_estimator(self):
-        loaded_model = self.ml_model.load_estimator()
-
-        self.assertIsInstance(loaded_model, BaseEstimator)

--- a/backend/server/tests/unit/models/test_prediction.py
+++ b/backend/server/tests/unit/models/test_prediction.py
@@ -4,6 +4,7 @@ from django.utils import timezone
 from django.core.exceptions import ValidationError
 
 from server.models import Match, MLModel, Team, Prediction
+from server.tests.fixtures.data_factories import fake_prediction_data
 
 
 class TestPrediction(TestCase):
@@ -61,6 +62,13 @@ class TestPrediction(TestCase):
                     self.match, prediction.predicted_winner
                 )
             )
+
+    def test_convert_data_to_record(self):
+        data = fake_prediction_data()
+        record = Prediction.convert_data_to_record(data)
+
+        self.assertIsInstance(record, Prediction)
+        record.clean_fields()
 
     def test_clean(self):
         with self.subTest("when predicted margin rounds to 0"):

--- a/backend/server/tests/unit/models/test_prediction.py
+++ b/backend/server/tests/unit/models/test_prediction.py
@@ -6,7 +6,7 @@ from django.core.exceptions import ValidationError
 import pandas as pd
 
 from server.models import Match, MLModel, Team, Prediction
-
+from server.helpers import pivot_team_matches_to_matches
 from server.tests.fixtures.data_factories import fake_prediction_data
 
 
@@ -68,36 +68,7 @@ class TestPrediction(TestCase):
 
     def test_convert_data_to_record(self):
         data = fake_prediction_data(self.match, ml_model_name=self.ml_model.name)
-        predictions_df = pd.DataFrame(data)
-
-        home_df = (
-            predictions_df.query("at_home == 1")
-            .rename(
-                columns={
-                    "team": "home_team",
-                    "oppo_team": "away_team",
-                    "predicted_margin": "home_margin",
-                }
-            )
-            .drop("at_home", axis=1)
-        )
-        away_df = (
-            predictions_df.query("at_home == 0")
-            .rename(
-                columns={
-                    "team": "away_team",
-                    "oppo_team": "home_team",
-                    "predicted_margin": "away_margin",
-                }
-            )
-            .drop("at_home", axis=1)
-        )
-
-        home_away_df = home_df.merge(
-            away_df,
-            on=["home_team", "away_team", "year", "round_number", "ml_model"],
-            how="inner",
-        )
+        home_away_df = pivot_team_matches_to_matches(pd.DataFrame(data))
 
         self.assertEqual(Prediction.objects.count(), 0)
         Prediction.update_or_create_from_data(home_away_df.to_dict("records")[0])
@@ -105,8 +76,8 @@ class TestPrediction(TestCase):
 
         with self.subTest("when prediction record already exists"):
             predicted_margin = 100
-            home_away_df.loc[:, "home_margin"] = predicted_margin
-            home_away_df.loc[:, "away_margin"] = -predicted_margin
+            home_away_df.loc[:, "home_predicted_margin"] = predicted_margin
+            home_away_df.loc[:, "away_predicted_margin"] = -predicted_margin
 
             Prediction.update_or_create_from_data(home_away_df.to_dict("records")[0])
             self.assertEqual(Prediction.objects.count(), 1)

--- a/backend/server/tests/unit/test_helpers.py
+++ b/backend/server/tests/unit/test_helpers.py
@@ -1,0 +1,22 @@
+from django.test import TestCase
+import pandas as pd
+
+from server.helpers import pivot_team_matches_to_matches
+from server.tests.fixtures.data_factories import fake_prediction_data
+
+
+class TestHelpers(TestCase):
+    def setUp(self):
+        self.team_match_df = pd.DataFrame(fake_prediction_data())
+
+    def test_pivot_team_matches_to_matches(self):
+        match_df = pivot_team_matches_to_matches(self.team_match_df)
+
+        self.assertIsInstance(match_df, pd.DataFrame)
+        self.assertIn("home_team", match_df.columns)
+        self.assertIn("away_team", match_df.columns)
+        self.assertIn("home_predicted_margin", match_df.columns)
+        self.assertIn("away_predicted_margin", match_df.columns)
+
+        self.assertNotIn("team", match_df.columns)
+        self.assertNotIn("oppo_team", match_df.columns)

--- a/backend/server/types.py
+++ b/backend/server/types.py
@@ -40,6 +40,7 @@ MatchData = TypedDict(
         "home_score": int,
         "away_score": int,
         "match_id": int,
+        "crowd": int,
     },
 )
 
@@ -68,3 +69,5 @@ CleanPredictionData = TypedDict(
         "away_predicted_margin": float,
     },
 )
+
+MlModel = TypedDict("MlModel", {"name": str, "filepath": str})

--- a/backend/server/types.py
+++ b/backend/server/types.py
@@ -42,3 +42,17 @@ MatchData = TypedDict(
         "match_id": int,
     },
 )
+
+
+PredictionData = TypedDict(
+    "PredictionData",
+    {
+        "team": str,
+        "year": int,
+        "round_number": int,
+        "at_home": int,
+        "oppo_team": str,
+        "ml_model": str,
+        "predicted_margin": float,
+    },
+)

--- a/backend/server/types.py
+++ b/backend/server/types.py
@@ -15,8 +15,8 @@ RawFixtureData = TypedDict(
     },
 )
 
-CleanedFixtureData = TypedDict(
-    "CleanedFixtureData",
+CleanFixtureData = TypedDict(
+    "CleanFixtureData",
     {
         "date": Union[datetime],
         "year": int,

--- a/backend/server/types.py
+++ b/backend/server/types.py
@@ -43,7 +43,6 @@ MatchData = TypedDict(
     },
 )
 
-
 PredictionData = TypedDict(
     "PredictionData",
     {
@@ -54,5 +53,18 @@ PredictionData = TypedDict(
         "oppo_team": str,
         "ml_model": str,
         "predicted_margin": float,
+    },
+)
+
+CleanPredictionData = TypedDict(
+    "CleanPredictionData",
+    {
+        "home_team": str,
+        "year": int,
+        "round_number": int,
+        "away_team": str,
+        "ml_model": str,
+        "home_margin": float,
+        "away_margin": float,
     },
 )

--- a/backend/server/types.py
+++ b/backend/server/types.py
@@ -64,7 +64,7 @@ CleanPredictionData = TypedDict(
         "round_number": int,
         "away_team": str,
         "ml_model": str,
-        "home_margin": float,
-        "away_margin": float,
+        "home_predicted_margin": float,
+        "away_predicted_margin": float,
     },
 )


### PR DESCRIPTION
In anticipation of moving `machine_learning` functionality to a separate service, I'm decoupling it from the `server` module such that the only `machine_learning` import inside `server` is in a `data_import` submodule meant to handle communication between the two. I also added an `api` module to `machine_learning` to handle the passing of data to `server`.