### PR TITLE
Add GQL query for cumulative model stats

### DIFF
--- a/backend/server/models.py
+++ b/backend/server/models.py
@@ -60,6 +60,15 @@ class Match(models.Model):
         return max(self.teammatch_set.all(), key=lambda tm: tm.score).team
 
     @property
+    def margin(self):
+        if not self.has_been_played:
+            return 0
+
+        return reduce(
+            lambda score_x, score_y: abs(score_x - score_y), self.__match_scores
+        )
+
+    @property
     def year(self):
         return self.start_date_time.year
 

--- a/backend/server/schema.py
+++ b/backend/server/schema.py
@@ -121,12 +121,22 @@ class RoundType(graphene.ObjectType):
 class SeasonType(graphene.ObjectType):
     """Match and prediction data grouped by season"""
 
+    season_year = graphene.Int()
+
     prediction_model_names = graphene.List(
         graphene.String, description="All model names available for the given year"
     )
     predictions_by_round = graphene.List(
         RoundType, description="Match and prediction data grouped by round"
     )
+
+    @staticmethod
+    def resolve_season_year(root, _info) -> int:
+        # Have to use list indexing to get first instead of .first(),
+        # because the latter raises a weird SQL error
+        return root.distinct("match__start_date_time__year")[
+            0
+        ].match.start_date_time.year
 
     @staticmethod
     def resolve_prediction_model_names(root, _info) -> List[str]:

--- a/backend/server/tests/unit/test_schema.py
+++ b/backend/server/tests/unit/test_schema.py
@@ -16,6 +16,7 @@ from project.settings.common import MELBOURNE_TIMEZONE
 ROUND_COUNT = 2
 YEAR_RANGE = (2014, 2016)
 MODEL_NAMES = ["predictanator", "accurate_af"]
+TWENTY_SEVENTEEN = 2017
 
 
 class TestSchema(TestCase):
@@ -169,7 +170,7 @@ class TestSchema(TestCase):
 
     def test_fetch_latest_round_predictions(self):
         ml_models = list(MLModel.objects.all())
-        year = 2017
+        year = TWENTY_SEVENTEEN
 
         latest_matches = [
             FullMatchFactory(
@@ -239,7 +240,7 @@ class TestSchema(TestCase):
 
     def test_fetch_latest_round_stats(self):
         ml_models = list(MLModel.objects.all())
-        year = 2017
+        year = TWENTY_SEVENTEEN
 
         latest_matches = [
             FullMatchFactory(

--- a/backend/server/tests/unit/test_schema.py
+++ b/backend/server/tests/unit/test_schema.py
@@ -106,6 +106,7 @@ class TestSchema(TestCase):
             """
             query QueryType {
                 fetchYearlyPredictions(year: 2015) {
+                    seasonYear
                     predictionModelNames
                     predictionsByRound {
                         roundNumber
@@ -120,6 +121,7 @@ class TestSchema(TestCase):
         data = executed["data"]["fetchYearlyPredictions"]
 
         self.assertEqual(set(data["predictionModelNames"]), set(ml_model_names))
+        self.assertEqual(data["seasonYear"], 2015)
 
         predictions = data["predictionsByRound"]
 

--- a/backend/server/tests/unit/test_schema.py
+++ b/backend/server/tests/unit/test_schema.py
@@ -1,4 +1,4 @@
-from datetime import date
+from datetime import date, datetime
 import itertools
 from dateutil import parser
 
@@ -10,6 +10,8 @@ from server.schema import schema
 from server.tests.fixtures.factories import FullMatchFactory
 from server.models import Match, MLModel
 from server.tests.fixtures.factories import MLModelFactory
+from project.settings.common import MELBOURNE_TIMEZONE
+
 
 ROUND_COUNT = 2
 YEAR_RANGE = (2014, 2016)
@@ -26,11 +28,15 @@ class TestSchema(TestCase):
         self.matches = [
             FullMatchFactory(
                 year=year,
+                round_number=(idx + 1),
+                start_date_time=datetime(
+                    year, 6, (idx % 30) + 1, tzinfo=MELBOURNE_TIMEZONE
+                ),
                 prediction__ml_model=ml_models[0],
                 prediction_two__ml_model=ml_models[1],
             )
             for year in range(*YEAR_RANGE)
-            for _ in range(ROUND_COUNT)
+            for idx in range(ROUND_COUNT)
         ]
 
     def test_fetch_predictions(self):

--- a/backend/server/tests/unit/test_schema.py
+++ b/backend/server/tests/unit/test_schema.py
@@ -1,4 +1,4 @@
-from datetime import date, datetime
+from datetime import datetime
 import itertools
 from dateutil import parser
 
@@ -28,9 +28,9 @@ class TestSchema(TestCase):
         self.matches = [
             FullMatchFactory(
                 year=year,
-                round_number=(idx + 1),
+                round_number=((idx % 23) + 1),
                 start_date_time=datetime(
-                    year, 6, (idx % 30) + 1, tzinfo=MELBOURNE_TIMEZONE
+                    year, 6, (idx % 29) + 1, tzinfo=MELBOURNE_TIMEZONE
                 ),
                 prediction__ml_model=ml_models[0],
                 prediction_two__ml_model=ml_models[1],
@@ -169,15 +169,19 @@ class TestSchema(TestCase):
 
     def test_fetch_latest_round_predictions(self):
         ml_models = list(MLModel.objects.all())
-        year = date.today().year
+        year = 2017
 
         latest_matches = [
             FullMatchFactory(
                 year=year,
+                round_number=((idx % 23) + 1),
+                start_date_time=datetime(
+                    year, 6, (idx % 29) + 1, tzinfo=MELBOURNE_TIMEZONE
+                ),
                 prediction__ml_model=ml_models[0],
                 prediction_two__ml_model=ml_models[1],
             )
-            for _ in range(ROUND_COUNT)
+            for idx in range(ROUND_COUNT)
         ]
 
         executed = self.client.execute(
@@ -232,6 +236,61 @@ class TestSchema(TestCase):
             ml_model_names = [pred["mlModel"]["name"] for pred in predictions]
 
             self.assertEqual(ml_model_names, ["accurate_af"])
+
+    def test_fetch_latest_round_stats(self):
+        ml_models = list(MLModel.objects.all())
+        year = 2017
+
+        latest_matches = [
+            FullMatchFactory(
+                year=year,
+                round_number=5,
+                start_date_time=datetime(
+                    year, 6, (idx % 29) + 1, tzinfo=MELBOURNE_TIMEZONE
+                ),
+                prediction__ml_model=ml_models[0],
+                prediction__is_correct=True,
+                prediction_two__ml_model=ml_models[1],
+                prediction_two__is_correct=True,
+            )
+            for idx in range(ROUND_COUNT)
+        ]
+
+        executed = self.client.execute(
+            """
+            query QueryType {
+                fetchLatestRoundStats(mlModelName: "accurate_af") {
+                    seasonYear
+                    roundNumber
+                    modelStats {
+                        modelName
+                        cumulativeCorrectCount
+                        cumulativeMeanAbsoluteError
+                        cumulativeSumAbsoluteError
+                    }
+                }
+            }
+            """
+        )
+
+        # import pdb
+
+        # pdb.set_trace()
+
+        data = executed["data"]["fetchLatestRoundStats"]
+
+        max_match_round = max([match.round_number for match in latest_matches])
+        self.assertEqual(data["roundNumber"], max_match_round)
+
+        match_years = [match.start_date_time.year for match in latest_matches]
+        self.assertEqual(np.mean(match_years), year)
+
+        model_stats = data["modelStats"]
+        self.assertEqual("accurate_af", model_stats["modelName"])
+
+        self.assertGreater(model_stats["cumulativeCorrectCount"], 0)
+        self.assertGreater(model_stats["cumulativeMeanAbsoluteError"], 0)
+        self.assertGreater(model_stats["cumulativeSumAbsoluteError"], 0)
 
     def _assert_correct_prediction_results(self, results, expected_results):
         # graphene returns OrderedDicts instead of dicts, which makes asserting


### PR DESCRIPTION
Repeats some of the logic/calculations that go into the yearly predictions query, but adds more stats, and returns it in a shape that is closer to what the frontend needs. Should probably refactor a bit, but the whole GQL schema needs a bit of rethinking, so I'll leave that till later, especially since this is a blocker for frontend work.

Shape of returned data is:
```
{
  seasonYear: <int>,
  roundNumber: <int>,
  modelStats: {
    modelName: <str>,
    cumulativeCorrectCount: <int>,
    cumulativeSumAbsoluteError: <int>,
    cumulativeMeanAbsoluteError: <float>
}
```