### PR TITLE
Fix query when last match is unplayed & related time issues

### DIFF
--- a/backend/server/models.py
+++ b/backend/server/models.py
@@ -86,7 +86,7 @@ class Match(models.Model):
         # We need to check the scores in case the data hasn't been updated since the
         # match was played, because as far as the data is concerned it hasn't, even though
         # the date has passed.
-        return self.__has_score and match_end_time < datetime.now(MELBOURNE_TIMEZONE)
+        return self.__has_score and match_end_time < datetime.now(tz=MELBOURNE_TIMEZONE)
 
     @property
     def __has_score(self):


### PR DESCRIPTION
If the last match is unplayed `resolve_fetch_latest_round_stats` was returning an empty data frame, because I was mixing and matching filters based on available prediction and match data. Fixing this also brought up some datetime/timezone issues, so I fixed some of those, making dealing with time a little more consistent.