### PR TITLE
Reenable flaky schema test

### DIFF
--- a/backend/server/tests/integration/test_tipping.py
+++ b/backend/server/tests/integration/test_tipping.py
@@ -84,28 +84,28 @@ class TestTipping(TestCase):
                 self.assertEqual(Match.objects.count(), ROW_COUNT)
                 self.assertEqual(TeamMatch.objects.count(), ROW_COUNT * 2)
 
-        # with freeze_time("2017-01-01"):
-        #     with self.subTest("with scoreless matches from ealier rounds"):
-        #         right_now = datetime.now(tz=MELBOURNE_TIMEZONE)
-        #         self.tipping.right_now = right_now
+        with freeze_time("2017-01-01"):
+            with self.subTest("with scoreless matches from ealier rounds"):
+                right_now = datetime.now(tz=MELBOURNE_TIMEZONE)
+                self.tipping.right_now = right_now
 
-        #         self.assertEqual(TeamMatch.objects.filter(score__gt=0).count(), 0)
-        #         self.assertEqual(Prediction.objects.filter(is_correct=True).count(), 0)
+                self.assertEqual(TeamMatch.objects.filter(score__gt=0).count(), 0)
+                self.assertEqual(Prediction.objects.filter(is_correct=True).count(), 0)
 
-        #         self.tipping.tip(verbose=0)
+                self.tipping.tip(verbose=0)
 
-        #         self.assertEqual(
-        #             TeamMatch.objects.filter(
-        #                 match__start_date_time__lt=right_now, score=0
-        #             ).count(),
-        #             0,
-        #         )
-        #         self.assertGreater(
-        #             Prediction.objects.filter(
-        #                 match__start_date_time__lt=right_now, is_correct=True
-        #             ).count(),
-        #             0,
-        #         )
+                self.assertEqual(
+                    TeamMatch.objects.filter(
+                        match__start_date_time__lt=right_now, score=0
+                    ).count(),
+                    0,
+                )
+                self.assertGreater(
+                    Prediction.objects.filter(
+                        match__start_date_time__lt=right_now, is_correct=True
+                    ).count(),
+                    0,
+                )
 
     @staticmethod
     def __update_or_create_from_data(update_or_create_from_data):
@@ -210,7 +210,10 @@ class TestTippingEndToEnd(TestCase):
         self.tipping.tip(verbose=0)
 
         match_count = Match.objects.count()
+        future_match_count = Match.objects.filter(
+            start_date_time__gt=datetime.now()
+        ).count()
 
         self.assertGreater(match_count, 0)
         self.assertEqual(TeamMatch.objects.count(), match_count * 2)
-        self.assertEqual(Prediction.objects.count(), match_count)
+        self.assertEqual(Prediction.objects.count(), future_match_count)

--- a/backend/server/tests/integration/test_tipping.py
+++ b/backend/server/tests/integration/test_tipping.py
@@ -211,7 +211,7 @@ class TestTippingEndToEnd(TestCase):
 
         match_count = Match.objects.count()
         future_match_count = Match.objects.filter(
-            start_date_time__gt=datetime.now()
+            start_date_time__gt=datetime.now().replace(tzinfo=MELBOURNE_TIMEZONE)
         ).count()
 
         self.assertGreater(match_count, 0)

--- a/backend/server/tests/unit/test_schema.py
+++ b/backend/server/tests/unit/test_schema.py
@@ -71,26 +71,26 @@ class TestSchema(TestCase):
             executed["data"]["fetchPredictions"], expected_predictions
         )
 
-        # with self.subTest("when year is 2015"):
-        #     executed = self.client.execute(
-        #         """
-        #         query QueryType {
-        #             fetchPredictions(year: 2015) {
-        #                 match { roundNumber, year },
-        #                 mlModel { name },
-        #                 isCorrect
-        #             }
-        #         }
-        #         """
-        #     )
+        with self.subTest("when year is 2015"):
+            executed = self.client.execute(
+                """
+                query QueryType {
+                    fetchPredictions(year: 2015) {
+                        match { roundNumber, year },
+                        mlModel { name },
+                        isCorrect
+                    }
+                }
+                """
+            )
 
-        #     expected_predictions = [
-        #         pred for pred in expected_predictions if pred["match"]["year"] == 2015
-        #     ]
+            expected_predictions = [
+                pred for pred in expected_predictions if pred["match"]["year"] == 2015
+            ]
 
-        #     self._assert_correct_prediction_results(
-        #         executed["data"]["fetchPredictions"], expected_predictions
-        #     )
+            self._assert_correct_prediction_results(
+                executed["data"]["fetchPredictions"], expected_predictions
+            )
 
     def test_fetch_prediction_years(self):
         expected_years = list({match.start_date_time.year for match in self.matches})

--- a/backend/server/tipping.py
+++ b/backend/server/tipping.py
@@ -108,7 +108,11 @@ class Tipping:
             print("Saving prediction records...")
 
         self.__make_predictions(upcoming_round_year, upcoming_round)
-        # self.__backfill_match_results()
+
+        if self.verbose == 1:
+            print("Filling in results for recent matches...")
+
+        self.__backfill_match_results()
 
         if self.submit_tips:
             self.__submit_tips()
@@ -266,6 +270,18 @@ class Tipping:
 
             return None
 
+        match_values = match.teammatch_set.values(
+            "match__start_date_time",
+            "match__round_number",
+            "match__venue",
+            "team__name",
+            "at_home",
+        )
+        assert match_results.any().any(), (
+            "Didn't find any match data rows that matched match record:\n"
+            f"{match_values}"
+        )
+
         assert len(match_result) == 1, (
             "Filtering match results by year, round_number and team name "
             "should result in a single row, but instead the following was "
@@ -282,6 +298,8 @@ class Tipping:
         away_team_match.score = match_result["away_score"]
         away_team_match.clean()
         away_team_match.save()
+
+        return None
 
     @staticmethod
     def __update_predictions_correctness(match: Match) -> None:

--- a/backend/server/tipping.py
+++ b/backend/server/tipping.py
@@ -18,6 +18,7 @@ from server.helpers import pivot_team_matches_to_matches
 
 
 NO_SCORE = 0
+FIRST_ROUND = 1
 # We calculate rolling sums/means for some features that can span over 5 seasons
 # of data, so we're setting it to 10 to be on the safe side.
 N_SEASONS_FOR_PREDICTION = 10
@@ -141,6 +142,16 @@ class Tipping:
 
         round_number = {match_data["round_number"] for match_data in fixture_data}.pop()
         year = {match_data["year"] for match_data in fixture_data}.pop()
+
+        prev_match = Match.objects.order_by("-start_date_time").first()
+
+        if prev_match is not None:
+            assert round_number in (prev_match.round_number + 1, FIRST_ROUND), (
+                "Expected upcoming round number to be 1 greater than previous round "
+                f"or 1, but upcoming round is {round_number} in {year}, "
+                f" and previous round was {prev_match.round_number} "
+                f"in {prev_match.start_date_time.year}"
+            )
 
         team_match_lists = [
             self.__build_match(match_data) for match_data in fixture_data


### PR DESCRIPTION
With the `round_number` data errors fixed I think, I can reenable backfilling of match results. I also added an assertion to avoid skipping round numbers again, which is what cause all the data problems to begin with.