### PR TITLE
Fix handling of timezones

### DIFF
--- a/backend/project/settings/common.py
+++ b/backend/project/settings/common.py
@@ -13,6 +13,8 @@ https://docs.djangoproject.com/en/2.1/ref/settings/
 import os
 from typing import List, Dict, Any
 
+from .data_config import *  # pylint: disable=wildcard-import,unused-wildcard-import
+
 # Build paths inside the project like this: os.path.join(BASE_DIR, ...)
 BASE_DIR = os.path.abspath(os.path.join(os.path.dirname(__file__), "../../"))
 

--- a/backend/project/settings/common.py
+++ b/backend/project/settings/common.py
@@ -104,7 +104,7 @@ STATIC_ROOT = os.path.join(BASE_DIR, "staticfiles")
 
 LANGUAGE_CODE = "en-us"
 
-TIME_ZONE = "Australia/Melbourne"
+TIME_ZONE = "UTC"
 
 USE_I18N = True
 

--- a/backend/project/settings/common.py
+++ b/backend/project/settings/common.py
@@ -12,7 +12,6 @@ https://docs.djangoproject.com/en/2.1/ref/settings/
 
 import os
 from typing import List, Dict, Any
-from datetime import timezone, timedelta
 
 # Build paths inside the project like this: os.path.join(BASE_DIR, ...)
 BASE_DIR = os.path.abspath(os.path.join(os.path.dirname(__file__), "../../"))
@@ -99,9 +98,6 @@ STATIC_URL = "/static/"
 STATICFILES_DIRS: List = []
 STATIC_ROOT = os.path.join(BASE_DIR, "staticfiles")
 
-
-HOURS_FROM_UTC_TO_MELBOURNE = 11
-MELBOURNE_TIMEZONE = timezone(timedelta(hours=HOURS_FROM_UTC_TO_MELBOURNE))
 
 # Internationalization
 # https://docs.djangoproject.com/en/2.1/topics/i18n/

--- a/backend/project/settings/development.py
+++ b/backend/project/settings/development.py
@@ -8,3 +8,5 @@ DEBUG = True
 
 # SECURITY WARNING: keep the secret key used in production secret!
 SECRET_KEY = "^6&#7de5dx#eqg6dm^l3#@wj6vjjn%2f=u(!&ia()h-l1ppan!"
+
+ENVIRONMENT = "development"

--- a/backend/project/settings/production.py
+++ b/backend/project/settings/production.py
@@ -4,6 +4,7 @@ import dj_database_url
 from project.settings.common import *
 
 DEBUG = False
+ENVIRONMENT = "production"
 
 SECRET_KEY = os.environ.get("SECRET_KEY")
 

--- a/backend/project/urls.py
+++ b/backend/project/urls.py
@@ -16,6 +16,7 @@ Including another URLconf
 import os
 from django.contrib import admin
 from django.urls import path, re_path
+from django.conf import settings
 from django.views.generic import TemplateView
 from django.views.decorators.csrf import csrf_exempt
 from graphene_django.views import GraphQLView
@@ -28,5 +29,5 @@ urlpatterns = [  # pylint: disable=C0103
     ),
 ]
 
-if os.getenv("DJANGO_SETTINGS_MODULE") == "project.settings.production":
+if settings.ENVIRONMENT == "production":
     urlpatterns.append(re_path(".*", TemplateView.as_view(template_name="index.html")))

--- a/backend/server/data_import.py
+++ b/backend/server/data_import.py
@@ -4,6 +4,7 @@ from typing import Tuple, Optional, List, Dict, Any, cast
 import os
 from urllib.parse import urljoin
 from dateutil import parser
+import pytz
 
 import pandas as pd
 import requests

--- a/backend/server/data_import.py
+++ b/backend/server/data_import.py
@@ -4,10 +4,10 @@ from typing import Tuple, Optional, List, Dict, Any, cast
 import os
 from urllib.parse import urljoin
 from dateutil import parser
-import pytz
 
 import pandas as pd
 import requests
+from django.utils import timezone
 
 from server.types import MlModel
 
@@ -23,7 +23,7 @@ def _parse_dates(data_frame: pd.DataFrame) -> pd.Series:
     # because the former doesn't maintain the timezone offset.
     # We make sure all datetimes are converted to UTC, because that makes things
     # easier due to Django converting all datetime fields to UTC when saving DB records.
-    return data_frame["date"].map(lambda dt: parser.parse(dt).astimezone(pytz.UTC))
+    return data_frame["date"].map(lambda dt: timezone.localtime(parser.parse(dt)))
 
 
 def _make_request(

--- a/backend/server/management/commands/send_email.py
+++ b/backend/server/management/commands/send_email.py
@@ -1,10 +1,10 @@
 import os
 from datetime import datetime
 from typing import List, Union
-import pytz
 
 from django.core.management.base import BaseCommand
 from django.template.loader import get_template
+from django.utils import timezone
 import sendgrid
 from sendgrid.helpers.mail import Mail
 
@@ -39,7 +39,7 @@ class Command(BaseCommand):
     def handle(self, *_args, **_kwargs):
         """Run 'send_email' command"""
 
-        right_now = datetime.now(tz=pytz.UTC)
+        right_now = timezone.localtime()
         upcoming_match = Match.objects.filter(start_date_time__gt=right_now).earliest(
             "start_date_time"
         )
@@ -49,8 +49,8 @@ class Command(BaseCommand):
         upcoming_round_predictions = (
             Prediction.objects.filter(
                 ml_model__name="tipresias",
-                match__start_date_time__gt=datetime(
-                    upcoming_match_year, JAN, FIRST, tzinfo=pytz.UTC
+                match__start_date_time__gt=timezone.make_aware(
+                    datetime(upcoming_match_year, JAN, FIRST)
                 ),
                 match__round_number=upcoming_round,
             )

--- a/backend/server/management/commands/send_email.py
+++ b/backend/server/management/commands/send_email.py
@@ -1,6 +1,7 @@
 import os
 from datetime import datetime
 from typing import List, Union
+import pytz
 
 from django.core.management.base import BaseCommand
 from django.template.loader import get_template
@@ -8,7 +9,6 @@ import sendgrid
 from sendgrid.helpers.mail import Mail
 
 from server.models import Match, Prediction
-from project.settings.common import MELBOURNE_TIMEZONE
 
 JAN = 1
 FIRST = 1
@@ -39,7 +39,7 @@ class Command(BaseCommand):
     def handle(self, *_args, **_kwargs):
         """Run 'send_email' command"""
 
-        right_now = datetime.now(tz=MELBOURNE_TIMEZONE)
+        right_now = datetime.now(tz=pytz.UTC)
         upcoming_match = Match.objects.filter(start_date_time__gt=right_now).earliest(
             "start_date_time"
         )
@@ -50,7 +50,7 @@ class Command(BaseCommand):
             Prediction.objects.filter(
                 ml_model__name="tipresias",
                 match__start_date_time__gt=datetime(
-                    upcoming_match_year, JAN, FIRST, tzinfo=MELBOURNE_TIMEZONE
+                    upcoming_match_year, JAN, FIRST, tzinfo=pytz.UTC
                 ),
                 match__round_number=upcoming_round,
             )

--- a/backend/server/models.py
+++ b/backend/server/models.py
@@ -1,11 +1,11 @@
 from typing import Optional
 from functools import reduce
 from datetime import datetime, timedelta
-import pytz
 
 from django.db import models, transaction
 from django.core.exceptions import ValidationError
 from django.utils.translation import gettext_lazy as _
+from django.utils import timezone
 import numpy as np
 
 from project.settings.data_config import TEAM_NAMES
@@ -93,7 +93,7 @@ class Match(models.Model):
         # We need to check the scores in case the data hasn't been updated since the
         # match was played, because as far as the data is concerned it hasn't, even though
         # the date has passed.
-        return self.__has_score and match_end_time < datetime.now(tz=pytz.UTC)
+        return self.__has_score and match_end_time < timezone.localtime()
 
     @property
     def __has_score(self):

--- a/backend/server/models.py
+++ b/backend/server/models.py
@@ -6,9 +6,9 @@ from django.db import models, transaction
 from django.core.exceptions import ValidationError
 from django.utils.translation import gettext_lazy as _
 from django.utils import timezone
+from django.conf import settings
 import numpy as np
 
-from project.settings.data_config import TEAM_NAMES
 from server.types import CleanPredictionData
 
 # Rough estimate, but exactitude isn't necessary here
@@ -16,7 +16,7 @@ GAME_LENGTH_HRS = 3
 
 
 def validate_name(name: str) -> None:
-    if name in TEAM_NAMES:
+    if name in settings.TEAM_NAMES:
         return None
 
     raise ValidationError(_("%(name)s is not a valid team name"), params={"name": name})

--- a/backend/server/schema.py
+++ b/backend/server/schema.py
@@ -1,10 +1,9 @@
 from typing import List, cast, Optional
-from datetime import datetime
-import pytz
 
 import graphene
 from graphene_django.types import DjangoObjectType
 from django.db.models import Count, Q, QuerySet
+from django.utils import timezone
 import pandas as pd
 from mypy_extensions import TypedDict
 
@@ -241,7 +240,7 @@ class Query(graphene.ObjectType):
     )
 
     fetch_yearly_predictions = graphene.Field(
-        SeasonType, year=graphene.Int(default_value=datetime.now(tz=pytz.UTC).year)
+        SeasonType, year=graphene.Int(default_value=timezone.localtime().year)
     )
 
     fetch_latest_round_predictions = graphene.Field(
@@ -302,7 +301,7 @@ class Query(graphene.ObjectType):
     @staticmethod
     def resolve_fetch_latest_round_stats(_root, _info, ml_model_name) -> ModelStats:
         max_played_match = (
-            Match.objects.filter(start_date_time__lt=datetime.now(tz=pytz.UTC))
+            Match.objects.filter(start_date_time__lt=timezone.localtime())
             .order_by("-start_date_time")
             .first()
         )
@@ -312,7 +311,7 @@ class Query(graphene.ObjectType):
             Prediction.objects.filter(
                 match__start_date_time__year=max_year,
                 ml_model__name=ml_model_name,
-                match__start_date_time__lt=datetime.now(tz=pytz.UTC),
+                match__start_date_time__lt=timezone.localtime(),
             )
             .select_related("match", "ml_model")
             .order_by("match__start_date_time")

--- a/backend/server/schema.py
+++ b/backend/server/schema.py
@@ -1,5 +1,6 @@
 from typing import List, cast, Optional
 from datetime import datetime
+import pytz
 
 import graphene
 from graphene_django.types import DjangoObjectType
@@ -8,7 +9,6 @@ import pandas as pd
 from mypy_extensions import TypedDict
 
 from server.models import Prediction, MLModel, TeamMatch, Match, Team
-from project.settings.common import MELBOURNE_TIMEZONE
 
 
 ModelPrediction = TypedDict(
@@ -241,8 +241,7 @@ class Query(graphene.ObjectType):
     )
 
     fetch_yearly_predictions = graphene.Field(
-        SeasonType,
-        year=graphene.Int(default_value=datetime.now(tz=MELBOURNE_TIMEZONE).year),
+        SeasonType, year=graphene.Int(default_value=datetime.now(tz=pytz.UTC).year)
     )
 
     fetch_latest_round_predictions = graphene.Field(
@@ -303,9 +302,7 @@ class Query(graphene.ObjectType):
     @staticmethod
     def resolve_fetch_latest_round_stats(_root, _info, ml_model_name) -> ModelStats:
         max_played_match = (
-            Match.objects.filter(
-                start_date_time__lt=datetime.now(tz=MELBOURNE_TIMEZONE)
-            )
+            Match.objects.filter(start_date_time__lt=datetime.now(tz=pytz.UTC))
             .order_by("-start_date_time")
             .first()
         )
@@ -315,7 +312,7 @@ class Query(graphene.ObjectType):
             Prediction.objects.filter(
                 match__start_date_time__year=max_year,
                 ml_model__name=ml_model_name,
-                match__start_date_time__lt=datetime.now(tz=MELBOURNE_TIMEZONE),
+                match__start_date_time__lt=datetime.now(tz=pytz.UTC),
             )
             .select_related("match", "ml_model")
             .order_by("match__start_date_time")

--- a/backend/server/tests/fixtures/data_factories.py
+++ b/backend/server/tests/fixtures/data_factories.py
@@ -8,6 +8,7 @@ import pytz
 from faker import Faker
 import numpy as np
 import pandas as pd
+from django.utils import timezone
 
 from server.types import CleanFixtureData, MatchData
 from server.models import Match
@@ -41,8 +42,8 @@ class CyclicalTeamNames:
 
 def _min_max_datetimes_by_year(year: int) -> Dict[str, datetime]:
     return {
-        "datetime_start": datetime(year, JAN, FIRST, tzinfo=pytz.UTC),
-        "datetime_end": datetime(year, DEC, THIRTY_FIRST, tzinfo=pytz.UTC),
+        "datetime_start": timezone.make_aware(datetime(year, JAN, FIRST)),
+        "datetime_end": timezone.make_aware(datetime(year, DEC, THIRTY_FIRST)),
     }
 
 

--- a/backend/server/tests/fixtures/data_factories.py
+++ b/backend/server/tests/fixtures/data_factories.py
@@ -3,6 +3,7 @@
 from typing import List, Dict, Tuple, Union
 from datetime import datetime
 import itertools
+import pytz
 
 from faker import Faker
 import numpy as np
@@ -10,7 +11,6 @@ import pandas as pd
 
 from server.types import CleanFixtureData, MatchData
 from server.models import Match
-from project.settings.common import MELBOURNE_TIMEZONE
 from project.settings.data_config import TEAM_NAMES, DEFUNCT_TEAM_NAMES
 
 FIRST = 1
@@ -41,15 +41,15 @@ class CyclicalTeamNames:
 
 def _min_max_datetimes_by_year(year: int) -> Dict[str, datetime]:
     return {
-        "datetime_start": datetime(year, JAN, FIRST),
-        "datetime_end": datetime(year, DEC, THIRTY_FIRST),
+        "datetime_start": datetime(year, JAN, FIRST, tzinfo=pytz.UTC),
+        "datetime_end": datetime(year, DEC, THIRTY_FIRST, tzinfo=pytz.UTC),
     }
 
 
 def _raw_match_data(year: int, team_names: Tuple[str, str]) -> MatchData:
     return {
         "date": FAKE.date_time_between_dates(
-            **_min_max_datetimes_by_year(year), tzinfo=MELBOURNE_TIMEZONE
+            **_min_max_datetimes_by_year(year), tzinfo=pytz.UTC
         ),
         "season": year,
         "round": "R1",
@@ -95,7 +95,7 @@ def fake_match_results_data(
 def _fixture_data(year: int, team_names: Tuple[str, str]) -> CleanFixtureData:
     return {
         "date": FAKE.date_time_between_dates(
-            **_min_max_datetimes_by_year(year), tzinfo=MELBOURNE_TIMEZONE
+            **_min_max_datetimes_by_year(year), tzinfo=pytz.UTC
         ),
         "year": year,
         "round_number": 1,

--- a/backend/server/tests/fixtures/data_factories.py
+++ b/backend/server/tests/fixtures/data_factories.py
@@ -9,10 +9,10 @@ from faker import Faker
 import numpy as np
 import pandas as pd
 from django.utils import timezone
+from django.conf import settings
 
 from server.types import CleanFixtureData, MatchData
 from server.models import Match
-from project.settings.data_config import TEAM_NAMES, DEFUNCT_TEAM_NAMES
 
 FIRST = 1
 SECOND = 2
@@ -21,7 +21,7 @@ DEC = 12
 THIRTY_FIRST = 31
 FAKE = Faker()
 CONTEMPORARY_TEAM_NAMES = [
-    name for name in TEAM_NAMES if name not in DEFUNCT_TEAM_NAMES
+    name for name in settings.TEAM_NAMES if name not in settings.DEFUNCT_TEAM_NAMES
 ]
 BASELINE_BET_PAYOUT = 1.92
 

--- a/backend/server/tests/fixtures/factories.py
+++ b/backend/server/tests/fixtures/factories.py
@@ -1,11 +1,11 @@
 from datetime import date, datetime
+import pytz
 
 import factory
 from factory.django import DjangoModelFactory
 from faker import Faker
 
 from server.models import Team, Prediction, Match, MLModel, TeamMatch
-from project.settings.common import MELBOURNE_TIMEZONE
 from project.settings.data_config import TEAM_NAMES, VENUES
 
 FAKE = Faker()
@@ -33,9 +33,11 @@ class MatchFactory(DjangoModelFactory):
 
     start_date_time = factory.LazyAttribute(
         lambda obj: FAKE.date_time_between_dates(
-            datetime_start=datetime(obj.year, JAN, FIRST),
-            datetime_end=datetime(obj.year, DEC, THIRTY_FIRST),
-            tzinfo=MELBOURNE_TIMEZONE,
+            datetime_start=datetime(obj.year, JAN, FIRST, tzinfo=pytz.UTC),
+            datetime_end=datetime(
+                obj.year, DEC, THIRTY_FIRST, tzinfo=pytz.UTC
+            ),
+            tzinfo=pytz.UTC,
         )
     )
     round_number = factory.Faker("pyint", min_value=1, max_value=24)

--- a/backend/server/tests/fixtures/factories.py
+++ b/backend/server/tests/fixtures/factories.py
@@ -5,9 +5,9 @@ import factory
 from factory.django import DjangoModelFactory
 from faker import Faker
 from django.utils import timezone
+from django.conf import settings
 
 from server.models import Team, Prediction, Match, MLModel, TeamMatch
-from project.settings.data_config import TEAM_NAMES, VENUES
 
 FAKE = Faker()
 THIS_YEAR = date.today().year
@@ -22,7 +22,7 @@ class TeamFactory(DjangoModelFactory):
         model = Team
         django_get_or_create = ("name",)
 
-    name = factory.Sequence(lambda n: TEAM_NAMES[n % len(TEAM_NAMES)])
+    name = factory.Sequence(lambda n: settings.TEAM_NAMES[n % len(settings.TEAM_NAMES)])
 
 
 class MatchFactory(DjangoModelFactory):
@@ -40,7 +40,9 @@ class MatchFactory(DjangoModelFactory):
         )
     )
     round_number = factory.Faker("pyint", min_value=1, max_value=24)
-    venue = VENUES[FAKE.pyint(min_value=0, max_value=(len(VENUES) - 1))]
+    venue = settings.VENUES[
+        FAKE.pyint(min_value=0, max_value=(len(settings.VENUES) - 1))
+    ]
 
 
 class TeamMatchFactory(DjangoModelFactory):

--- a/backend/server/tests/fixtures/factories.py
+++ b/backend/server/tests/fixtures/factories.py
@@ -4,6 +4,7 @@ import pytz
 import factory
 from factory.django import DjangoModelFactory
 from faker import Faker
+from django.utils import timezone
 
 from server.models import Team, Prediction, Match, MLModel, TeamMatch
 from project.settings.data_config import TEAM_NAMES, VENUES
@@ -33,10 +34,8 @@ class MatchFactory(DjangoModelFactory):
 
     start_date_time = factory.LazyAttribute(
         lambda obj: FAKE.date_time_between_dates(
-            datetime_start=datetime(obj.year, JAN, FIRST, tzinfo=pytz.UTC),
-            datetime_end=datetime(
-                obj.year, DEC, THIRTY_FIRST, tzinfo=pytz.UTC
-            ),
+            datetime_start=timezone.make_aware(datetime(obj.year, JAN, FIRST)),
+            datetime_end=timezone.make_aware(datetime(obj.year, DEC, THIRTY_FIRST)),
             tzinfo=pytz.UTC,
         )
     )

--- a/backend/server/tests/integration/management/commands/test_seed_db.py
+++ b/backend/server/tests/integration/management/commands/test_seed_db.py
@@ -1,5 +1,6 @@
 from unittest.mock import Mock, patch
 from datetime import datetime
+import pytz
 
 from django.test import TestCase
 import joblib
@@ -11,7 +12,6 @@ from server.tests.fixtures.data_factories import (
     fake_match_results_data,
     fake_prediction_data,
 )
-from project.settings.common import MELBOURNE_TIMEZONE
 
 
 MATCH_COUNT_PER_YEAR = 5
@@ -119,10 +119,10 @@ class TestSeedDb(TestCase):
 
         tz_start_date = datetime.strptime(  # pylint: disable=W0612
             start_date, "%Y-%m-%d"
-        ).replace(tzinfo=MELBOURNE_TIMEZONE)
+        ).replace(tzinfo=pytz.UTC)
         tz_end_date = datetime.strptime(  # pylint: disable=W0612
             end_date, "%Y-%m-%d"
-        ).replace(tzinfo=MELBOURNE_TIMEZONE)
+        ).replace(tzinfo=pytz.UTC)
 
         return self.match_results_data_frame.query(
             "date >= @tz_start_date & date <= @tz_end_date"

--- a/backend/server/tests/integration/management/commands/test_seed_db.py
+++ b/backend/server/tests/integration/management/commands/test_seed_db.py
@@ -1,8 +1,8 @@
 from unittest.mock import Mock, patch
 from datetime import datetime
-import pytz
 
 from django.test import TestCase
+from django.utils import timezone
 import joblib
 import pandas as pd
 
@@ -117,12 +117,12 @@ class TestSeedDb(TestCase):
         if start_date is None or end_date is None:
             return self.match_results_data_frame
 
-        tz_start_date = datetime.strptime(  # pylint: disable=W0612
-            start_date, "%Y-%m-%d"
-        ).replace(tzinfo=pytz.UTC)
-        tz_end_date = datetime.strptime(  # pylint: disable=W0612
-            end_date, "%Y-%m-%d"
-        ).replace(tzinfo=pytz.UTC)
+        tz_start_date = timezone.make_aware(  # pylint: disable=unused-variable
+            datetime.strptime(start_date, "%Y-%m-%d")
+        )
+        tz_end_date = timezone.make_aware(  # pylint: disable=unused-variable
+            datetime.strptime(end_date, "%Y-%m-%d")
+        )
 
         return self.match_results_data_frame.query(
             "date >= @tz_start_date & date <= @tz_end_date"

--- a/backend/server/tests/integration/management/commands/test_send_email.py
+++ b/backend/server/tests/integration/management/commands/test_send_email.py
@@ -1,5 +1,6 @@
 from datetime import datetime
 from unittest.mock import patch
+import pytz
 
 from django.test import TestCase
 from faker import Faker
@@ -8,7 +9,6 @@ import numpy as np
 from server.management.commands import send_email
 from server.tests.fixtures.data_factories import fake_match_results_data
 from server.tests.fixtures.factories import MLModelFactory, FullMatchFactory
-from project.settings.common import MELBOURNE_TIMEZONE
 
 FAKE = Faker()
 ROW_COUNT = 10
@@ -16,7 +16,7 @@ ROW_COUNT = 10
 
 class TestSendEmail(TestCase):
     def setUp(self):
-        today = datetime.now(tz=MELBOURNE_TIMEZONE)
+        today = datetime.now(tz=pytz.UTC)
         year = today.year
 
         self.match_results_data = fake_match_results_data(ROW_COUNT, (year, year + 1))
@@ -26,7 +26,7 @@ class TestSendEmail(TestCase):
 
         for match_data in self.match_results_data.to_dict("records"):
             match_date = (
-                match_data["date"].to_pydatetime().replace(tzinfo=MELBOURNE_TIMEZONE)
+                match_data["date"].to_pydatetime().astimezone(pytz.UTC)
             )
             match_attrs = {
                 "start_date_time": match_date,

--- a/backend/server/tests/integration/management/commands/test_send_email.py
+++ b/backend/server/tests/integration/management/commands/test_send_email.py
@@ -1,8 +1,7 @@
-from datetime import datetime
 from unittest.mock import patch
-import pytz
 
 from django.test import TestCase
+from django.utils import timezone
 from faker import Faker
 import numpy as np
 
@@ -16,7 +15,7 @@ ROW_COUNT = 10
 
 class TestSendEmail(TestCase):
     def setUp(self):
-        today = datetime.now(tz=pytz.UTC)
+        today = timezone.localtime()
         year = today.year
 
         self.match_results_data = fake_match_results_data(ROW_COUNT, (year, year + 1))
@@ -25,9 +24,7 @@ class TestSendEmail(TestCase):
         ml_model = MLModelFactory(name="tipresias")
 
         for match_data in self.match_results_data.to_dict("records"):
-            match_date = (
-                match_data["date"].to_pydatetime().astimezone(pytz.UTC)
-            )
+            match_date = timezone.localtime(match_data["date"].to_pydatetime())
             match_attrs = {
                 "start_date_time": match_date,
                 "round_number": match_data["round_number"],

--- a/backend/server/tests/integration/test_tipping.py
+++ b/backend/server/tests/integration/test_tipping.py
@@ -6,6 +6,7 @@ import os
 
 from django.test import TestCase
 from django.utils import timezone
+from django.conf import settings
 from freezegun import freeze_time
 import pandas as pd
 import numpy as np
@@ -15,7 +16,6 @@ from server.tipping import Tipping
 from server import data_import
 from server.tests.fixtures.data_factories import fake_fixture_data, fake_prediction_data
 from server.tests.fixtures.factories import MLModelFactory, TeamFactory
-from project.settings.data_config import TEAM_NAMES
 
 
 ROW_COUNT = 5
@@ -205,7 +205,7 @@ class TestTippingEndToEnd(TestCase):
     def setUp(self):
         MLModelFactory(name="tipresias")
 
-        for team_name in TEAM_NAMES:
+        for team_name in settings.TEAM_NAMES:
             TeamFactory(name=team_name)
 
         self.tipping = Tipping(ml_models="tipresias", submit_tips=False)

--- a/backend/server/tests/integration/test_tipping.py
+++ b/backend/server/tests/integration/test_tipping.py
@@ -12,6 +12,7 @@ import numpy as np
 
 from server.models import Match, TeamMatch, Prediction
 from server.tipping import Tipping
+from server import data_import
 from server.tests.fixtures.data_factories import fake_fixture_data, fake_prediction_data
 from server.tests.fixtures.factories import MLModelFactory, TeamFactory
 from project.settings.data_config import TEAM_NAMES
@@ -221,6 +222,14 @@ class TestTippingEndToEnd(TestCase):
             start_date_time__gt=timezone.localtime()
         ).count()
 
-        self.assertGreater(match_count, 0)
+        start_date = datetime.today()
+        end_date = datetime(start_date.year, 12, 31)
+        fixture_data = data_import.fetch_fixture_data(str(start_date), str(end_date))
+
+        # Sometimes the fixtures haven't been updated yet. This mostly happens
+        # during finals and the off-season
+        if fixture_data.any().any():
+            self.assertGreater(match_count, 0)
+
         self.assertEqual(TeamMatch.objects.count(), match_count * 2)
         self.assertEqual(Prediction.objects.count(), future_match_count)

--- a/backend/server/tests/unit/models/test_match.py
+++ b/backend/server/tests/unit/models/test_match.py
@@ -1,5 +1,4 @@
 from datetime import datetime, timedelta
-import pytz
 from django.test import TestCase
 from django.utils import timezone
 from django.core.exceptions import ValidationError
@@ -9,9 +8,7 @@ from server.models import Match, Team
 
 class TestMatch(TestCase):
     def setUp(self):
-        match_datetime = timezone.make_aware(
-            datetime(2018, 5, 5), timezone=pytz.UTC
-        )
+        match_datetime = timezone.make_aware(datetime(2018, 5, 5))
         self.match = Match.objects.create(
             start_date_time=match_datetime, round_number=5, venue="Corporate Stadium"
         )
@@ -50,7 +47,7 @@ class TestMatch(TestCase):
             team_match.score = 100
             team_match.save()
 
-            self.match.start_date_time = datetime.now(tz=pytz.UTC) - timedelta(hours=1)
+            self.match.start_date_time = timezone.localtime() - timedelta(hours=1)
             self.match.save()
 
             self.assertFalse(self.match.has_been_played)

--- a/backend/server/tests/unit/test_schema.py
+++ b/backend/server/tests/unit/test_schema.py
@@ -1,6 +1,7 @@
 from datetime import datetime
 import itertools
 from dateutil import parser
+import pytz
 
 from django.test import TestCase
 from graphene.test import Client
@@ -11,7 +12,6 @@ from server.schema import schema
 from server.tests.fixtures.factories import FullMatchFactory
 from server.models import Match, MLModel
 from server.tests.fixtures.factories import MLModelFactory
-from project.settings.common import MELBOURNE_TIMEZONE, HOURS_FROM_UTC_TO_MELBOURNE
 
 
 ROUND_COUNT = 4
@@ -31,9 +31,7 @@ class TestSchema(TestCase):
             FullMatchFactory(
                 year=year,
                 round_number=((idx % 23) + 1),
-                start_date_time=datetime(
-                    year, 6, (idx % 29) + 1, tzinfo=MELBOURNE_TIMEZONE
-                ),
+                start_date_time=datetime(year, 6, (idx % 29) + 1, tzinfo=pytz.UTC),
                 prediction__ml_model=ml_models[0],
                 prediction_two__ml_model=ml_models[1],
             )
@@ -189,9 +187,7 @@ class TestSchema(TestCase):
             FullMatchFactory(
                 year=year,
                 round_number=((idx % 23) + 1),
-                start_date_time=datetime(
-                    year, 6, (idx % 29) + 1, tzinfo=MELBOURNE_TIMEZONE
-                ),
+                start_date_time=datetime(year, 6, (idx % 29) + 1, tzinfo=pytz.UTC),
                 prediction__ml_model=ml_models[0],
                 prediction_two__ml_model=ml_models[1],
             )
@@ -260,9 +256,7 @@ class TestSchema(TestCase):
             FullMatchFactory(
                 year=YEAR,
                 round_number=(idx + 1),
-                start_date_time=datetime(
-                    YEAR, MONTH, (idx % 29) + 1, tzinfo=MELBOURNE_TIMEZONE
-                ),
+                start_date_time=datetime(YEAR, MONTH, (idx % 29) + 1, tzinfo=pytz.UTC),
                 prediction__ml_model=ml_models[0],
                 prediction__is_correct=True,
                 prediction_two__ml_model=ml_models[1],
@@ -306,10 +300,9 @@ class TestSchema(TestCase):
 
         with self.subTest("when the last matches haven't been played yet"):
             DAY = 3
+            fake_datetime = datetime(YEAR, MONTH, DAY, tzinfo=pytz.UTC)
 
-            with freeze_time(
-                f"{YEAR}-0{MONTH}-0{DAY}", tz_offset=-HOURS_FROM_UTC_TO_MELBOURNE
-            ):
+            with freeze_time(fake_datetime):
                 past_executed = self.client.execute(query)
 
                 data = past_executed["data"]["fetchLatestRoundStats"]

--- a/backend/server/tests/unit/test_schema.py
+++ b/backend/server/tests/unit/test_schema.py
@@ -1,9 +1,9 @@
 from datetime import datetime
 import itertools
 from dateutil import parser
-import pytz
 
 from django.test import TestCase
+from django.utils import timezone
 from graphene.test import Client
 import numpy as np
 from freezegun import freeze_time
@@ -31,7 +31,7 @@ class TestSchema(TestCase):
             FullMatchFactory(
                 year=year,
                 round_number=((idx % 23) + 1),
-                start_date_time=datetime(year, 6, (idx % 29) + 1, tzinfo=pytz.UTC),
+                start_date_time=timezone.make_aware(datetime(year, 6, (idx % 29) + 1)),
                 prediction__ml_model=ml_models[0],
                 prediction_two__ml_model=ml_models[1],
             )
@@ -187,7 +187,7 @@ class TestSchema(TestCase):
             FullMatchFactory(
                 year=year,
                 round_number=((idx % 23) + 1),
-                start_date_time=datetime(year, 6, (idx % 29) + 1, tzinfo=pytz.UTC),
+                start_date_time=timezone.make_aware(datetime(year, 6, (idx % 29) + 1)),
                 prediction__ml_model=ml_models[0],
                 prediction_two__ml_model=ml_models[1],
             )
@@ -256,7 +256,9 @@ class TestSchema(TestCase):
             FullMatchFactory(
                 year=YEAR,
                 round_number=(idx + 1),
-                start_date_time=datetime(YEAR, MONTH, (idx % 29) + 1, tzinfo=pytz.UTC),
+                start_date_time=timezone.make_aware(
+                    datetime(YEAR, MONTH, (idx % 29) + 1)
+                ),
                 prediction__ml_model=ml_models[0],
                 prediction__is_correct=True,
                 prediction_two__ml_model=ml_models[1],
@@ -300,7 +302,7 @@ class TestSchema(TestCase):
 
         with self.subTest("when the last matches haven't been played yet"):
             DAY = 3
-            fake_datetime = datetime(YEAR, MONTH, DAY, tzinfo=pytz.UTC)
+            fake_datetime = timezone.make_aware(datetime(YEAR, MONTH, DAY))
 
             with freeze_time(fake_datetime):
                 past_executed = self.client.execute(query)

--- a/backend/server/tipping.py
+++ b/backend/server/tipping.py
@@ -68,6 +68,15 @@ class Tipping:
 
         fixture_data_frame = self.__fetch_fixture_data(self.current_year)
 
+        if not fixture_data_frame.any().any():
+            if self.verbose == 1:
+                print(
+                    "Fixture for the upcoming round haven't been posted yet, "
+                    "so there's nothing to tip. Try again later."
+                )
+
+            return None
+
         upcoming_round = (
             fixture_data_frame.query("date > @self.right_now")
             .loc[:, "round_number"]
@@ -118,6 +127,8 @@ class Tipping:
         if self.submit_tips:
             self.__submit_tips()
 
+        return None
+
     def __fetch_fixture_data(self, year: int) -> pd.DataFrame:
         if self.verbose == 1:
             print(f"Fetching fixture for {year}...\n")
@@ -125,6 +136,9 @@ class Tipping:
         fixture_data_frame = self.data_importer.fetch_fixture_data(
             start_date=f"{year}-01-01", end_date=f"{year}-12-31"
         )
+
+        if not fixture_data_frame.any().any():
+            return fixture_data_frame
 
         latest_match_date = fixture_data_frame["date"].max()
 

--- a/backend/server/tipping.py
+++ b/backend/server/tipping.py
@@ -5,12 +5,12 @@ from datetime import datetime, date, timedelta
 from typing import List, Optional, Dict, Tuple
 import os
 from warnings import warn
+import pytz
 
 import pandas as pd
 from splinter import Browser
 from splinter.driver import ElementAPI
 
-from project.settings.common import MELBOURNE_TIMEZONE
 from server.models import Match, TeamMatch, Team, Prediction
 from server.types import CleanFixtureData
 from server import data_import
@@ -53,7 +53,7 @@ class Tipping:
         ml_models=None,
         submit_tips=True,
     ) -> None:
-        self.right_now = datetime.now(tz=MELBOURNE_TIMEZONE)
+        self.right_now = datetime.now(tz=pytz.UTC)
         self.current_year = self.right_now.year
         self.fetch_data = fetch_data
         self.data_importer = data_importer
@@ -196,7 +196,7 @@ class Tipping:
             raw_date.day,
             raw_date.hour,
             raw_date.minute,
-            tzinfo=MELBOURNE_TIMEZONE,
+            tzinfo=pytz.UTC,
         )
 
         match, was_created = Match.objects.get_or_create(
@@ -376,7 +376,7 @@ class Tipping:
             Prediction.objects.filter(
                 ml_model__name="tipresias",
                 match__start_date_time__gt=datetime(
-                    latest_year, JAN, FIRST, tzinfo=MELBOURNE_TIMEZONE
+                    latest_year, JAN, FIRST, tzinfo=pytz.UTC
                 ),
                 match__round_number=latest_round,
             )


### PR DESCRIPTION
I thought I had a decent short-term fix in making everything AEST, but it turns out that Django just magically converts everything to UTC when saving datetime fields to the DB, so when I retrieved records, I was working with UTC when I thought I was working with AEST. Rather than trying to manage the transition between these two timezones, I'm just making everything all UTC, all the time.

While working with time settings, I went ahead and cleaned up how I use settings variables across the app.