### PR TITLE
Convert date params to melbourne timezone

### DIFF
--- a/backend/server/management/commands/seed_db.py
+++ b/backend/server/management/commands/seed_db.py
@@ -5,7 +5,7 @@ from typing import Tuple, List
 from datetime import datetime
 import pandas as pd
 import numpy as np
-from django import utils
+from django.utils import timezone
 from django.core.management.base import BaseCommand
 
 from server.models import Team, Match, TeamMatch, MLModel, Prediction
@@ -51,8 +51,8 @@ class Command(BaseCommand):
         year_range_tuple = (years_list[0], years_list[1])
 
         match_data_frame = self.data_importer.fetch_match_results_data(
-            start_date=f"{years_list[0]}-01-01",
-            end_date=f"{years_list[1] - 1}-12-31",
+            start_date=timezone.make_aware(datetime(years_list[0], 1, 1)),
+            end_date=timezone.make_aware(datetime(years_list[1] - 1, 12, 31)),
             fetch_data=self.fetch_data,
         )
 
@@ -133,7 +133,7 @@ class Command(BaseCommand):
             python_date.tzinfo is None
             or python_date.tzinfo.utcoffset(python_date) is None
         ):
-            match_date = utils.timezone.make_aware(python_date)
+            match_date = timezone.make_aware(python_date)
         else:
             match_date = python_date
 

--- a/backend/server/tests/integration/management/commands/test_seed_db.py
+++ b/backend/server/tests/integration/management/commands/test_seed_db.py
@@ -1,8 +1,6 @@
 from unittest.mock import Mock, patch
-from datetime import datetime
 
 from django.test import TestCase
-from django.utils import timezone
 import joblib
 import pandas as pd
 
@@ -117,15 +115,8 @@ class TestSeedDb(TestCase):
         if start_date is None or end_date is None:
             return self.match_results_data_frame
 
-        tz_start_date = timezone.make_aware(  # pylint: disable=unused-variable
-            datetime.strptime(start_date, "%Y-%m-%d")
-        )
-        tz_end_date = timezone.make_aware(  # pylint: disable=unused-variable
-            datetime.strptime(end_date, "%Y-%m-%d")
-        )
-
         return self.match_results_data_frame.query(
-            "date >= @tz_start_date & date <= @tz_end_date"
+            "date >= @start_date & date <= @end_date"
         )
 
     @staticmethod

--- a/backend/server/tipping.py
+++ b/backend/server/tipping.py
@@ -134,7 +134,8 @@ class Tipping:
             print(f"Fetching fixture for {year}...\n")
 
         fixture_data_frame = self.data_importer.fetch_fixture_data(
-            start_date=f"{year}-01-01", end_date=f"{year}-12-31"
+            start_date=timezone.make_aware(datetime(year, 1, 1)),
+            end_date=timezone.make_aware(datetime(year, 12, 31)),
         )
 
         if not fixture_data_frame.any().any():
@@ -252,9 +253,7 @@ class Tipping:
         ).start_date_time
 
         return self.data_importer.fetch_match_results_data(
-            str(earliest_match_date.date()),
-            str(self.right_now.date()),
-            fetch_data=self.fetch_data,
+            earliest_match_date, self.right_now, fetch_data=self.fetch_data
         )
 
     def __update_played_match_scores(


### PR DESCRIPTION
Related to recent timezone fixes, this just handles the edge-case in which running the `tipping` command early in the morning (before 10:00am Melbourne time, give or take) would result in setting the data-fetching params one day early due to UTC still being late the night before.