### PR TITLE
Use GC Registry for app image instead of dockerhub

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -15,3 +15,4 @@ PRODUCTION_HOST=<IP address or hostname of the prod server>
 PROJECT_ID=<ID of the Google Cloud project>
 DOCKER_PASSWORD=<password for being able to push docker images in CI>
 DATABASE_URL=<URL for connecting to the database>
+GC_SERVICE_ACCOUNT=<name for the Google Cloud service account responsible for managing the compute engine instance>

--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -2,7 +2,7 @@
 
 set -euo pipefail
 
-DOCKER_IMAGE=cfranklin11/tipresias_app:latest
+DOCKER_IMAGE=gcr.io/${PROJECT_ID}/${PROJECT_ID}-app
 
 docker pull ${DOCKER_IMAGE}
 docker build --cache-from ${DOCKER_IMAGE} -t ${DOCKER_IMAGE} .


### PR DESCRIPTION
I finally figured out how to get all the permissions correct,
so I can use gcr instead of dockerhub for the compute engine's
container image.