### PR TITLE
Re-add DB migrations to deployment

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -89,6 +89,7 @@ deploy_rsa.enc
 .vscode
 *.sql
 data_science
+db/backups
 
 # GCP files
 .gcloud

--- a/README.md
+++ b/README.md
@@ -23,14 +23,12 @@ Child of [Footy Tipper](https://github.com/cfranklin11/footy-tipper), Tipresias,
   - Generate data set files: `docker-compose run --rm data_science ./scripts/generate_data_sets.sh`
   - Generate trained model files: `docker-compose run --rm data_science python3 scripts/save_default_models.py`
 - Seed the DB: `docker-compose run --rm backend python3 manage.py seed_db` (this takes a very long time, so it's recommended that you reset the DB as described below if possible)
-- Reset the DB to match production: `./scripts/reset_local_db_to_prod.sh`
-  - This requires ability to `ssh` into the prod server (i.e. you must have been added as a user to the server by an admin)
-  - `PROD_USER` and `IP_ADDRESS` environment variables have to be set in the current bash session, and their values have to be applicable to the relevant server
 - To interact with production resources, install the Google Cloud SDK:
   - `brew cask install google-cloud-sdk` (on Mac)
   - `gcloud auth login` (redirects you to log into your Google account in the browser)
   - `gcloud config set project ${PROJECT_ID}`
 - To `ssh` into the server, run `./scripts/ssh.sh`.
+- To reset the DB to match production: `./scripts/reset_local_db_to_prod.sh`
 - To run the tipping command, run `./scripts/tip.sh`.
 
 ### Run the app

--- a/scripts/create_instance.sh
+++ b/scripts/create_instance.sh
@@ -2,7 +2,7 @@
 
 set -euo pipefail
 
-gcloud beta compute instances create-with-container tipresias-app \
+gcloud beta compute instances create-with-container ${PROJECT_ID}-app \
   --container-env DATA_SCIENCE_SERVICE=${DATA_SCIENCE_SERVICE},DATABASE_URL=${DATABASE_URL},DJANGO_SETTINGS_MODULE=project.settings.production,EMAIL_RECIPIENT=${EMAIL_RECIPIENT},FOOTY_TIPS_USERNAME=${FOOTY_TIPS_USERNAME},FOOTY_TIPS_PASSWORD=${FOOTY_TIPS_PASSWORD},GCPF_TOKEN=${GCPF_TOKEN},NODE_ENV=production,PRODUCTION_HOST=${PRODUCTION_HOST},PROJECT_ID=${PROJECT_ID},PYTHON_ENV=production,SENDGRID_API_KEY=${SENDGRID_API_KEY},SECRET_KEY=${SECRET_KEY}\
   --container-image ${DOCKER_IMAGE} \
   --machine-type g1-small \

--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -16,3 +16,7 @@ gcloud beta compute instances update-container ${PROJECT_ID}-app \
   --container-image ${DOCKER_IMAGE} \
   --zone australia-southeast1-b \
   --project ${PROJECT_ID}
+
+./backend/scripts/wait-for-it.sh ${PRODUCTION_HOST}:${PORT:-8000} \
+  -t 60 \
+  -- ./scripts/migrate.sh

--- a/scripts/dump_local_db.sh
+++ b/scripts/dump_local_db.sh
@@ -5,5 +5,6 @@ set -euo pipefail
 DB_FILE=local_dump_`date +%Y-%m-%d"_"%H_%M_%S`.sql
 
 # Including a bunch of extra options for compatibility with Google Cloud SQL
-docker exec -t -u postgres tipresias_db_1 pg_dump -U postgres --format=plain --no-owner --no-acl tipresias \
+docker exec -t -u postgres tipresias_db_1 \
+  pg_dump -U postgres --format=plain --no-owner --no-acl tipresias \
   | sed -E 's/(DROP|CREATE|COMMENT ON) EXTENSION/-- \1 EXTENSION/g' > "db/backups/${DB_FILE}"

--- a/scripts/migrate.sh
+++ b/scripts/migrate.sh
@@ -1,0 +1,10 @@
+#!/bin/bash
+
+set -euo pipefail
+
+./scripts/ssh.sh docker run --rm \
+  -e DJANGO_SETTINGS_MODULE=project.settings.production \
+  -e SECRET_KEY=${SECRET_KEY} \
+  -e DATABASE_URL=${DATABASE_URL} \
+  gcr.io/${PROJECT_ID}/${PROJECT_ID}-app \
+  python3 backend/manage.py migrate

--- a/scripts/set_local_db_to_prod.sh
+++ b/scripts/set_local_db_to_prod.sh
@@ -24,4 +24,5 @@ docker exec -t -u postgres tipresias_db_1 psql \
 docker exec -t -u postgres tipresias_db_1 psql \
   --command="CREATE ROLE cloudsqlsuperuser" \
   --dbname=${DATABASE_NAME}
-cat $PWD/db/backups/${DB_FILE} | docker exec -i tipresias_db_1 psql -U postgres -d ${DATABASE_NAME}
+cat $PWD/db/backups/${DB_FILE} \
+  | docker exec -i tipresias_db_1 psql -U postgres -d ${DATABASE_NAME}


### PR DESCRIPTION
In the move from DigitalOcean to Google Cloud Platform, running migrations after deployment got lost. Google Compute Engine is either really wonky or the documentation is really bad, so I couldn't figure out a simple way to just run a quick command via `gcloud`, but ssh-ing in to run a `docker` command works well enough.