### PR TITLE
Refactor GraphQL schema

### DIFF
--- a/backend/server/schema.py
+++ b/backend/server/schema.py
@@ -220,7 +220,10 @@ class SeasonType(graphene.ObjectType):
         description="Match and prediction data grouped by round",
         round_number=graphene.Int(
             default_value=None,
-            description="Optional filter when only one round of data is required",
+            description=(
+                "Optional filter when only one round of data is required. "
+                "-1 will return the last available round."
+            ),
         ),
     )
 
@@ -287,8 +290,14 @@ class SeasonType(graphene.ObjectType):
         query_set_data_frame = pd.DataFrame(list(query_set))
 
         if round_number is not None:
+            round_number_filter = (  # pylint: disable=unused-variable
+                query_set_data_frame["match__round_number"].max()
+                if round_number == -1
+                else round_number
+            )
+
             query_set_data_frame = query_set_data_frame.query(
-                "match__round_number == @round_number"
+                "match__round_number == @round_number_filter"
             )
 
         round_predictions = (

--- a/backend/server/tests/unit/test_schema.py
+++ b/backend/server/tests/unit/test_schema.py
@@ -128,7 +128,7 @@ class TestSchema(TestCase):
                     predictionModelNames
                     predictionsByRound {
                         roundNumber
-                        modelPredictions {
+                        modelMetrics {
                             modelName
                             cumulativeCorrectCount
                             cumulativeAccuracy
@@ -148,9 +148,9 @@ class TestSchema(TestCase):
         predictions = data["predictionsByRound"]
 
         for pred in predictions:
-            for model_pred in pred["modelPredictions"]:
-                self.assertGreaterEqual(model_pred["cumulativeAccuracy"], 0.0)
-                self.assertLessEqual(model_pred["cumulativeAccuracy"], 1.0)
+            for model_metric in pred["modelMetrics"]:
+                self.assertGreaterEqual(model_metric["cumulativeAccuracy"], 0.0)
+                self.assertLessEqual(model_metric["cumulativeAccuracy"], 1.0)
 
         earlier_round = predictions[0]
         later_round = predictions[1]
@@ -159,7 +159,7 @@ class TestSchema(TestCase):
 
         earlier_round_cum_counts = [
             prediction["cumulativeCorrectCount"]
-            for prediction in earlier_round["modelPredictions"]
+            for prediction in earlier_round["modelMetrics"]
         ]
         earlier_round_correct = [
             prediction["isCorrect"]
@@ -172,7 +172,7 @@ class TestSchema(TestCase):
 
         later_round_cum_counts = [
             prediction["cumulativeCorrectCount"]
-            for prediction in later_round["modelPredictions"]
+            for prediction in later_round["modelMetrics"]
         ]
         later_round_correct = [
             prediction["isCorrect"]
@@ -194,7 +194,7 @@ class TestSchema(TestCase):
                 query QueryType {
                     fetchYearlyPredictions(year: 2015) {
                         predictionsByRound {
-                            modelPredictions(mlModelName: "predictanator") { modelName }
+                            modelMetrics(mlModelName: "predictanator") { modelName }
                             matches { predictions { isCorrect } }
                         }
                     }
@@ -204,10 +204,10 @@ class TestSchema(TestCase):
 
             data = executed["data"]["fetchYearlyPredictions"]["predictionsByRound"][0]
 
-            self.assertEqual(len(data["modelPredictions"]), 1)
-            self.assertEqual(data["modelPredictions"][0]["modelName"], "predictanator")
+            self.assertEqual(len(data["modelMetrics"]), 1)
+            self.assertEqual(data["modelMetrics"][0]["modelName"], "predictanator")
             # matches and predictions associations are unaffected
-            # by the modelPredictions argument (predictions has its own argument
+            # by the modelMetrics argument (predictions has its own argument
             # for mlModelName)
             self.assertEqual(len(data["matches"][0]["predictions"]), len(ml_models))
 

--- a/backend/server/tests/unit/test_schema.py
+++ b/backend/server/tests/unit/test_schema.py
@@ -188,6 +188,29 @@ class TestSchema(TestCase):
 
         self.assertLessEqual(sum(earlier_round_cum_counts), sum(later_round_cum_counts))
 
+        with self.subTest("with mlModelName argument 'predictanator'"):
+            executed = self.client.execute(
+                """
+                query QueryType {
+                    fetchYearlyPredictions(year: 2015) {
+                        predictionsByRound {
+                            modelPredictions(mlModelName: "predictanator") { modelName }
+                            matches { predictions { isCorrect } }
+                        }
+                    }
+                }
+                """
+            )
+
+            data = executed["data"]["fetchYearlyPredictions"]["predictionsByRound"][0]
+
+            self.assertEqual(len(data["modelPredictions"]), 1)
+            self.assertEqual(data["modelPredictions"][0]["modelName"], "predictanator")
+            # matches and predictions associations are unaffected
+            # by the modelPredictions argument (predictions has its own argument
+            # for mlModelName)
+            self.assertEqual(len(data["matches"][0]["predictions"]), len(ml_models))
+
     def test_fetch_latest_round_predictions(self):
         ml_models = list(MLModel.objects.all())
         year = TWENTY_SEVENTEEN

--- a/backend/server/tests/unit/test_schema.py
+++ b/backend/server/tests/unit/test_schema.py
@@ -211,6 +211,25 @@ class TestSchema(TestCase):
             # for mlModelName)
             self.assertEqual(len(data["matches"][0]["predictions"]), len(ml_models))
 
+        with self.subTest("with roundNumber argument of -1"):
+            executed = self.client.execute(
+                """
+                query QueryType {
+                    fetchYearlyPredictions(year: 2015) {
+                        predictionsByRound(roundNumber: -1) { roundNumber }
+                    }
+                }
+                """
+            )
+
+            data = executed["data"]["fetchYearlyPredictions"]["predictionsByRound"]
+
+            self.assertEqual(len(data), 1)
+            self.assertEqual(
+                data[0]["roundNumber"],
+                Match.objects.order_by("round_number").last().round_number,
+            )
+
     def test_fetch_latest_round_predictions(self):
         ml_models = list(MLModel.objects.all())
         year = TWENTY_SEVENTEEN

--- a/frontend/src/components/BarChartMain/index.js
+++ b/frontend/src/components/BarChartMain/index.js
@@ -23,7 +23,7 @@ const dataTransformer = (previousDataSet: PreviousDataSet): NewDataSet => {
   const newDataSet = previousDataSet.reduce((acc, currentItem, currentIndex) => {
     acc[currentIndex] = acc[currentIndex] || {};
     acc[currentIndex].roundNumber = currentItem.roundNumber;
-    currentItem.modelPredictions.forEach((item) => {
+    currentItem.modelMetrics.forEach((item) => {
       const { modelName } = item;
       acc[currentIndex][modelName] = item.cumulativeCorrectCount;
     });

--- a/frontend/src/components/DefinitionList/index.js
+++ b/frontend/src/components/DefinitionList/index.js
@@ -2,19 +2,7 @@
 import React, { Fragment } from 'react';
 import type { Node } from 'react';
 import { DefinitionListStyled, DefinitionTermStyled, DefinitionDescriptionStyled } from './style';
-// TODO: Implement this in a src/graphql/index.js
-// query {
-//   fetchLatestRoundStats{
-//     seasonYear
-//     roundNumber
-//     modelStats{
-//       modelName
-//       cumulativeCorrectCount
-//       cumulativeMeanAbsoluteError
-//       cumulativeMarginDifference
-//     }
-//    }
-// }
+
 type Definition = {
   id: number,
   key: string,

--- a/frontend/src/containers/Dashboard/index.js
+++ b/frontend/src/containers/Dashboard/index.js
@@ -94,33 +94,40 @@ class Dashboard extends Component<Props, State> {
           </Widget>
 
           <Widget gridColumn="1 / -2">
-            <Query query={FETCH_LATEST_ROUND_STATS}>
+            <Query query={FETCH_LATEST_ROUND_STATS} variables={{ year, roundNumber: -1, mlModelName: 'tipresias_2019' }}>
               {(response: any): Node => {
                 const { loading, error, data } = response;
                 if (loading) return <p>Loading metrics...</p>;
                 if (error) return <StatusBar text={error.message} error />;
-                const { seasonYear, roundNumber, modelStats } = data.fetchLatestRoundStats;
+                const { seasonYear, predictionsByRound } = data.fetchYearlyPredictions;
+                const { roundNumber, modelPredictions } = predictionsByRound[0];
+                const {
+                  modelName,
+                  cumulativeCorrectCount,
+                  cumulativeMarginDifference,
+                  cumulativeMeanAbsoluteError,
+                } = modelPredictions[0];
                 return (
                   <Fragment>
                     <WidgetHeading>
-                      {`${modelStats.modelName} performance metrics for round ${roundNumber} season ${seasonYear}`}
+                      {`${modelName} performance metrics for round ${roundNumber} season ${seasonYear}`}
 
                     </WidgetHeading>
                     <DefinitionList items={[
                       {
                         id: 1,
                         key: 'Cumulative Correct Count',
-                        value: modelStats.cumulativeCorrectCount,
+                        value: cumulativeCorrectCount,
                       },
                       {
                         id: 2,
                         key: 'Cumulative Mean Absolute Error (MAE)',
-                        value: modelStats.cumulativeMeanAbsoluteError,
+                        value: cumulativeMeanAbsoluteError,
                       },
                       {
                         id: 3,
                         key: 'Cumulative Margin Difference',
-                        value: modelStats.cumulativeMarginDifference,
+                        value: cumulativeMarginDifference,
                       },
                     ]}
                     />

--- a/frontend/src/containers/Dashboard/index.js
+++ b/frontend/src/containers/Dashboard/index.js
@@ -100,13 +100,13 @@ class Dashboard extends Component<Props, State> {
                 if (loading) return <p>Loading metrics...</p>;
                 if (error) return <StatusBar text={error.message} error />;
                 const { seasonYear, predictionsByRound } = data.fetchYearlyPredictions;
-                const { roundNumber, modelPredictions } = predictionsByRound[0];
+                const { roundNumber, modelMetrics } = predictionsByRound[0];
                 const {
                   modelName,
                   cumulativeCorrectCount,
                   cumulativeMarginDifference,
                   cumulativeMeanAbsoluteError,
-                } = modelPredictions[0];
+                } = modelMetrics[0];
                 return (
                   <Fragment>
                     <WidgetHeading>

--- a/frontend/src/graphql/index.js
+++ b/frontend/src/graphql/index.js
@@ -65,26 +65,30 @@ export const FETCH_YEARLY_PREDICTIONS_QUERY = gql`
   query fetchYearlyPredictions($year: Int){
     fetchYearlyPredictions(year: $year){
       predictionModelNames
-       predictionsByRound{
+      predictionsByRound{
         roundNumber
         modelPredictions{
           modelName
           cumulativeCorrectCount
         }
       }
-   }
-}`;
+    }
+  }
+`;
 
 export const FETCH_LATEST_ROUND_STATS = gql`
-  query {
-  fetchLatestRoundStats{
-    seasonYear
-    roundNumber
-    modelStats{
-      modelName
-      cumulativeCorrectCount
-      cumulativeMeanAbsoluteError
-      cumulativeMarginDifference
+  query fetchYearlyPredictions($year: Int, $roundNumber: Int, $mlModelName: String){
+    fetchYearlyPredictions(year: $year){
+      seasonYear
+      predictionsByRound(roundNumber: $roundNumber){
+        roundNumber
+        modelPredictions(mlModelName: $mlModelName){
+          modelName
+          cumulativeCorrectCount
+          cumulativeMeanAbsoluteError
+          cumulativeMarginDifference
+        }
+      }
     }
-   }
-}`;
+  }
+`;

--- a/frontend/src/graphql/index.js
+++ b/frontend/src/graphql/index.js
@@ -67,7 +67,7 @@ export const FETCH_YEARLY_PREDICTIONS_QUERY = gql`
       predictionModelNames
       predictionsByRound{
         roundNumber
-        modelPredictions{
+        modelMetrics{
           modelName
           cumulativeCorrectCount
         }
@@ -82,7 +82,7 @@ export const FETCH_LATEST_ROUND_STATS = gql`
       seasonYear
       predictionsByRound(roundNumber: $roundNumber){
         roundNumber
-        modelPredictions(mlModelName: $mlModelName){
+        modelMetrics(mlModelName: $mlModelName){
           modelName
           cumulativeCorrectCount
           cumulativeMeanAbsoluteError

--- a/frontend/src/types/index.js
+++ b/frontend/src/types/index.js
@@ -15,7 +15,7 @@ export type BarDataType = {
 
 export type BarChartDataType = {
   roundNumber: number,
-  modelPredictions: Array<BarDataType>
+  modelMetrics: Array<BarDataType>
 }
 
 export type MatchType = {


### PR DESCRIPTION
A cleanup of this module was overdue. I consolidated cumulative-metrics queries into the `fetchYearlyPredictions` query, which only required a few minor changes to the frontend. I also moved the manual building of data dictionaries to be done entirely via the Django ORM, which sped up that query a lot.

There still remains the refactoring of metric calculation logic, and probably the breakup of the schema module into individual files, but this is a big enough chunk of work for a PR.