### PR TITLE
Update to handle running scripts in Google Cloud

### DIFF
--- a/scripts/tip.sh
+++ b/scripts/tip.sh
@@ -2,5 +2,15 @@
 
 set -euo pipefail
 
-./scripts/ssh.sh python3 backend/manage.py tip \
-  && python3 backend/manage.py send_email
+./scripts/ssh.sh docker run \
+  --rm \
+  -e DJANGO_SETTINGS_MODULE=project.settings.production \
+  -e SECRET_KEY=${SECRET_KEY} \
+  -e DATABASE_URL=${DATABASE_URL} \
+  -e PYTHON_ENV=production \
+  -e GCPF_TOKEN=${GCPF_TOKEN} \
+  -e DATA_SCIENCE_SERVICE=${DATA_SCIENCE_SERVICE} \
+  -e FOOTY_TIPS_USERNAME=${FOOTY_TIPS_USERNAME} \
+  -e FOOTY_TIPS_PASSWORD=${FOOTY_TIPS_PASSWORD} \
+  gcr.io/${PROJECT_ID}/${PROJECT_ID}-app \
+  /bin/bash -c "python3 manage.py tip; python3 manage.py send_email"


### PR DESCRIPTION
Since the app runs in a docker container whose name we don't know ahead of time, we run the commands off the image instead of executing them in the same container. This requires manually adding all the relevant env vars to the newly-created container, but it works.