### PR TITLE
Automate submission of tips to Monash competition

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,8 +1,6 @@
 EMAIL_RECIPIENT=<an email to send the footy emails>
 SENDGRID_API_KEY=<sendgrid api key>
 SECRET_KEY=<a random string for django>
-DATA_SCIENCE_SERVICE=<hostname of the data science serverless functions>
-GCPF_TOKEN=<bearer token for accessing the data science service API>
 PROD_USER=<name of user who can deploy to prod server>
 FOOTY_TIPS_USERNAME=<username for an account on footytips.com.au>
 FOOTY_TIPS_PASSWORD=<password for an account of footytips.com.au>
@@ -15,3 +13,5 @@ PROJECT_ID=<ID of the Google Cloud project>
 DOCKER_PASSWORD=<password for being able to push docker images in CI>
 DATABASE_URL=<URL for connecting to the database>
 GC_SERVICE_ACCOUNT=<name for the Google Cloud service account responsible for managing the compute engine instance>
+DATA_SCIENCE_SERVICE=<hostname of the data science serverless functions>
+GCPF_TOKEN=<bearer token for accessing the data science service API>

--- a/backend/project/settings/data_config.py
+++ b/backend/project/settings/data_config.py
@@ -29,6 +29,13 @@ TEAM_TRANSLATIONS = {
     "Geelong Cats": "Geelong",
     "West Coast Eagles": "West Coast",
     "Sydney Swans": "Sydney",
+    # Monash footy tipping team names
+    "G_W_Sydney": "GWS",
+    "W_Bulldogs": "Western Bulldogs",
+    "P_Adelaide": "Port Adelaide",
+    "Gold_Coast": "Gold Coast",
+    "St_Kilda": "St Kilda",
+    "W_Coast": "West Coast",
 }
 
 VENUE_CITIES = {

--- a/backend/server/data_import.py
+++ b/backend/server/data_import.py
@@ -95,7 +95,7 @@ def _fetch_data(
 def fetch_prediction_data(
     year_range: Tuple[int, int],
     round_number: Optional[int] = None,
-    ml_models: Optional[str] = None,
+    ml_models: Optional[List[str]] = None,
 ) -> pd.DataFrame:
     """
     Fetch prediction data from machine_learning module.
@@ -104,7 +104,7 @@ def fetch_prediction_data(
     -------
     year_range: Min (inclusive) and max (exclusive) years for which to fetch data.
     round_number: Specify a particular round for which to fetch data.
-    ml_models: Comma-separated list of ML model names to use for making predictions.
+    ml_models: List of ML model names to use for making predictions.
 
     Returns:
     --------
@@ -112,6 +112,7 @@ def fetch_prediction_data(
     """
     min_year, max_year = year_range
     year_range_param = "-".join((str(min_year), str(max_year)))
+    ml_model_param = None if ml_models is None else ",".join(ml_models)
 
     return pd.DataFrame(
         _fetch_data(
@@ -119,7 +120,7 @@ def fetch_prediction_data(
             {
                 "year_range": year_range_param,
                 "round_number": round_number,
-                "ml_models": ml_models,
+                "ml_models": ml_model_param,
             },
         )
     )

--- a/backend/server/data_import.py
+++ b/backend/server/data_import.py
@@ -73,7 +73,7 @@ def _fetch_data(
 ) -> List[Dict[str, Any]]:
     params = params or {}
 
-    if os.getenv("PYTHON_ENV") == "production":
+    if os.getenv("PYTHON_ENV") == "production" or bool(os.getenv("CI")):
         service_host = DATA_SCIENCE_SERVICE
         headers = {"Authorization": f'Bearer {os.getenv("GCPF_TOKEN")}'}
     else:

--- a/backend/server/management/commands/tip.py
+++ b/backend/server/management/commands/tip.py
@@ -2,7 +2,7 @@
 
 from django.core.management.base import BaseCommand
 
-from server.tipping import Tipping
+from server.tipping import Tipper
 
 
 class Command(BaseCommand):
@@ -15,4 +15,4 @@ class Command(BaseCommand):
 
     def handle(self, *_args, verbose=1, **_kwargs) -> None:  # pylint: disable=W0221
         """Run 'tip' command."""
-        Tipping(submit_tips=True).tip(verbose=verbose)
+        Tipper().tip(verbose=verbose)

--- a/backend/server/tests/integration/test_tipping.py
+++ b/backend/server/tests/integration/test_tipping.py
@@ -10,7 +10,7 @@ from freezegun import freeze_time
 import pandas as pd
 
 from server.models import Match, TeamMatch, Prediction
-from server.tipping import Tipping
+from server.tipping import Tipper
 from server import data_import
 from server.tests.fixtures.data_factories import fake_fixture_data, fake_prediction_data
 from server.tests.fixtures.factories import MLModelFactory, TeamFactory
@@ -23,7 +23,7 @@ TIP_DATES = [
 ]
 
 
-class TestTipping(TestCase):
+class TestTipper(TestCase):
     @classmethod
     def setUpClass(cls):
         super().setUpClass()
@@ -62,8 +62,8 @@ class TestTipping(TestCase):
         )
 
         # Not fetching data, because it takes forever
-        self.tipping = Tipping(
-            fetch_data=False, data_importer=mock_data_import, submit_tips=False
+        self.tipping = Tipper(
+            fetch_data=False, data_importer=mock_data_import, tip_submitters=[]
         )
 
     def test_tip(self):
@@ -183,7 +183,7 @@ class TestTipping(TestCase):
         TeamFactory(name=match_data["away_team"])
 
 
-class TestTippingEndToEnd(TestCase):
+class TestTipperEndToEnd(TestCase):
     @classmethod
     def setUpClass(cls):
         super().setUpClass()
@@ -194,7 +194,7 @@ class TestTippingEndToEnd(TestCase):
             TeamFactory(name=team_name)
 
     def setUp(self):
-        self.tipping = Tipping(ml_models=settings.PRINCIPLE_ML_MODEL, submit_tips=False)
+        self.tipping = Tipper(ml_models=settings.PRINCIPLE_ML_MODEL, tip_submitters=[])
 
     def test_tip(self):
         self.assertEqual(Match.objects.count(), 0)

--- a/backend/server/tests/integration/test_tipping.py
+++ b/backend/server/tests/integration/test_tipping.py
@@ -2,8 +2,6 @@
 import copy
 from datetime import datetime, timedelta
 from unittest.mock import Mock, patch
-from unittest import skipIf
-import os
 
 from django.test import TestCase
 from django.utils import timezone
@@ -185,11 +183,6 @@ class TestTipping(TestCase):
         TeamFactory(name=match_data["away_team"])
 
 
-@skipIf(
-    os.getenv("CI", "").lower() == "true",
-    "Useful test for subtle, breaking changes, but way too long to run in CI. "
-    "Run manually on your machine to be safe",
-)
 class TestTippingEndToEnd(TestCase):
     @classmethod
     def setUpClass(cls):

--- a/backend/server/tests/integration/test_tipping.py
+++ b/backend/server/tests/integration/test_tipping.py
@@ -71,7 +71,7 @@ class TestTipping(TestCase):
     def test_tip(self):
         with freeze_time(TIP_DATES[0]):
             right_now = timezone.localtime()
-            self.tipping.right_now = right_now
+            self.tipping._right_now = right_now  # pylint: disable=protected-access
 
             with self.subTest("with no existing match records in DB"):
                 self.assertEqual(Match.objects.count(), 0)
@@ -99,7 +99,7 @@ class TestTipping(TestCase):
         with freeze_time(TIP_DATES[1]):
             with self.subTest("with scoreless matches from ealier rounds"):
                 right_now = timezone.localtime()
-                self.tipping.right_now = right_now
+                self.tipping._right_now = right_now  # pylint: disable=protected-access
 
                 self.assertEqual(TeamMatch.objects.filter(score__gt=0).count(), 0)
                 self.assertEqual(Prediction.objects.filter(is_correct=True).count(), 0)

--- a/docker-compose.ci.yml
+++ b/docker-compose.ci.yml
@@ -13,6 +13,8 @@ services:
       - SENDGRID_API_KEY=test
       - CI=true
       - DATABASE_NAME=$DATABASE_NAME
+      - DATA_SCIENCE_SERVICE=$DATA_SCIENCE_SERVICE
+      - GCPF_TOKEN=$GCPF_TOKEN
     command: python3 manage.py runserver 0.0.0.0:8000
   frontend:
     image: cfranklin11/tipresias_frontend:latest


### PR DESCRIPTION
Manually entering tips for FootyTips was kind of tedious; doing it for the Monash competition is _really_ tedious. As part of implementing this, I refactored tip submissions into their own classes. I'll probably refactor them further into an abstract submission class, but I don't want to jump the gun on that, especially since they're basically impossible to test.

I can't do a test run of the `tip` command either, because the AFL season is on indefinite hiatus due to some global pandemic I keep hearing about.