### PR TITLE
Add cumulativeAccuracy to queried values

### DIFF
--- a/backend/server/graphql/types/season.py
+++ b/backend/server/graphql/types/season.py
@@ -304,6 +304,7 @@ class SeasonType(graphene.ObjectType):
                 "match__margin",
                 "margin_diff",
                 "cumulative_correct_count",
+                "cumulative_accuracy",
             )
         )
 

--- a/backend/server/tests/unit/test_schema.py
+++ b/backend/server/tests/unit/test_schema.py
@@ -333,6 +333,7 @@ class TestSchema(TestCase):
                             cumulativeCorrectCount
                             cumulativeMeanAbsoluteError
                             cumulativeMarginDifference
+                            cumulativeAccuracy
                             cumulativeBits
                         }
                     }
@@ -353,6 +354,7 @@ class TestSchema(TestCase):
         self.assertGreater(model_stats["cumulativeCorrectCount"], 0)
         self.assertGreater(model_stats["cumulativeMeanAbsoluteError"], 0)
         self.assertGreater(model_stats["cumulativeMarginDifference"], 0)
+        self.assertGreater(model_stats["cumulativeAccuracy"], 0)
         # Bits can be positive or negative, so we just want to make sure it's not 0,
         # which would suggest a problem
         self.assertNotEqual(model_stats["cumulativeBits"], 0)


### PR DESCRIPTION
Not really sure how I left this out, nor how it's the only metric
I didn't test for, but it's back in and working now.