### PR TITLE
Add fetchMlModels query

### DIFF
--- a/backend/project/settings/common.py
+++ b/backend/project/settings/common.py
@@ -17,6 +17,8 @@ from .data_config import *  # pylint: disable=wildcard-import,unused-wildcard-im
 
 
 PRINCIPLE_ML_MODEL = "tipresias_2020"
+CONFIDENCE_ML_MODEL = "confidence_estimator"
+COMPETITION_ML_MODELS = [PRINCIPLE_ML_MODEL, CONFIDENCE_ML_MODEL]
 
 # Build paths inside the project like this: os.path.join(BASE_DIR, ...)
 BASE_DIR = os.path.abspath(os.path.join(os.path.dirname(__file__), "../../"))

--- a/backend/server/graphql/types/__init__.py
+++ b/backend/server/graphql/types/__init__.py
@@ -1,4 +1,4 @@
 """GraphQL type classes."""
 
 from .season import SeasonType, RoundType
-from .models import PredictionType
+from .models import PredictionType, MLModelType

--- a/backend/server/graphql/types/models.py
+++ b/backend/server/graphql/types/models.py
@@ -2,6 +2,7 @@
 
 import graphene
 from graphene_django.types import DjangoObjectType
+from django.conf import settings
 
 from server.models import Team, Prediction, Match, TeamMatch, MLModel
 
@@ -75,3 +76,12 @@ class MLModelType(DjangoObjectType):
         """For adding Django model attributes to their associated GraphQL types."""
 
         model = MLModel
+
+    for_competition = graphene.Boolean(
+        description="Whether the model's predictions are used in any competitions."
+    )
+
+    @staticmethod
+    def resolve_for_competition(root: MLModel, _info):
+        """"Return whether the model is used for competitions."""
+        return root.name in settings.COMPETITION_ML_MODELS

--- a/backend/server/management/commands/send_email.py
+++ b/backend/server/management/commands/send_email.py
@@ -25,7 +25,6 @@ PREDICTION_HEADERS = [
     "Predicted Win Probability",
     "Probability Predicts Different Team",
 ]
-CONFIDENCE_ML_MODEL = "confidence_estimator"
 
 
 class Command(BaseCommand):
@@ -76,7 +75,7 @@ class Command(BaseCommand):
             ml_model__name=settings.PRINCIPLE_ML_MODEL
         )
         probability_prediction = match_predictions.get(
-            ml_model__name=CONFIDENCE_ML_MODEL
+            ml_model__name=settings.CONFIDENCE_ML_MODEL
         )
 
         different_winner_label = (

--- a/backend/server/tests/integration/management/commands/test_send_email.py
+++ b/backend/server/tests/integration/management/commands/test_send_email.py
@@ -25,8 +25,7 @@ class TestSendEmail(TestCase):
 
         # Save records in DB
         ml_models = [
-            MLModelFactory(name=name)
-            for name in [settings.PRINCIPLE_ML_MODEL, "confidence_estimator"]
+            MLModelFactory(name=name) for name in settings.COMPETITION_ML_MODELS
         ]
 
         for match_data in self.match_results_data.to_dict("records"):

--- a/backend/server/tipping.py
+++ b/backend/server/tipping.py
@@ -41,7 +41,6 @@ FIRST = 1
 # There's also a 'gaussian' competition, but I don't participate in that one,
 # so leaving it out for now.
 SUPPORTED_MONASH_COMPS = ["normal", "info"]
-MODELS_FOR_COMPETITIONS = [settings.PRINCIPLE_ML_MODEL, "confidence_estimator"]
 
 
 class MonashSubmitter:
@@ -496,7 +495,7 @@ class Tipper:
 
         latest_round_predictions = (
             Prediction.objects.filter(
-                ml_model__name__in=MODELS_FOR_COMPETITIONS,
+                ml_model__name__in=settings.COMPETITION_ML_MODELS,
                 match__start_date_time__gt=timezone.make_aware(
                     datetime(latest_year, JAN, FIRST)
                 ),


### PR DESCRIPTION
Some model names are currently hardcoded on the frontend,
because there wasn't a good way to get that information from the
API, but this broke with the addition of new models and changed
names for existing ones. This query should allow us to remove
those hardcoded names.