### PR TITLE
Add back docker container/image cleanup commands

### DIFF
--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -20,3 +20,22 @@ gcloud beta compute instances update-container ${PROJECT_ID}-app \
 ./backend/scripts/wait-for-it.sh ${PRODUCTION_HOST}:${PORT:-8000} \
   -t 60 \
   -- ./scripts/migrate.sh
+
+# Clean up old containers & images to avoid running out of disk space.
+# We pass a blank ssh config file to avoid locale errors that result
+# from ssh trying to transmit LC_* env vars.
+touch ssh_config
+
+gcloud compute ssh \
+  --project ${PROJECT_ID} \
+  --zone australia-southeast1-b \
+  --ssh-flag="-F ./ssh_config" \
+  ${PROJECT_ID}-app \
+  -- docker container ls --all --quiet --filter exited=1 | xargs docker container rm
+
+gcloud compute ssh \
+  --project ${PROJECT_ID} \
+  --zone australia-southeast1-b \
+  --ssh-flag="-F ./ssh_config" \
+  ${PROJECT_ID}-app \
+  -- yes | docker image prune


### PR DESCRIPTION
I finally figured out the cause of the locale errors and a solution.
By default, ssh tries to transmit LC_* env vars for locale stuff.
The usual solution is modify ssh config on client or server side,
but I don't have that luxury, so I pass a blank ssh config file
and that seems to work fine.