### PR TITLE
Fix calculations based on null win probabilities

### DIFF
--- a/backend/server/graphql/types/season.py
+++ b/backend/server/graphql/types/season.py
@@ -310,6 +310,10 @@ class SeasonType(graphene.ObjectType):
 
         return (
             pd.DataFrame(query_set)
+            # We fill missing win probabilities with 0.5, because that's the equivalent
+            # of not picking a winner. 0 would represent an extreme prediction
+            # and result in large negative bits calculations.
+            .fillna({"predicted_win_probability": 0.5})
             .fillna(0)
             .assign(bits=_calculate_bits)
             .assign(

--- a/backend/server/tests/unit/test_schema.py
+++ b/backend/server/tests/unit/test_schema.py
@@ -398,6 +398,20 @@ class TestSchema(TestCase):
                 self.assertGreater(model_stats["cumulativeMeanAbsoluteError"], 0)
                 self.assertGreater(model_stats["cumulativeMarginDifference"], 0)
 
+        with self.subTest("when a model doesn't predict win probabilities"):
+            MLModel.objects.get(name="accurate_af").prediction_set.update(
+                predicted_win_probability=None
+            )
+
+            executed = self.client.execute(query)
+
+            data = executed["data"]["fetchYearlyPredictions"]["predictionsByRound"][0][
+                "modelMetrics"
+            ]
+            cumulative_bits = data[0]["cumulativeBits"]
+
+            self.assertEqual(cumulative_bits, 0)
+
     def test_fetch_ml_models(self):
         N_MODELS = 3
 


### PR DESCRIPTION
For metric calculations, missing win probabilities should be
0.5 (i.e. no predicted winner) rather than 0, which is the null
prediction for margin.