### PR TITLE
Update GQL types to require non-nullable fields

### DIFF
--- a/backend/server/graphql/schema.py
+++ b/backend/server/graphql/schema.py
@@ -17,12 +17,13 @@ class Query(graphene.ObjectType):
     """Base GraphQL Query type that contains all queries and their resolvers."""
 
     fetch_predictions = graphene.List(
-        PredictionType, year=graphene.Int(default_value=None)
+        PredictionType, year=graphene.Int(), required=True
     )
 
     fetch_prediction_years = graphene.List(
         graphene.Int,
         description="All years for which model predictions exist in the database",
+        required=True,
     )
 
     fetch_yearly_predictions = graphene.Field(
@@ -31,6 +32,7 @@ class Query(graphene.ObjectType):
             default_value=timezone.localtime().year,
             description=("Filter results by year."),
         ),
+        required=True,
     )
 
     fetch_latest_round_predictions = graphene.Field(
@@ -39,6 +41,7 @@ class Query(graphene.ObjectType):
             "Match info and predictions for the latest round for which data "
             "is available"
         ),
+        required=True,
     )
 
     fetch_ml_models = graphene.List(
@@ -52,6 +55,7 @@ class Query(graphene.ObjectType):
                 "(e.g. margin, win probability)."
             ),
         ),
+        required=True,
     )
 
     @staticmethod

--- a/backend/server/graphql/types/models.py
+++ b/backend/server/graphql/types/models.py
@@ -34,11 +34,11 @@ class MatchType(DjangoObjectType):
         model = Match
 
     winner = graphene.Field(TeamType)
-    year = graphene.Int()
+    year = graphene.Int(required=True)
     home_team = graphene.Field(TeamType)
     away_team = graphene.Field(TeamType)
     predictions = graphene.List(
-        PredictionType, ml_model_name=graphene.String(default_value=None)
+        PredictionType, ml_model_name=graphene.String(default_value=None), required=True
     )
 
     @staticmethod
@@ -78,7 +78,8 @@ class MLModelType(DjangoObjectType):
         model = MLModel
 
     for_competition = graphene.Boolean(
-        description="Whether the model's predictions are used in any competitions."
+        description="Whether the model's predictions are used in any competitions.",
+        required=True,
     )
 
     is_principle = graphene.Boolean(
@@ -87,7 +88,8 @@ class MLModelType(DjangoObjectType):
             "among all the models used in competitions (i.e. all competition models "
             "predict winners, but only one's predictions are official "
             "predicted winners of Tipresias)."
-        )
+        ),
+        required=True,
     )
 
     @staticmethod

--- a/backend/server/models/prediction.py
+++ b/backend/server/models/prediction.py
@@ -48,7 +48,10 @@ class Prediction(models.Model):
         predicted_margin, predicted_margin_winner = cls._calculate_predicted_margin(
             prediction_data, home_team, away_team
         )
-        predicted_win_probability, predicted_proba_winner = cls._calculate_predicted_win_probability(  # pylint: disable=line-too-long
+        (
+            predicted_win_probability,
+            predicted_proba_winner,
+        ) = cls._calculate_predicted_win_probability(  # pylint: disable=line-too-long
             prediction_data, home_team, away_team
         )
 


### PR DESCRIPTION
The Ruby implementation of GQL defines fields as non-nullable by
default, but the Python implementation does the reverse, so a
bunch of fields that I thought were declared as non-nullable were
in fact, technically speaking, nullable per the schema. That's
what you get for skimming the documentation.