### PR TITLE
GQL refactor: chart parameter query

### DIFF
--- a/backend/server/graphql/schema.py
+++ b/backend/server/graphql/schema.py
@@ -5,11 +5,25 @@ from typing import List
 import graphene
 from django.db.models import QuerySet
 from django.utils import timezone
+from django.db.models import Count
 import pandas as pd
+from mypy_extensions import TypedDict
 
 from server.models import Prediction, Match, MLModel
 from server.types import RoundPrediction
-from .types import SeasonType, PredictionType, RoundType, MLModelType
+from .types import (
+    SeasonType,
+    PredictionType,
+    RoundType,
+    MLModelType,
+    SeasonPerformanceChartParametersType,
+)
+
+
+SeasonPerformanceChartParameters = TypedDict(
+    "SeasonPerformanceChartParameters",
+    {"available_seasons": List[int], "available_ml_models": List[MLModel]},
+)
 
 
 class Query(graphene.ObjectType):
@@ -19,7 +33,16 @@ class Query(graphene.ObjectType):
         graphene.NonNull(PredictionType), year=graphene.Int(), required=True
     )
 
-    fetch_prediction_years = graphene.List(
+    fetch_season_performance_chart_parameters = graphene.Field(
+        SeasonPerformanceChartParametersType,
+        description=(
+            "Parameters for displaying info and populating inputs "
+            "for the season performance chart."
+        ),
+        required=True,
+    )
+
+    fetch_season_years = graphene.List(
         graphene.NonNull(graphene.Int),
         description="All years for which model predictions exist in the database",
         required=True,
@@ -66,14 +89,25 @@ class Query(graphene.ObjectType):
         return Prediction.objects.filter(match__start_date_time__year=year)
 
     @staticmethod
-    def resolve_fetch_prediction_years(_root, _info) -> List[int]:
-        """Return all years for which we have prediction data."""
-        return (
-            Prediction.objects.select_related("match")
-            .distinct("match__start_date_time__year")
-            .order_by("match__start_date_time__year")
-            .values_list("match__start_date_time__year", flat=True)
-        )
+    def resolve_fetch_season_performance_chart_parameters(
+        _root, _info
+    ) -> SeasonPerformanceChartParameters:
+        """
+        Return parameters for labels and inputs for the performance chart.
+        """
+        return {
+            "available_seasons": (
+                Prediction.objects.select_related("match")
+                .distinct("match__start_date_time__year")
+                .order_by("match__start_date_time__year")
+                .values_list("match__start_date_time__year", flat=True)
+            ),
+            "available_ml_models": (
+                MLModel.objects.prefetch_related("prediction_set")
+                .annotate(prediction_count=Count("prediction"))
+                .filter(prediction_count__gt=0)
+            ),
+        }
 
     @staticmethod
     def resolve_fetch_yearly_predictions(_root, _info, year) -> QuerySet:

--- a/backend/server/graphql/types/__init__.py
+++ b/backend/server/graphql/types/__init__.py
@@ -1,4 +1,4 @@
 """GraphQL type classes."""
 
-from .season import SeasonType, RoundType
+from .season import SeasonType, RoundType, SeasonPerformanceChartParametersType
 from .models import PredictionType, MLModelType

--- a/backend/server/graphql/types/season.py
+++ b/backend/server/graphql/types/season.py
@@ -26,7 +26,7 @@ import numpy as np
 
 from server.types import ModelMetric, RoundPrediction
 from server.models import TeamMatch, Match
-from .models import MatchType
+from .models import MatchType, MLModelType
 
 ML_MODEL_NAME_LVL = 0
 # For regressors that might try to predict negative values or 0,
@@ -35,6 +35,26 @@ MIN_LOG_VAL = 1 * 10 ** -10
 
 ROUND_NUMBER_LVL = 0
 GROUP_BY_LVL = 0
+
+
+class SeasonPerformanceChartParametersType(graphene.ObjectType):
+    """
+    Parameters for displaying info and populating inputs for the performance chart.
+    """
+
+    available_seasons = graphene.List(
+        graphene.NonNull(graphene.Int),
+        description=(
+            "All season years for which model predictions exist in the database"
+        ),
+        required=True,
+    )
+
+    available_ml_models = graphene.List(
+        graphene.NonNull(MLModelType),
+        description="All ML models that have predictions in the database.",
+        required=True,
+    )
 
 
 class CumulativeMetricsByRoundType(graphene.ObjectType):

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -2,6 +2,14 @@
   "name": "tipresias",
   "version": "0.1.0",
   "private": true,
+  "scripts": {
+    "start": "react-app-rewired start",
+    "build": "react-app-rewired build",
+    "test:eslint": "yarn run eslint 'src/**/*.js' --ext .jsx --ext .js",
+    "test:flow": "yarn flow",
+    "test:unit": "react-app-rewired test --env=jsdom",
+    "storybook": "start-storybook"
+  },
   "dependencies": {
     "@apollo/react-components": "^3.1.5",
     "@apollo/react-hoc": "^3.1.5",
@@ -24,14 +32,6 @@
     "react-scripts": "3.4.1",
     "recharts": "^1.8.5",
     "styled-components": "^4.4.1"
-  },
-  "scripts": {
-    "start": "react-app-rewired start",
-    "build": "react-app-rewired build",
-    "test:eslint": "yarn run eslint 'src/**/*.js' --ext .jsx --ext .js",
-    "test:flow": "yarn flow",
-    "test:unit": "react-app-rewired test --env=jsdom",
-    "storybook": "start-storybook"
   },
   "devDependencies": {
     "@apollo/react-testing": "^3.1.4",

--- a/frontend/schema.json
+++ b/frontend/schema.json
@@ -47,7 +47,23 @@
             "deprecationReason": null
           },
           {
-            "name": "fetchPredictionYears",
+            "name": "fetchSeasonPerformanceChartParameters",
+            "description": "Parameters for displaying info and populating inputs for the season performance chart.",
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "OBJECT",
+                "name": "SeasonPerformanceChartParametersType",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "fetchSeasonYears",
             "description": "All years for which model predictions exist in the database",
             "args": [],
             "type": {
@@ -864,6 +880,65 @@
         "fields": null,
         "inputFields": null,
         "interfaces": null,
+        "enumValues": null,
+        "possibleTypes": null
+      },
+      {
+        "kind": "OBJECT",
+        "name": "SeasonPerformanceChartParametersType",
+        "description": "Parameters for displaying info and populating inputs for the performance chart.",
+        "fields": [
+          {
+            "name": "availableSeasons",
+            "description": "All season years for which model predictions exist in the database",
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "LIST",
+                "name": null,
+                "ofType": {
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "SCALAR",
+                    "name": "Int",
+                    "ofType": null
+                  }
+                }
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "availableMlModels",
+            "description": "All ML models that have predictions in the database.",
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "LIST",
+                "name": null,
+                "ofType": {
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "OBJECT",
+                    "name": "MLModelType",
+                    "ofType": null
+                  }
+                }
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
+        "inputFields": null,
+        "interfaces": [],
         "enumValues": null,
         "possibleTypes": null
       },

--- a/frontend/src/containers/App/__tests__/index.js
+++ b/frontend/src/containers/App/__tests__/index.js
@@ -6,6 +6,7 @@ import FETCH_PREDICTIONS_QUERY from '../../../graphql';
 import App from '../index';
 import Select from '../../../components/Select';
 
+// TODO: These specs are out of date. There is a ticket to update/fix them.
 jest.mock('../../../components/LineChartMain', () => MockComponent);
 jest.mock('../../../components/StatusBar', () => MockComponent);
 jest.mock('../../../components/ChartLoading', () => MockComponent);

--- a/frontend/src/containers/App/index.js
+++ b/frontend/src/containers/App/index.js
@@ -10,7 +10,7 @@ import PageFooter from '../../components/PageFooter';
 import Dashboard from '../Dashboard';
 import Glossary from '../Glossary';
 import About from '../About';
-import { FETCH_MODELS_AND_YEARS_QUERY } from '../../graphql';
+import { FETCH_CHART_PARAMETERS_QUERY } from '../../graphql';
 import {
   AppContainerStyled, MainStyled, ToggleThemeButton,
 } from './style';
@@ -24,10 +24,17 @@ const isDarkModeStored = () => {
 const App = () => {
   const [isDarkMode, setIsDarkMode] = useState(isDarkModeStored());
 
-  const { data, loading, error } = useQuery<fetchModelsAndYears>(FETCH_MODELS_AND_YEARS_QUERY);
+  const { data, loading, error } = useQuery<fetchModelsAndYears>(FETCH_CHART_PARAMETERS_QUERY);
   if (loading) return <div>Loading Tipresias....</div>;
   if (error) return <div>Error: Something happened, try again later.</div>;
   if (data === undefined) return <p>Error: Data not defined.</p>;
+
+  const {
+    fetchSeasonPerformanceChartParameters: {
+      availableSeasons,
+      availableMlModels,
+    },
+  } = data;
 
 
   const metrics = ['cumulativeAccuracy', 'cumulativeBits', 'cumulativeMeanAbsoluteError'];
@@ -57,7 +64,17 @@ const App = () => {
 
           </PageHeader>
           <MainStyled>
-            <Route exact path="/" render={() => <Dashboard years={data.fetchPredictionYears} models={data.fetchMlModels} metrics={metrics} />} />
+            <Route
+              exact
+              path="/"
+              render={() => (
+                <Dashboard
+                  years={availableSeasons}
+                  models={availableMlModels}
+                  metrics={metrics}
+                />
+              )}
+            />
             <Route path="/glossary" component={Glossary} />
             <Route exact path="/about" component={About} />
           </MainStyled>

--- a/frontend/src/graphql/graphql-types/fetchSeasonPerformanceChartParameters.js
+++ b/frontend/src/graphql/graphql-types/fetchSeasonPerformanceChartParameters.js
@@ -1,0 +1,53 @@
+/* @flow */
+/* eslint-disable */
+// @generated
+// This file was automatically generated and should not be edited.
+
+// ====================================================
+// GraphQL query operation: fetchSeasonPerformanceChartParameters
+// ====================================================
+
+export type fetchSeasonPerformanceChartParameters_fetchSeasonPerformanceChartParameters_availableMlModels = {
+  __typename: "MLModelType",
+  name: string,
+  /**
+   * Whether the model is the principle model for predicting match winners among
+   * all the models used in competitions (i.e. all competition models predict
+   * winners, but only one's predictions are official predicted winners of Tipresias).
+   */
+  isPrinciple: boolean,
+  /**
+   * Whether the model's predictions are used in any competitions.
+   */
+  usedInCompetitions: boolean,
+};
+
+export type fetchSeasonPerformanceChartParameters_fetchSeasonPerformanceChartParameters = {
+  __typename: "SeasonPerformanceChartParametersType",
+  /**
+   * All season years for which model predictions exist in the database
+   */
+  availableSeasons: Array<number>,
+  /**
+   * All ML models that have predictions in the database.
+   */
+  availableMlModels: Array<fetchSeasonPerformanceChartParameters_fetchSeasonPerformanceChartParameters_availableMlModels>,
+};
+
+export type fetchSeasonPerformanceChartParameters = {
+  /**
+   * Parameters for displaying info and populating inputs for the season performance chart.
+   */
+  fetchSeasonPerformanceChartParameters: fetchSeasonPerformanceChartParameters_fetchSeasonPerformanceChartParameters
+};/* @flow */
+/* eslint-disable */
+// @generated
+// This file was automatically generated and should not be edited.
+
+//==============================================================
+// START Enums and Input Objects
+//==============================================================
+
+//==============================================================
+// END Enums and Input Objects
+//==============================================================

--- a/frontend/src/graphql/index.js
+++ b/frontend/src/graphql/index.js
@@ -81,13 +81,15 @@ export const FETCH_YEARLY_PREDICTIONS_QUERY = gql`
   }
 `;
 
-export const FETCH_MODELS_AND_YEARS_QUERY = gql`
-query fetchModelsAndYears {
-  fetchPredictionYears
-  fetchMlModels {
-    name
-    isPrinciple
-    usedInCompetitions
+export const FETCH_CHART_PARAMETERS_QUERY = gql`
+  query fetchSeasonPerformanceChartParameters {
+    fetchSeasonPerformanceChartParameters {
+      availableSeasons
+      availableMlModels {
+        name
+        isPrinciple
+        usedInCompetitions
+      }
+    }
   }
-}
 `;

--- a/frontend/src/graphql/index.js
+++ b/frontend/src/graphql/index.js
@@ -1,6 +1,9 @@
 import { gql } from 'apollo-boost';
 // eslint-disable-next-line import/prefer-default-export
 
+// TODO: This query is no longer used, but is included in the specs
+// for the App component, which are out of date.
+// Update the tests and delete this.
 export const FETCH_PREDICTIONS_QUERY = gql`
   query fetchPredictions($year: Int){
     fetchPredictions(year: $year) {


### PR DESCRIPTION
The original refactor PR was getting excessive, so I'm breaking it up per query. This creates a specific query for fetching the input parameters for the main chart, which avoids needing to query raw models and processing the data separately.