### PR TITLE
GQL Refactor: season metrics & latest round predictions

### DIFF
--- a/backend/server/graphql/schema.py
+++ b/backend/server/graphql/schema.py
@@ -6,15 +6,12 @@ import graphene
 from django.db.models import QuerySet
 from django.utils import timezone
 from django.db.models import Count
-import pandas as pd
 from mypy_extensions import TypedDict
 
 from server.models import Prediction, Match, MLModel
-from server.graphql.types.season import RoundModelMetrics
 from .types import (
     SeasonType,
     PredictionType,
-    RoundType,
     MLModelType,
     SeasonPerformanceChartParametersType,
     RoundPredictionType,

--- a/backend/server/graphql/schema.py
+++ b/backend/server/graphql/schema.py
@@ -10,7 +10,7 @@ import pandas as pd
 from mypy_extensions import TypedDict
 
 from server.models import Prediction, Match, MLModel
-from server.types import RoundPrediction
+from server.graphql.types.season import RoundModelMetrics
 from .types import (
     SeasonType,
     PredictionType,
@@ -48,11 +48,11 @@ class Query(graphene.ObjectType):
         required=True,
     )
 
-    fetch_yearly_predictions = graphene.Field(
+    fetch_season_model_metrics = graphene.Field(
         SeasonType,
-        year=graphene.Int(
+        season=graphene.Int(
             default_value=timezone.localtime().year,
-            description=("Filter results by year."),
+            description=("Filter metrics by season."),
         ),
         required=True,
     )
@@ -110,14 +110,14 @@ class Query(graphene.ObjectType):
         }
 
     @staticmethod
-    def resolve_fetch_yearly_predictions(_root, _info, year) -> QuerySet:
-        """Return all predictions from the given year."""
+    def resolve_fetch_season_model_metrics(_root, _info, season) -> QuerySet:
+        """Return all model performance metrics from the given season."""
         return Prediction.objects.filter(
-            match__start_date_time__year=year
+            match__start_date_time__year=season
         ).select_related("ml_model", "match")
 
     @staticmethod
-    def resolve_fetch_latest_round_predictions(_root, _info) -> RoundPrediction:
+    def resolve_fetch_latest_round_predictions(_root, _info) -> RoundModelMetrics:
         """Return predictions and model metrics for the latest available round."""
         max_match = Match.objects.order_by("-start_date_time").first()
 

--- a/backend/server/graphql/types/__init__.py
+++ b/backend/server/graphql/types/__init__.py
@@ -1,4 +1,9 @@
 """GraphQL type classes."""
 
-from .season import SeasonType, RoundType, SeasonPerformanceChartParametersType
+from .season import (
+    SeasonType,
+    RoundType,
+    SeasonPerformanceChartParametersType,
+    RoundPredictionType,
+)
 from .models import PredictionType, MLModelType

--- a/backend/server/tests/unit/test_schema.py
+++ b/backend/server/tests/unit/test_schema.py
@@ -1,6 +1,5 @@
 # pylint: disable=missing-docstring
 from datetime import datetime
-import itertools
 from dateutil import parser
 
 from django.test import TestCase

--- a/backend/server/types.py
+++ b/backend/server/types.py
@@ -5,8 +5,6 @@ from datetime import datetime
 
 from mypy_extensions import TypedDict
 from pandas import Timestamp
-from django.db.models import QuerySet
-import pandas as pd
 
 
 FixtureData = TypedDict(
@@ -67,20 +65,3 @@ CleanPredictionData = TypedDict(
 )
 
 MlModel = TypedDict("MlModel", {"name": str, "filepath": str})
-
-ModelMetric = TypedDict(
-    "ModelMetric",
-    {
-        "ml_model__name": str,
-        "cumulative_correct_count": int,
-        "cumulative_accuracy": float,
-        "cumulative_mean_absolute_error": float,
-        "cumulative_margin_difference": int,
-        "cumulative_bits": float,
-    },
-)
-
-RoundPrediction = TypedDict(
-    "RoundPrediction",
-    {"match__round_number": int, "model_metrics": pd.DataFrame, "matches": QuerySet},
-)

--- a/frontend/schema.json
+++ b/frontend/schema.json
@@ -87,12 +87,12 @@
             "deprecationReason": null
           },
           {
-            "name": "fetchYearlyPredictions",
+            "name": "fetchSeasonModelMetrics",
             "description": null,
             "args": [
               {
-                "name": "year",
-                "description": "Filter results by year.",
+                "name": "season",
+                "description": "Filter metrics by season.",
                 "type": {
                   "kind": "SCALAR",
                   "name": "Int",
@@ -115,14 +115,14 @@
           },
           {
             "name": "fetchLatestRoundPredictions",
-            "description": "Match info and predictions for the latest round for which data is available",
+            "description": "Official Tipresias predictions for the latest round for which data is available",
             "args": [],
             "type": {
               "kind": "NON_NULL",
               "name": null,
               "ofType": {
                 "kind": "OBJECT",
-                "name": "RoundType",
+                "name": "RoundPredictionType",
                 "ofType": null
               }
             },
@@ -945,10 +945,10 @@
       {
         "kind": "OBJECT",
         "name": "SeasonType",
-        "description": "Match and prediction data grouped by season.",
+        "description": "Model performance metrics grouped by season.",
         "fields": [
           {
-            "name": "seasonYear",
+            "name": "season",
             "description": null,
             "args": [],
             "type": {
@@ -964,32 +964,8 @@
             "deprecationReason": null
           },
           {
-            "name": "predictionModelNames",
-            "description": "All model names available for the given year",
-            "args": [],
-            "type": {
-              "kind": "NON_NULL",
-              "name": null,
-              "ofType": {
-                "kind": "LIST",
-                "name": null,
-                "ofType": {
-                  "kind": "NON_NULL",
-                  "name": null,
-                  "ofType": {
-                    "kind": "SCALAR",
-                    "name": "String",
-                    "ofType": null
-                  }
-                }
-              }
-            },
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "predictionsByRound",
-            "description": "Match and prediction data grouped by round",
+            "name": "roundModelMetrics",
+            "description": "Model performance metrics grouped by round",
             "args": [
               {
                 "name": "roundNumber",
@@ -1051,7 +1027,7 @@
           },
           {
             "name": "modelMetrics",
-            "description": "Cumulative performance metrics for predictions made by the given model through the given round",
+            "description": "Performance metrics for predictions made by the given model through the given round",
             "args": [
               {
                 "name": "mlModelName",
@@ -1085,7 +1061,7 @@
                   "name": null,
                   "ofType": {
                     "kind": "OBJECT",
-                    "name": "CumulativeMetricsByRoundType",
+                    "name": "ModelMetricsByRoundType",
                     "ofType": null
                   }
                 }
@@ -1126,19 +1102,19 @@
       },
       {
         "kind": "OBJECT",
-        "name": "CumulativeMetricsByRoundType",
-        "description": "Cumulative performance metrics for the given model through the given round.",
+        "name": "ModelMetricsByRoundType",
+        "description": "Performance metrics for the given model through the given round.",
         "fields": [
           {
-            "name": "modelName",
+            "name": "mlModel",
             "description": null,
             "args": [],
             "type": {
               "kind": "NON_NULL",
               "name": null,
               "ofType": {
-                "kind": "SCALAR",
-                "name": "String",
+                "kind": "OBJECT",
+                "name": "MLModelType",
                 "ofType": null
               }
             },
@@ -1221,6 +1197,144 @@
                 "name": "Float",
                 "ofType": null
               }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
+        "inputFields": null,
+        "interfaces": [],
+        "enumValues": null,
+        "possibleTypes": null
+      },
+      {
+        "kind": "OBJECT",
+        "name": "RoundPredictionType",
+        "description": "Official Tipresias predictions for a given round.",
+        "fields": [
+          {
+            "name": "roundNumber",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "Int",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "matchPredictions",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "LIST",
+                "name": null,
+                "ofType": {
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "OBJECT",
+                    "name": "MatchPredictionType",
+                    "ofType": null
+                  }
+                }
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
+        "inputFields": null,
+        "interfaces": [],
+        "enumValues": null,
+        "possibleTypes": null
+      },
+      {
+        "kind": "OBJECT",
+        "name": "MatchPredictionType",
+        "description": "Official Tipresias predictions for a given match.",
+        "fields": [
+          {
+            "name": "startDateTime",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "DateTime",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "predictedWinner",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "predictedMargin",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "Int",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "predictedWinProbability",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "Float",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "isCorrect",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "SCALAR",
+              "name": "Boolean",
+              "ofType": null
             },
             "isDeprecated": false,
             "deprecationReason": null

--- a/frontend/src/containers/Dashboard/dataTransformerLineChart.js
+++ b/frontend/src/containers/Dashboard/dataTransformerLineChart.js
@@ -1,7 +1,9 @@
 // @flow
+
 import type {
-  fetchYearlyPredictions_fetchYearlyPredictions_predictionsByRound as RoundType,
-} from '../../graphql/graphql-types/fetchYearlyPredictions';
+  fetchSeasonModelMetrics_fetchSeasonModelMetrics_roundModelMetrics
+  as RoundType,
+} from '../../graphql/graphql-types/fetchSeasonModelMetrics';
 
 export type rowType = {
   modelName: string,

--- a/frontend/src/containers/Dashboard/dataTransformerLineChart.js
+++ b/frontend/src/containers/Dashboard/dataTransformerLineChart.js
@@ -15,23 +15,23 @@ type NewDataItem = {
 type NewDataSet = Array<NewDataItem>
 
 const dataTransformerLineChart = (
-  predictionsByRound: Array<RoundType>,
+  roundModelMetrics: Array<RoundType>,
   metric: Object,
 ): NewDataSet => {
-  const newDataSet = predictionsByRound.reduce((acc, currentItem, currentIndex) => {
+  const newDataSet = roundModelMetrics.reduce((acc, currentItem, currentIndex) => {
     const { roundNumber, modelMetrics } = currentItem;
     acc[currentIndex] = acc[currentIndex] || {};
     acc[currentIndex].roundNumber = roundNumber;
     modelMetrics.forEach((item) => {
       if (!item) return;
-      const { modelName } = item;
+      const { mlModel: { name } } = item;
       // cumulativeAccuracy: %
       if (metric.name === 'cumulativeAccuracy') {
         const metricPercentage = (item[metric.name] * 100);
-        acc[currentIndex][modelName] = parseFloat(metricPercentage.toFixed(2));
+        acc[currentIndex][name] = parseFloat(metricPercentage.toFixed(2));
       } else {
         // bits and MAE: decimal
-        acc[currentIndex][modelName] = parseFloat(item[metric.name].toFixed(2));
+        acc[currentIndex][name] = parseFloat(item[metric.name].toFixed(2));
       }
     });
     return acc;

--- a/frontend/src/containers/Dashboard/dataTransformerTable.js
+++ b/frontend/src/containers/Dashboard/dataTransformerTable.js
@@ -1,18 +1,18 @@
 // @flow
 import type {
-  fetchLatestRoundPredictions_fetchLatestRoundPredictions_matches as MatchType,
+  fetchLatestRoundPredictions_fetchLatestRoundPredictions_matchPredictions as MatchPredictionType,
 } from '../../graphql/graphql-types/fetchLatestRoundPredictions';
 import icons from '../../icons';
 
 const { iconCheck, iconCross } = icons;
 
-type MatchesType = Array<MatchType>;
+type MatchPredictionsType = Array<MatchPredictionType>;
 type svgIcon = { svg: boolean, text: string, path: string }
 type RowType = Array<string | svgIcon>;
 type DataTableType = Array<RowType>;
 
 const dataTransformerTable = (
-  matchPredictions: MatchesType,
+  matchPredictions: MatchPredictionsType,
 ): DataTableType => {
   const newDataSet = matchPredictions.reduce((acc, {
     startDateTime, predictedWinner, predictedMargin, predictedWinProbability, isCorrect,

--- a/frontend/src/containers/Dashboard/dataTransformerTable.js
+++ b/frontend/src/containers/Dashboard/dataTransformerTable.js
@@ -1,7 +1,6 @@
 // @flow
 import type {
   fetchLatestRoundPredictions_fetchLatestRoundPredictions_matches as MatchType,
-  fetchLatestRoundPredictions_fetchLatestRoundPredictions_matches_predictions as PredictionType,
 } from '../../graphql/graphql-types/fetchLatestRoundPredictions';
 import icons from '../../icons';
 
@@ -12,69 +11,30 @@ type svgIcon = { svg: boolean, text: string, path: string }
 type RowType = Array<string | svgIcon>;
 type DataTableType = Array<RowType>;
 
-// loop the array of predictions and choose the predictedmargin value that is higher
-const getPredictedMargin = (
-  predictionsWithMargin: Array<PredictionType>,
-) => {
-  const margin = predictionsWithMargin.reduce(
-    (prevValue: number, currentItem: PredictionType) => {
-      if (!currentItem.predictedMargin) return 0;
-      return (
-        currentItem.predictedMargin > prevValue ? currentItem.predictedMargin : prevValue
-      );
-    }, 0,
-  );
-  return margin;
-};
-
 const dataTransformerTable = (
-  matches: MatchesType,
-  principalModelName: string,
+  matchPredictions: MatchesType,
 ): DataTableType => {
-  const newDataSet = matches.reduce((acc, matchItem, currentIndex) => {
-    if (matchItem.predictions.length === 0) return [];
-
+  const newDataSet = matchPredictions.reduce((acc, {
+    startDateTime, predictedWinner, predictedMargin, predictedWinProbability, isCorrect,
+  }, currentIndex) => {
     acc[currentIndex] = acc[currentIndex] || [];
 
-    const [date] = matchItem.startDateTime.split('T');
-    acc[currentIndex][0] = date;
-
-    // predicted Winner (form principalModel)
-    const [predictionWithPrincipleModel] = matchItem.predictions.filter(
-      (item: any) => (item && item.mlModel.name === principalModelName)
-      ,
-    );
-    if (!predictionWithPrincipleModel) { return []; }
-    acc[currentIndex][1] = predictionWithPrincipleModel.predictedWinner.name;
-
-    // predictedMargin
-    const predictionsWithValidMargin = matchItem.predictions.filter(
-      (item: any) => item.mlModel.usedInCompetitions === true && item.predictedMargin !== null,
-    );
-    acc[currentIndex][2] = getPredictedMargin(predictionsWithValidMargin).toString();
-
-    // predictedWinProbability
-    const winProbabilityForCompetition = matchItem.predictions.filter(
-      (item: any) => item.mlModel.usedInCompetitions === true
-        && item.predictedWinProbability !== null,
-    );
-
-    const predictedWinProbability = winProbabilityForCompetition.reduce(
-      (prevValue: number, currentItem: PredictionType) => {
-        if (!currentItem.predictedWinProbability) return 0;
-        return currentItem.predictedWinProbability > prevValue
-          ? currentItem.predictedWinProbability
-          : prevValue;
-      },
-      0,
-    );
-    acc[currentIndex][3] = `${(Math.round(predictedWinProbability * 100)).toString()}%`;
-
-    // isCorrect (form principalModel)
-    const { isCorrect } = predictionWithPrincipleModel;
-    acc[currentIndex][4] = isCorrect
+    const [date] = startDateTime.split('T');
+    const formattedWinProbability = `
+      ${(Math.round(predictedWinProbability * 100)).toString()}%
+    `;
+    const resultIcon = isCorrect
       ? { svg: true, text: 'prediction is correct', path: iconCheck }
       : { svg: true, text: 'prediction is incorrect', path: iconCross };
+
+    acc[currentIndex] = [
+      date,
+      predictedWinner,
+      predictedMargin.toString(),
+      formattedWinProbability,
+      resultIcon,
+    ];
+
     return acc;
   }, []);
   return newDataSet;

--- a/frontend/src/containers/Dashboard/index.js
+++ b/frontend/src/containers/Dashboard/index.js
@@ -176,7 +176,7 @@ const Dashboard = ({ years, models, metrics }: DashboardProps) => {
             {({ loading, error, data }: fetchLatestRoundPredictionsResponse): Node => {
               if (loading) return <p>Brrrrrr...</p>;
               if (error) return <StatusBar text={error.message} error />;
-              if (data.fetchLatestRoundPredictions.matches.length === 0) {
+              if (data.fetchLatestRoundPredictions.matchPredictions.length === 0) {
                 return (
                   <StatusBar
                     text="No data available."
@@ -186,8 +186,8 @@ const Dashboard = ({ years, models, metrics }: DashboardProps) => {
               }
 
               const { roundNumber } = data.fetchLatestRoundPredictions;
-              const { matches } = data.fetchLatestRoundPredictions;
-              const rowsArray = dataTransformerTable(matches, principleModel.name);
+              const { matchPredictions } = data.fetchLatestRoundPredictions;
+              const rowsArray = dataTransformerTable(matchPredictions);
 
               if (rowsArray.length === 0) {
                 return <StatusBar text="No data available." error />;

--- a/frontend/src/containers/Dashboard/index.js
+++ b/frontend/src/containers/Dashboard/index.js
@@ -4,7 +4,7 @@ import type { Node } from 'react';
 import { Query } from '@apollo/react-components';
 import styled from 'styled-components/macro';
 import {
-  FETCH_YEARLY_PREDICTIONS_QUERY,
+  FETCH_SEASON_METRICS_QUERY,
   FETCH_LATEST_ROUND_PREDICTIONS_QUERY,
 } from '../../graphql';
 import type { fetchYearlyPredictions } from '../../graphql/graphql-types/fetchYearlyPredictions';
@@ -91,23 +91,23 @@ const Dashboard = ({ years, models, metrics }: DashboardProps) => {
           </WidgetHeading>
           <Query
             query={
-              FETCH_YEARLY_PREDICTIONS_QUERY
+              FETCH_SEASON_METRICS_QUERY
             }
             variables={{
-              year,
+              season: year,
               forCompetitionOnly: false,
             }}
           >
             {({ loading, error, data }: fetchYearlyPredictionsResponse): Node => {
               if (loading) return <ChartLoading text="Brrrrr ..." />;
               if (error) return <StatusBar text={error.message} error />;
-              const { predictionsByRound: predictionsByRoundData } = data.fetchYearlyPredictions;
+              const { roundModelMetrics } = data.fetchSeasonModelMetrics;
 
-              if (predictionsByRoundData.length === 0) {
+              if (roundModelMetrics.length === 0) {
                 return <StatusBar text="No data found" empty />;
               }
               const metric = { name: currentMetric, label: currentMetricLabel };
-              const dataTransformed = dataTransformerLineChart(predictionsByRoundData, metric);
+              const dataTransformed = dataTransformerLineChart(roundModelMetrics, metric);
 
               // @todo find a better way to add
               // unit of measure for labels that need it. ie. accuracy
@@ -206,14 +206,14 @@ const Dashboard = ({ years, models, metrics }: DashboardProps) => {
 
         <Widget gridColumn="1 / -2">
           <Query
-            query={FETCH_YEARLY_PREDICTIONS_QUERY}
-            variables={{ year: latestYear, roundNumber: -1, forCompetitionOnly: true }}
+            query={FETCH_SEASON_METRICS_QUERY}
+            variables={{ season: latestYear, roundNumber: -1, forCompetitionOnly: true }}
           >
             {({ loading, error, data }: fetchYearlyPredictionsResponse): Node => {
               if (loading) return <p>Brrrrr...</p>;
               if (error) return <StatusBar text={error.message} error />;
-              const { seasonYear, predictionsByRound } = data.fetchYearlyPredictions;
-              const { roundNumber, modelMetrics } = predictionsByRound[0];
+              const { season, roundModelMetrics } = data.fetchSeasonModelMetrics;
+              const { roundNumber, modelMetrics } = roundModelMetrics[0];
 
 
               // cumulativeCorrectCount
@@ -241,7 +241,7 @@ const Dashboard = ({ years, models, metrics }: DashboardProps) => {
                   <WidgetHeading>
                     Performance metrics for Tipresias
                   </WidgetHeading>
-                  <WidgetSubHeading>{`Round ${roundNumber},  Season ${seasonYear} `}</WidgetSubHeading>
+                  <WidgetSubHeading>{`Round ${roundNumber},  Season ${season} `}</WidgetSubHeading>
                   <DefinitionList items={[
                     {
                       id: 1,

--- a/frontend/src/containers/Dashboard/index.js
+++ b/frontend/src/containers/Dashboard/index.js
@@ -7,7 +7,7 @@ import {
   FETCH_SEASON_METRICS_QUERY,
   FETCH_LATEST_ROUND_PREDICTIONS_QUERY,
 } from '../../graphql';
-import type { fetchYearlyPredictions } from '../../graphql/graphql-types/fetchYearlyPredictions';
+import type { fetchSeasonModelMetrics } from '../../graphql/graphql-types/fetchSeasonModelMetrics';
 import type { fetchLatestRoundPredictions } from '../../graphql/graphql-types/fetchLatestRoundPredictions';
 import LineChartMain from '../../components/LineChartMain';
 import Select from '../../components/Select';
@@ -37,10 +37,10 @@ type DashboardProps = {
   years: Array<number>
 };
 
-interface fetchYearlyPredictionsResponse {
+interface fetchSeasonModelMetricsResponse {
   loading: any;
   error: any;
-  data: fetchYearlyPredictions;
+  data: fetchSeasonModelMetrics;
 }
 
 interface fetchLatestRoundPredictionsResponse {
@@ -98,7 +98,7 @@ const Dashboard = ({ years, models, metrics }: DashboardProps) => {
               forCompetitionOnly: false,
             }}
           >
-            {({ loading, error, data }: fetchYearlyPredictionsResponse): Node => {
+            {({ loading, error, data }: fetchSeasonModelMetricsResponse): Node => {
               if (loading) return <ChartLoading text="Brrrrr ..." />;
               if (error) return <StatusBar text={error.message} error />;
               const { roundModelMetrics } = data.fetchSeasonModelMetrics;
@@ -209,7 +209,7 @@ const Dashboard = ({ years, models, metrics }: DashboardProps) => {
             query={FETCH_SEASON_METRICS_QUERY}
             variables={{ season: latestYear, roundNumber: -1, forCompetitionOnly: true }}
           >
-            {({ loading, error, data }: fetchYearlyPredictionsResponse): Node => {
+            {({ loading, error, data }: fetchSeasonModelMetricsResponse): Node => {
               if (loading) return <p>Brrrrr...</p>;
               if (error) return <StatusBar text={error.message} error />;
               const { season, roundModelMetrics } = data.fetchSeasonModelMetrics;
@@ -218,7 +218,7 @@ const Dashboard = ({ years, models, metrics }: DashboardProps) => {
 
               // cumulativeCorrectCount
               const { cumulativeCorrectCount } = modelMetrics.find(
-                item => (item.modelName === principleModel.name),
+                item => (item.mlModel.name === principleModel.name),
               ) || {};
 
               // bits

--- a/frontend/src/graphql/graphql-types/fetchLatestRoundPredictions.js
+++ b/frontend/src/graphql/graphql-types/fetchLatestRoundPredictions.js
@@ -7,63 +7,24 @@
 // GraphQL query operation: fetchLatestRoundPredictions
 // ====================================================
 
-export type fetchLatestRoundPredictions_fetchLatestRoundPredictions_matches_homeTeam = {
-  __typename: "TeamType",
-  name: string,
-};
-
-export type fetchLatestRoundPredictions_fetchLatestRoundPredictions_matches_awayTeam = {
-  __typename: "TeamType",
-  name: string,
-};
-
-export type fetchLatestRoundPredictions_fetchLatestRoundPredictions_matches_predictions_mlModel = {
-  __typename: "MLModelType",
-  name: string,
-  /**
-   * Whether the model's predictions are used in any competitions.
-   */
-  usedInCompetitions: boolean,
-  /**
-   * Whether the model is the principle model for predicting match winners among
-   * all the models used in competitions (i.e. all competition models predict
-   * winners, but only one's predictions are official predicted winners of Tipresias).
-   */
-  isPrinciple: boolean,
-};
-
-export type fetchLatestRoundPredictions_fetchLatestRoundPredictions_matches_predictions_predictedWinner = {
-  __typename: "TeamType",
-  name: string,
-};
-
-export type fetchLatestRoundPredictions_fetchLatestRoundPredictions_matches_predictions = {
-  __typename: "PredictionType",
-  mlModel: fetchLatestRoundPredictions_fetchLatestRoundPredictions_matches_predictions_mlModel,
-  predictedWinner: fetchLatestRoundPredictions_fetchLatestRoundPredictions_matches_predictions_predictedWinner,
-  predictedMargin: ?number,
-  predictedWinProbability: ?number,
-  isCorrect: boolean,
-};
-
-export type fetchLatestRoundPredictions_fetchLatestRoundPredictions_matches = {
-  __typename: "MatchType",
-  year: number,
+export type fetchLatestRoundPredictions_fetchLatestRoundPredictions_matchPredictions = {
+  __typename: "MatchPredictionType",
   startDateTime: any,
-  homeTeam: ?fetchLatestRoundPredictions_fetchLatestRoundPredictions_matches_homeTeam,
-  awayTeam: ?fetchLatestRoundPredictions_fetchLatestRoundPredictions_matches_awayTeam,
-  predictions: Array<fetchLatestRoundPredictions_fetchLatestRoundPredictions_matches_predictions>,
+  predictedWinner: string,
+  predictedMargin: number,
+  predictedWinProbability: number,
+  isCorrect: ?boolean,
 };
 
 export type fetchLatestRoundPredictions_fetchLatestRoundPredictions = {
-  __typename: "RoundType",
+  __typename: "RoundPredictionType",
   roundNumber: number,
-  matches: Array<fetchLatestRoundPredictions_fetchLatestRoundPredictions_matches>,
+  matchPredictions: Array<fetchLatestRoundPredictions_fetchLatestRoundPredictions_matchPredictions>,
 };
 
 export type fetchLatestRoundPredictions = {
   /**
-   * Match info and predictions for the latest round for which data is available
+   * Official Tipresias predictions for the latest round for which data is available
    */
   fetchLatestRoundPredictions: fetchLatestRoundPredictions_fetchLatestRoundPredictions
 };/* @flow */

--- a/frontend/src/graphql/graphql-types/fetchSeasonModelMetrics.js
+++ b/frontend/src/graphql/graphql-types/fetchSeasonModelMetrics.js
@@ -4,12 +4,17 @@
 // This file was automatically generated and should not be edited.
 
 // ====================================================
-// GraphQL query operation: fetchYearlyPredictions
+// GraphQL query operation: fetchSeasonModelMetrics
 // ====================================================
 
-export type fetchYearlyPredictions_fetchYearlyPredictions_predictionsByRound_modelMetrics = {
-  __typename: "CumulativeMetricsByRoundType",
-  modelName: string,
+export type fetchSeasonModelMetrics_fetchSeasonModelMetrics_roundModelMetrics_modelMetrics_mlModel = {
+  __typename: "MLModelType",
+  name: string,
+};
+
+export type fetchSeasonModelMetrics_fetchSeasonModelMetrics_roundModelMetrics_modelMetrics = {
+  __typename: "ModelMetricsByRoundType",
+  mlModel: fetchSeasonModelMetrics_fetchSeasonModelMetrics_roundModelMetrics_modelMetrics_mlModel,
   /**
    * Cumulative mean of correct tips (i.e. accuracy) made by the given model for the given season.
    */
@@ -32,30 +37,30 @@ export type fetchYearlyPredictions_fetchYearlyPredictions_predictionsByRound_mod
   cumulativeMarginDifference: number,
 };
 
-export type fetchYearlyPredictions_fetchYearlyPredictions_predictionsByRound = {
+export type fetchSeasonModelMetrics_fetchSeasonModelMetrics_roundModelMetrics = {
   __typename: "RoundType",
   roundNumber: number,
   /**
-   * Cumulative performance metrics for predictions made by the given model through the given round
+   * Performance metrics for predictions made by the given model through the given round
    */
-  modelMetrics: Array<fetchYearlyPredictions_fetchYearlyPredictions_predictionsByRound_modelMetrics>,
+  modelMetrics: Array<fetchSeasonModelMetrics_fetchSeasonModelMetrics_roundModelMetrics_modelMetrics>,
 };
 
-export type fetchYearlyPredictions_fetchYearlyPredictions = {
+export type fetchSeasonModelMetrics_fetchSeasonModelMetrics = {
   __typename: "SeasonType",
-  seasonYear: number,
+  season: number,
   /**
-   * Match and prediction data grouped by round
+   * Model performance metrics grouped by round
    */
-  predictionsByRound: Array<fetchYearlyPredictions_fetchYearlyPredictions_predictionsByRound>,
+  roundModelMetrics: Array<fetchSeasonModelMetrics_fetchSeasonModelMetrics_roundModelMetrics>,
 };
 
-export type fetchYearlyPredictions = {
-  fetchYearlyPredictions: fetchYearlyPredictions_fetchYearlyPredictions
+export type fetchSeasonModelMetrics = {
+  fetchSeasonModelMetrics: fetchSeasonModelMetrics_fetchSeasonModelMetrics
 };
 
-export type fetchYearlyPredictionsVariables = {
-  year?: ?number,
+export type fetchSeasonModelMetricsVariables = {
+  season?: ?number,
   roundNumber?: ?number,
   forCompetitionOnly?: ?boolean,
 };/* @flow */

--- a/frontend/src/graphql/index.js
+++ b/frontend/src/graphql/index.js
@@ -32,34 +32,18 @@ export const FETCH_PREDICTIONS_QUERY = gql`
   }`;
 
 export const FETCH_LATEST_ROUND_PREDICTIONS_QUERY = gql`
-query fetchLatestRoundPredictions{
-  fetchLatestRoundPredictions {
-    roundNumber
-    matches {
-      year
-      startDateTime
-      homeTeam{
-        name
-      }
-      awayTeam{
-        name
-      }
-      predictions{
-        mlModel{
-          name
-          usedInCompetitions
-          isPrinciple
-        }
-        predictedWinner{
-          name
-        }
+  query fetchLatestRoundPredictions{
+    fetchLatestRoundPredictions {
+      roundNumber
+      matchPredictions {
+        startDateTime
+        predictedWinner
         predictedMargin
         predictedWinProbability
         isCorrect
       }
     }
   }
-}
 `;
 
 export const FETCH_SEASON_METRICS_QUERY = gql`

--- a/frontend/src/graphql/index.js
+++ b/frontend/src/graphql/index.js
@@ -62,14 +62,14 @@ query fetchLatestRoundPredictions{
 }
 `;
 
-export const FETCH_YEARLY_PREDICTIONS_QUERY = gql`
-  query fetchYearlyPredictions($year: Int, $roundNumber: Int, $forCompetitionOnly: Boolean){
-    fetchYearlyPredictions(year: $year){
-      seasonYear
-      predictionsByRound (roundNumber: $roundNumber){
+export const FETCH_SEASON_METRICS_QUERY = gql`
+  query($season: Int, $roundNumber: Int, $forCompetitionOnly: Boolean) {
+    fetchSeasonModelMetrics(season: $season){
+      season
+      roundModelMetrics(roundNumber: $roundNumber) {
         roundNumber
-        modelMetrics(forCompetitionOnly: $forCompetitionOnly){
-          modelName
+        modelMetrics(forCompetitionOnly: $forCompetitionOnly) {
+          mlModel { name }
           cumulativeAccuracy
           cumulativeBits
           cumulativeMeanAbsoluteError

--- a/frontend/src/graphql/index.js
+++ b/frontend/src/graphql/index.js
@@ -47,7 +47,11 @@ export const FETCH_LATEST_ROUND_PREDICTIONS_QUERY = gql`
 `;
 
 export const FETCH_SEASON_METRICS_QUERY = gql`
-  query($season: Int, $roundNumber: Int, $forCompetitionOnly: Boolean) {
+  query fetchSeasonModelMetrics(
+    $season: Int,
+    $roundNumber: Int,
+    $forCompetitionOnly: Boolean
+  ) {
     fetchSeasonModelMetrics(season: $season){
       season
       roundModelMetrics(roundNumber: $roundNumber) {


### PR DESCRIPTION
Part 2 of 3 for refactoring the GQL schema.

This updates and simplifies the model metrics by season query the populates the main performance chart, and the table with the latest model predictions. The main idea is to shift some data munging logic from the frontend to the backend and improve the naming of various GQL types.