### PR TITLE
Round floats from metric calculations

### DIFF
--- a/backend/server/tests/unit/test_schema.py
+++ b/backend/server/tests/unit/test_schema.py
@@ -213,8 +213,8 @@ class TestSchema(TestCase):
         # are being calculated correctly
         self.assertEqual(sum(earlier_round_cum_correct), sum(earlier_round_correct))
         self.assertEqual(
-            sum(earlier_round_cum_accuracy) / len(earlier_round_cum_accuracy),
-            sum(earlier_round_correct) / len(earlier_round_correct),
+            round(sum(earlier_round_cum_accuracy) / len(earlier_round_cum_accuracy), 4),
+            round(sum(earlier_round_correct) / len(earlier_round_correct), 4),
         )
 
         later_round_cum_correct = [


### PR DESCRIPTION
Some weird float rounding at the very end of floats with repeating
decimals (e.g. 4.333333 vs 4.333334) made this spec flaky. Cutting
off such decimals after four digits should avoid this issue.