### PR TITLE
Refactor GQL query for latest performance metrics

### DIFF
--- a/backend/server/graphql/calculations.py
+++ b/backend/server/graphql/calculations.py
@@ -1,0 +1,110 @@
+"""Module for shared logic for calculating model metrics."""
+
+from typing import Optional, List
+
+from django.db.models import (
+    Case,
+    When,
+    Value,
+    IntegerField,
+    Subquery,
+    OuterRef,
+    Max,
+    Min,
+    Func,
+    F,
+    Sum,
+    Window,
+    Avg,
+    QuerySet,
+)
+from django.utils import timezone
+
+from server.models import TeamMatch
+
+
+CUMULATIVE_METRICS_VALUES = [
+    "absolute_margin_diff",
+    "cumulative_accuracy",
+    "cumulative_correct_count",
+    "match__margin",
+    "match__round_number",
+    "match__start_date_time",
+    "match__winner__name",
+    "ml_model__name",
+    "ml_model__used_in_competitions",
+    "predicted_margin",
+    "predicted_winner__name",
+    "predicted_win_probability",
+]
+
+
+def _calculate_cumulative_accuracy():
+    return Window(
+        expression=Avg("tip_point"),
+        partition_by=F("ml_model_id"),
+        order_by=F("match__start_date_time").asc(),
+    )
+
+
+def _calculate_cumulative_correct():
+    return Window(
+        expression=Sum("tip_point"),
+        partition_by=F("ml_model_id"),
+        order_by=F("match__start_date_time").asc(),
+    )
+
+
+def _calculate_absolute_margin_difference():
+    return Case(
+        When(
+            is_correct=True,
+            then=Func(F("predicted_margin") - F("match__margin"), function="ABS"),
+        ),
+        default=(F("predicted_margin") + F("match__margin")),
+        output_field=IntegerField(),
+    )
+
+
+def _get_match_winner_name():
+    return Subquery(
+        TeamMatch.objects.filter(match_id=OuterRef("match_id"))
+        .order_by("-score")
+        .values_list("team__name")[:1]
+    )
+
+
+def _calculate_tip_points():
+    return Case(
+        When(is_correct=True, then=Value(1)),
+        default=Value(0),
+        output_field=IntegerField(),
+    )
+
+
+def cumulative_metrics_query(
+    prediction_query_set: QuerySet, additional_values: Optional[List[str]] = None,
+):
+    """
+    Chain methods onto a Prediction query set to calculate cumulative model metrics.
+    """
+    values_args = CUMULATIVE_METRICS_VALUES + (additional_values or [])
+
+    return (
+        prediction_query_set.select_related("ml_model", "match")
+        .order_by("match__start_date_time")
+        # We don't want to include unplayed matches, which would impact
+        # mean-based metrics like accuracy and MAE
+        .filter(match__start_date_time__lt=timezone.localtime())
+        .annotate(
+            tip_point=_calculate_tip_points(),
+            match__winner__name=_get_match_winner_name(),
+            match__margin=(
+                Max("match__teammatch__score") - Min("match__teammatch__score")
+            ),
+            absolute_margin_diff=_calculate_absolute_margin_difference(),
+            cumulative_correct_count=_calculate_cumulative_correct(),
+            cumulative_accuracy=_calculate_cumulative_accuracy(),
+        )
+        .values(*values_args)
+    )

--- a/backend/server/graphql/calculations.py
+++ b/backend/server/graphql/calculations.py
@@ -1,6 +1,7 @@
 """Module for shared logic for calculating model metrics."""
 
-from typing import Optional, List
+from typing import Optional, List, Dict, Any
+from functools import partial
 
 from django.db.models import (
     Case,
@@ -19,6 +20,8 @@ from django.db.models import (
     QuerySet,
 )
 from django.utils import timezone
+import pandas as pd
+import numpy as np
 
 from server.models import TeamMatch
 
@@ -37,6 +40,11 @@ CUMULATIVE_METRICS_VALUES = [
     "predicted_winner__name",
     "predicted_win_probability",
 ]
+ROUND_NUMBER_LVL = 0
+GROUP_BY_LVL = 0
+# For regressors that might try to predict negative values or 0,
+# we need a slightly positive minimum to not get errors when calculating logarithms
+MIN_LOG_VAL = 1 * 10 ** -10
 
 
 def _calculate_cumulative_accuracy():
@@ -84,7 +92,7 @@ def _calculate_tip_points():
 
 def cumulative_metrics_query(
     prediction_query_set: QuerySet, additional_values: Optional[List[str]] = None,
-):
+) -> List[Dict[str, Any]]:
     """
     Chain methods onto a Prediction query set to calculate cumulative model metrics.
     """
@@ -107,4 +115,98 @@ def cumulative_metrics_query(
             cumulative_accuracy=_calculate_cumulative_accuracy(),
         )
         .values(*values_args)
+    )
+
+
+def _filter_by_round(data_frame: pd.DataFrame, round_number: Optional[int] = None):
+    if round_number is None:
+        return data_frame
+
+    round_number_filter = (
+        data_frame.index.get_level_values(ROUND_NUMBER_LVL).max()
+        if round_number == -1
+        else round_number
+    )
+
+    return data_frame.loc[(round_number_filter, slice(None)), :]
+
+
+def _calculate_cumulative_bits(data_frame: pd.DataFrame):
+    return (
+        data_frame.groupby("ml_model__name")
+        .expanding()["bits"]
+        .sum()
+        .rename("cumulative_bits")
+        .reset_index(level=GROUP_BY_LVL, drop=True)
+    )
+
+
+# Raw bits calculations per http://probabilistic-footy.monash.edu/~footy/about.shtml
+def _calculate_bits(data_frame: pd.DataFrame):
+    positive_pred = lambda y_pred: (
+        np.maximum(y_pred, np.repeat(MIN_LOG_VAL, len(y_pred)))
+    )
+    draw_bits = lambda y_pred: (
+        1 + (0.5 * np.log2(positive_pred(y_pred * (1 - y_pred))))
+    )
+    win_bits = lambda y_pred: 1 + np.log2(positive_pred(y_pred))
+    loss_bits = lambda y_pred: 1 + np.log2(positive_pred(1 - y_pred))
+
+    return np.where(
+        data_frame["match__margin"] == 0,
+        draw_bits(data_frame["predicted_win_probability"]),
+        np.where(
+            data_frame["match__winner__name"] == data_frame["predicted_winner__name"],
+            win_bits(data_frame["predicted_win_probability"]),
+            loss_bits(data_frame["predicted_win_probability"]),
+        ),
+    )
+
+
+# TODO: I've migrated the simple calculations over to SQL, but calculations
+# based on margin_diff are difficult, because Django doesn't allow an annotation
+# based on an aggregation (margin_diff uses Max/Min), and `Window` can't be used
+# in an `aggregate` call. I may need to resort to raw SQL, but that would probably
+# still require figuring out why the ORM doesn't like this combination.
+def _calculate_cumulative_mae(data_frame: pd.DataFrame):
+    return (
+        data_frame.groupby("ml_model__name")
+        .expanding()["absolute_margin_diff"]
+        .mean()
+        .round(2)
+        .rename("cumulative_mean_absolute_error")
+        .reset_index(level=GROUP_BY_LVL, drop=True)
+    )
+
+
+def _calculate_cumulative_margin_difference(data_frame: pd.DataFrame):
+    return (
+        data_frame.groupby("ml_model__name")
+        .expanding()["absolute_margin_diff"]
+        .sum()
+        .rename("cumulative_margin_difference")
+        .reset_index(level=GROUP_BY_LVL, drop=True)
+    )
+
+
+def calculate_cumulative_metrics(
+    metric_values: List[Dict[str, Any]], round_number: Optional[int]
+) -> pd.DataFrame:
+    """Calculate cumulative methods that can't be calculated via the ORM."""
+    return (
+        pd.DataFrame(metric_values)
+        # We fill missing win probabilities with 0.5, because that's the equivalent
+        # of not picking a winner. 0 would represent an extreme prediction
+        # and result in large negative bits calculations.
+        .fillna({"predicted_win_probability": 0.5})
+        .fillna(0)
+        .assign(bits=_calculate_bits)
+        .assign(
+            cumulative_margin_difference=_calculate_cumulative_margin_difference,
+            cumulative_bits=_calculate_cumulative_bits,
+            cumulative_mean_absolute_error=_calculate_cumulative_mae,
+        )
+        .groupby(["match__round_number", "ml_model__name"])
+        .last()
+        .pipe(partial(_filter_by_round, round_number=round_number))
     )

--- a/backend/server/graphql/schema.py
+++ b/backend/server/graphql/schema.py
@@ -1,14 +1,33 @@
 """GraphQL schema for all queries."""
 
-from typing import List
+from typing import List, Optional
+from functools import partial
 
 import graphene
-from django.db.models import QuerySet
 from django.utils import timezone
-from django.db.models import Count
+from django.db.models import (
+    Count,
+    Case,
+    When,
+    Value,
+    IntegerField,
+    Subquery,
+    OuterRef,
+    Max,
+    Min,
+    Func,
+    F,
+    Sum,
+    Window,
+    Avg,
+    QuerySet,
+)
 from mypy_extensions import TypedDict
+import pandas as pd
+import numpy as np
 
-from server.models import Prediction, Match, MLModel
+from server.models import Prediction, Match, MLModel, TeamMatch
+from server.types import RoundMetrics
 from .types import (
     SeasonType,
     PredictionType,
@@ -26,6 +45,175 @@ SeasonPerformanceChartParameters = TypedDict(
 RoundPredictions = TypedDict(
     "RoundPredictions", {"round_number": int, "match_predictions": QuerySet}
 )
+
+RoundModelMetrics = TypedDict(
+    "RoundModelMetrics",
+    {"match__round_number": int, "model_metrics": pd.DataFrame, "matches": QuerySet},
+)
+
+
+ROUND_NUMBER_LVL = 0
+GROUP_BY_LVL = 0
+# For regressors that might try to predict negative values or 0,
+# we need a slightly positive minimum to not get errors when calculating logarithms
+MIN_LOG_VAL = 1 * 10 ** -10
+
+
+class RoundMetricsType(graphene.ObjectType):
+    """Cumulative performance Metrics for Tipresias competition models."""
+
+    season = graphene.NonNull(graphene.Int)
+    match__round_number = graphene.NonNull(graphene.Int, name="roundNumber")
+
+    cumulative_correct_count = graphene.Int(
+        description=("Cumulative sum of correct tips for the given season"),
+        default_value=0,
+        required=True,
+    )
+    cumulative_accuracy = graphene.Float(
+        description=(
+            "Cumulative mean of correct tips (i.e. accuracy) for the given season."
+        ),
+        default_value=0,
+        required=True,
+    )
+    cumulative_mean_absolute_error = graphene.Float(
+        description="Cumulative mean absolute error for the given season",
+        default_value=0,
+        required=True,
+    )
+    cumulative_margin_difference = graphene.Int(
+        description=(
+            "Cumulative difference between predicted margin and actual margin "
+            "for the given season."
+        ),
+        default_value=0,
+        required=True,
+    )
+    cumulative_bits = graphene.Float(
+        description="Cumulative bits metric for the given season.",
+        default_value=0,
+        required=True,
+    )
+
+    @staticmethod
+    def resolve_season(root: RoundMetrics, _info):
+        """Get season value from match__start_date_time."""
+        return root["match__start_date_time"].year
+
+
+def _filter_by_round(data_frame: pd.DataFrame, round_number: Optional[int] = None):
+    if round_number is None:
+        return data_frame
+
+    round_number_filter = (
+        data_frame.index.get_level_values(ROUND_NUMBER_LVL).max()
+        if round_number == -1
+        else round_number
+    )
+
+    return data_frame.loc[(round_number_filter, slice(None)), :]
+
+
+def _calculate_cumulative_bits(data_frame: pd.DataFrame):
+    return (
+        data_frame.groupby("ml_model__name")
+        .expanding()["bits"]
+        .sum()
+        .rename("cumulative_bits")
+        .reset_index(level=GROUP_BY_LVL, drop=True)
+    )
+
+
+# Raw bits calculations per http://probabilistic-footy.monash.edu/~footy/about.shtml
+def _calculate_bits(data_frame: pd.DataFrame):
+    positive_pred = lambda y_pred: (
+        np.maximum(y_pred, np.repeat(MIN_LOG_VAL, len(y_pred)))
+    )
+    draw_bits = lambda y_pred: (
+        1 + (0.5 * np.log2(positive_pred(y_pred * (1 - y_pred))))
+    )
+    win_bits = lambda y_pred: 1 + np.log2(positive_pred(y_pred))
+    loss_bits = lambda y_pred: 1 + np.log2(positive_pred(1 - y_pred))
+
+    return np.where(
+        data_frame["match__margin"] == 0,
+        draw_bits(data_frame["predicted_win_probability"]),
+        np.where(
+            data_frame["match__winner__name"] == data_frame["predicted_winner__name"],
+            win_bits(data_frame["predicted_win_probability"]),
+            loss_bits(data_frame["predicted_win_probability"]),
+        ),
+    )
+
+
+# TODO: I've migrated the simple calculations over to SQL, but calculations
+# based on margin_diff are difficult, because Django doesn't allow an annotation
+# based on an aggregation (margin_diff uses Max/Min), and `Window` can't be used
+# in an `aggregate` call. I may need to resort to raw SQL, but that would probably
+# still require figuring out why the ORM doesn't like this combination.
+def _calculate_cumulative_mae(data_frame: pd.DataFrame):
+    return (
+        data_frame.groupby("ml_model__name")
+        .expanding()["absolute_margin_diff"]
+        .mean()
+        .round(2)
+        .rename("cumulative_mean_absolute_error")
+        .reset_index(level=GROUP_BY_LVL, drop=True)
+    )
+
+
+def _calculate_cumulative_margin_difference(data_frame: pd.DataFrame):
+    return (
+        data_frame.groupby("ml_model__name")
+        .expanding()["absolute_margin_diff"]
+        .sum()
+        .rename("cumulative_margin_difference")
+        .reset_index(level=GROUP_BY_LVL, drop=True)
+    )
+
+
+def _calculate_cumulative_accuracy():
+    return Window(
+        expression=Avg("tip_point"),
+        partition_by=F("ml_model_id"),
+        order_by=F("match__start_date_time").asc(),
+    )
+
+
+def _calculate_cumulative_correct():
+    return Window(
+        expression=Sum("tip_point"),
+        partition_by=F("ml_model_id"),
+        order_by=F("match__start_date_time").asc(),
+    )
+
+
+def _calculate_absolute_margin_difference():
+    return Case(
+        When(
+            is_correct=True,
+            then=Func(F("predicted_margin") - F("match__margin"), function="ABS"),
+        ),
+        default=(F("predicted_margin") + F("match__margin")),
+        output_field=IntegerField(),
+    )
+
+
+def _get_match_winner_name():
+    return Subquery(
+        TeamMatch.objects.filter(match_id=OuterRef("match_id"))
+        .order_by("-score")
+        .values_list("team__name")[:1]
+    )
+
+
+def _calculate_tip_points():
+    return Case(
+        When(is_correct=True, then=Value(1)),
+        default=Value(0),
+        output_field=IntegerField(),
+    )
 
 
 class Query(graphene.ObjectType):
@@ -64,6 +252,15 @@ class Query(graphene.ObjectType):
         description=(
             "Official Tipresias predictions for the latest round for which data "
             "is available"
+        ),
+        required=True,
+    )
+
+    fetch_latest_round_metrics = graphene.Field(
+        RoundMetricsType,
+        description=(
+            "Performance metrics for Tipresias models for the current season "
+            "through the last-played round."
         ),
         required=True,
     )
@@ -133,6 +330,128 @@ class Query(graphene.ObjectType):
             "round_number": max_match.round_number,
             "match_predictions": prediction_query,
         }
+
+    @staticmethod
+    def resolve_fetch_latest_round_metrics(_root, _info) -> RoundMetrics:
+        """
+        Return performance metrics for competition models through the last-played round.
+        """
+        max_match = (
+            Match.objects.filter(start_date_time__lt=timezone.now())
+            .order_by("-start_date_time")
+            .first()
+        )
+
+        metric_values = (
+            Prediction.objects.filter(
+                match__start_date_time__year=max_match.year,
+                ml_model__used_in_competitions=True,
+                # We don't want to include unplayed matches, which would impact
+                # mean-based metrics like accuracy and MAE
+                match__start_date_time__lt=timezone.localtime(),
+            )
+            .select_related("ml_model", "match")
+            .order_by("match__start_date_time")
+            .annotate(
+                tip_point=_calculate_tip_points(),
+                match__winner__name=_get_match_winner_name(),
+                match__margin=(
+                    Max("match__teammatch__score") - Min("match__teammatch__score")
+                ),
+                absolute_margin_diff=_calculate_absolute_margin_difference(),
+                cumulative_correct_count=_calculate_cumulative_correct(),
+                cumulative_accuracy=_calculate_cumulative_accuracy(),
+            )
+            .values(
+                "match__start_date_time",
+                "match__start_date_time__year",
+                "match__round_number",
+                "ml_model__name",
+                "ml_model__used_in_competitions",
+                "predicted_margin",
+                "predicted_win_probability",
+                "predicted_winner__name",
+                "match__winner__name",
+                "match__margin",
+                "absolute_margin_diff",
+                "cumulative_correct_count",
+                "cumulative_accuracy",
+                "match__id",
+                "ml_model__is_principle",
+            )
+        )
+
+        metrics_df = (
+            pd.DataFrame(metric_values)
+            # We fill missing win probabilities with 0.5, because that's the equivalent
+            # of not picking a winner. 0 would represent an extreme prediction
+            # and result in large negative bits calculations.
+            .fillna({"predicted_win_probability": 0.5})
+            .fillna(0)
+            .assign(bits=_calculate_bits)
+            .assign(
+                cumulative_margin_difference=_calculate_cumulative_margin_difference,
+                cumulative_bits=_calculate_cumulative_bits,
+                cumulative_mean_absolute_error=_calculate_cumulative_mae,
+            )
+            .groupby(["match__round_number", "ml_model__name"])
+            .last()
+            .pipe(partial(_filter_by_round, round_number=max_match.round_number))
+        )
+
+        assert metrics_df["ml_model__used_in_competitions"].all()
+
+        principle_data = (
+            metrics_df.query("ml_model__is_principle == True")
+            .reset_index(drop=False)
+            .set_index("match__id")
+            # We replace previously-filled values with NaNs to make it easier to fill
+            # missing principle metrics with metrics from the other competition models.
+            # It's okay if we NaNify a legitimate 0/0.5, because the other model(s)
+            # will just fill the NaN with the same neutral value.
+            .replace(
+                to_replace={
+                    "cumulative_mean_absolute_error": 0,
+                    "cumulative_margin_difference": 0,
+                    "cumulative_bits": 0,
+                    "predicted_margin": 0,
+                    "predicted_win_probability": 0.5,
+                },
+                value={
+                    "cumulative_mean_absolute_error": np.nan,
+                    "cumulative_margin_difference": np.nan,
+                    "cumulative_bits": np.nan,
+                    "predicted_margin": np.nan,
+                    "predicted_win_probability": np.nan,
+                },
+            )
+        )
+
+        non_principle_data = (
+            metrics_df.query("ml_model__is_principle == False")
+            .fillna(0)
+            .replace(
+                to_replace={"predicted_win_probability": 0.5},
+                value={"predicted_win_probability": 0},
+            )
+            .select_dtypes("number")
+            .groupby("match__id")
+            # We can sum because each prediction type will only have one model with values,
+            # and the rest of the rows will be zeros.
+            .sum()
+        )
+
+        consolidated_metrics = principle_data.fillna(non_principle_data).to_dict(
+            "records"
+        )
+
+        assert len(consolidated_metrics) == 1, (
+            "Latest round predictions should be in the form of a single data set "
+            "composed of all competition models, but multiple sets were calculated:\n"
+            f"{consolidated_metrics}"
+        )
+
+        return consolidated_metrics[0]
 
     @staticmethod
     def resolve_fetch_ml_models(

--- a/backend/server/graphql/schema.py
+++ b/backend/server/graphql/schema.py
@@ -5,29 +5,14 @@ from functools import partial
 
 import graphene
 from django.utils import timezone
-from django.db.models import (
-    Count,
-    Case,
-    When,
-    Value,
-    IntegerField,
-    Subquery,
-    OuterRef,
-    Max,
-    Min,
-    Func,
-    F,
-    Sum,
-    Window,
-    Avg,
-    QuerySet,
-)
+from django.db.models import QuerySet, Count
 from mypy_extensions import TypedDict
 import pandas as pd
 import numpy as np
 
-from server.models import Prediction, Match, MLModel, TeamMatch
+from server.models import Prediction, Match, MLModel
 from server.types import RoundMetrics
+from server.graphql.calculations import cumulative_metrics_query
 from .types import (
     SeasonType,
     PredictionType,
@@ -173,49 +158,6 @@ def _calculate_cumulative_margin_difference(data_frame: pd.DataFrame):
     )
 
 
-def _calculate_cumulative_accuracy():
-    return Window(
-        expression=Avg("tip_point"),
-        partition_by=F("ml_model_id"),
-        order_by=F("match__start_date_time").asc(),
-    )
-
-
-def _calculate_cumulative_correct():
-    return Window(
-        expression=Sum("tip_point"),
-        partition_by=F("ml_model_id"),
-        order_by=F("match__start_date_time").asc(),
-    )
-
-
-def _calculate_absolute_margin_difference():
-    return Case(
-        When(
-            is_correct=True,
-            then=Func(F("predicted_margin") - F("match__margin"), function="ABS"),
-        ),
-        default=(F("predicted_margin") + F("match__margin")),
-        output_field=IntegerField(),
-    )
-
-
-def _get_match_winner_name():
-    return Subquery(
-        TeamMatch.objects.filter(match_id=OuterRef("match_id"))
-        .order_by("-score")
-        .values_list("team__name")[:1]
-    )
-
-
-def _calculate_tip_points():
-    return Case(
-        When(is_correct=True, then=Value(1)),
-        default=Value(0),
-        output_field=IntegerField(),
-    )
-
-
 class Query(graphene.ObjectType):
     """Base GraphQL Query type that contains all queries and their resolvers."""
 
@@ -342,43 +284,17 @@ class Query(graphene.ObjectType):
             .first()
         )
 
-        metric_values = (
-            Prediction.objects.filter(
-                match__start_date_time__year=max_match.year,
-                ml_model__used_in_competitions=True,
-                # We don't want to include unplayed matches, which would impact
-                # mean-based metrics like accuracy and MAE
-                match__start_date_time__lt=timezone.localtime(),
-            )
-            .select_related("ml_model", "match")
-            .order_by("match__start_date_time")
-            .annotate(
-                tip_point=_calculate_tip_points(),
-                match__winner__name=_get_match_winner_name(),
-                match__margin=(
-                    Max("match__teammatch__score") - Min("match__teammatch__score")
-                ),
-                absolute_margin_diff=_calculate_absolute_margin_difference(),
-                cumulative_correct_count=_calculate_cumulative_correct(),
-                cumulative_accuracy=_calculate_cumulative_accuracy(),
-            )
-            .values(
-                "match__start_date_time",
-                "match__start_date_time__year",
-                "match__round_number",
-                "ml_model__name",
-                "ml_model__used_in_competitions",
-                "predicted_margin",
-                "predicted_win_probability",
-                "predicted_winner__name",
-                "match__winner__name",
-                "match__margin",
-                "absolute_margin_diff",
-                "cumulative_correct_count",
-                "cumulative_accuracy",
-                "match__id",
-                "ml_model__is_principle",
-            )
+        prediction_query_set = Prediction.objects.filter(
+            match__start_date_time__year=max_match.year,
+            ml_model__used_in_competitions=True,
+        )
+        additional_metric_values = [
+            "match__start_date_time__year",
+            "match__id",
+            "ml_model__is_principle",
+        ]
+        metric_values = cumulative_metrics_query(
+            prediction_query_set, additional_metric_values,
         )
 
         metrics_df = (

--- a/backend/server/graphql/schema.py
+++ b/backend/server/graphql/schema.py
@@ -1,7 +1,6 @@
 """GraphQL schema for all queries."""
 
-from typing import List, Optional
-from functools import partial
+from typing import List
 
 import graphene
 from django.utils import timezone
@@ -12,7 +11,10 @@ import numpy as np
 
 from server.models import Prediction, Match, MLModel
 from server.types import RoundMetrics
-from server.graphql.calculations import cumulative_metrics_query
+from server.graphql.calculations import (
+    cumulative_metrics_query,
+    calculate_cumulative_metrics,
+)
 from .types import (
     SeasonType,
     PredictionType,
@@ -35,13 +37,6 @@ RoundModelMetrics = TypedDict(
     "RoundModelMetrics",
     {"match__round_number": int, "model_metrics": pd.DataFrame, "matches": QuerySet},
 )
-
-
-ROUND_NUMBER_LVL = 0
-GROUP_BY_LVL = 0
-# For regressors that might try to predict negative values or 0,
-# we need a slightly positive minimum to not get errors when calculating logarithms
-MIN_LOG_VAL = 1 * 10 ** -10
 
 
 class RoundMetricsType(graphene.ObjectType):
@@ -82,80 +77,63 @@ class RoundMetricsType(graphene.ObjectType):
     )
 
     @staticmethod
-    def resolve_season(root: RoundMetrics, _info):
+    def resolve_season(round_metrics: RoundMetrics, _info):
         """Get season value from match__start_date_time."""
-        return root["match__start_date_time"].year
+        return round_metrics["match__start_date_time"].year
 
 
-def _filter_by_round(data_frame: pd.DataFrame, round_number: Optional[int] = None):
-    if round_number is None:
-        return data_frame
+def _consolidate_competition_model_metrics(model_metrics: pd.DataFrame) -> RoundMetrics:
+    assert model_metrics["ml_model__used_in_competitions"].all()
 
-    round_number_filter = (
-        data_frame.index.get_level_values(ROUND_NUMBER_LVL).max()
-        if round_number == -1
-        else round_number
+    principle_data = (
+        model_metrics.query("ml_model__is_principle == True")
+        .reset_index(drop=False)
+        .set_index("match__id")
+        # We replace previously-filled values with NaNs to make it easier to fill
+        # missing principle metrics with metrics from the other competition models.
+        # It's okay if we NaNify a legitimate 0/0.5, because the other model(s)
+        # will just fill the NaN with the same neutral value.
+        .replace(
+            to_replace={
+                "cumulative_mean_absolute_error": 0,
+                "cumulative_margin_difference": 0,
+                "cumulative_bits": 0,
+                "predicted_margin": 0,
+                "predicted_win_probability": 0.5,
+            },
+            value={
+                "cumulative_mean_absolute_error": np.nan,
+                "cumulative_margin_difference": np.nan,
+                "cumulative_bits": np.nan,
+                "predicted_margin": np.nan,
+                "predicted_win_probability": np.nan,
+            },
+        )
     )
 
-    return data_frame.loc[(round_number_filter, slice(None)), :]
-
-
-def _calculate_cumulative_bits(data_frame: pd.DataFrame):
-    return (
-        data_frame.groupby("ml_model__name")
-        .expanding()["bits"]
+    non_principle_data = (
+        model_metrics.query("ml_model__is_principle == False")
+        .fillna(0)
+        .replace(
+            to_replace={"predicted_win_probability": 0.5},
+            value={"predicted_win_probability": 0},
+        )
+        .select_dtypes("number")
+        .groupby("match__id")
+        # We can sum because each prediction type will only have one model with values,
+        # and the rest of the rows will be zeros.
         .sum()
-        .rename("cumulative_bits")
-        .reset_index(level=GROUP_BY_LVL, drop=True)
     )
 
+    consolidated_metrics = principle_data.fillna(non_principle_data).to_dict("records")
 
-# Raw bits calculations per http://probabilistic-footy.monash.edu/~footy/about.shtml
-def _calculate_bits(data_frame: pd.DataFrame):
-    positive_pred = lambda y_pred: (
-        np.maximum(y_pred, np.repeat(MIN_LOG_VAL, len(y_pred)))
-    )
-    draw_bits = lambda y_pred: (
-        1 + (0.5 * np.log2(positive_pred(y_pred * (1 - y_pred))))
-    )
-    win_bits = lambda y_pred: 1 + np.log2(positive_pred(y_pred))
-    loss_bits = lambda y_pred: 1 + np.log2(positive_pred(1 - y_pred))
-
-    return np.where(
-        data_frame["match__margin"] == 0,
-        draw_bits(data_frame["predicted_win_probability"]),
-        np.where(
-            data_frame["match__winner__name"] == data_frame["predicted_winner__name"],
-            win_bits(data_frame["predicted_win_probability"]),
-            loss_bits(data_frame["predicted_win_probability"]),
-        ),
+    assert len(consolidated_metrics) == 1, (
+        "Latest round predictions should be in the form of a single data set "
+        "composed of all competition models, but multiple sets were calculated:\n"
+        f"{consolidated_metrics}"
     )
 
-
-# TODO: I've migrated the simple calculations over to SQL, but calculations
-# based on margin_diff are difficult, because Django doesn't allow an annotation
-# based on an aggregation (margin_diff uses Max/Min), and `Window` can't be used
-# in an `aggregate` call. I may need to resort to raw SQL, but that would probably
-# still require figuring out why the ORM doesn't like this combination.
-def _calculate_cumulative_mae(data_frame: pd.DataFrame):
-    return (
-        data_frame.groupby("ml_model__name")
-        .expanding()["absolute_margin_diff"]
-        .mean()
-        .round(2)
-        .rename("cumulative_mean_absolute_error")
-        .reset_index(level=GROUP_BY_LVL, drop=True)
-    )
-
-
-def _calculate_cumulative_margin_difference(data_frame: pd.DataFrame):
-    return (
-        data_frame.groupby("ml_model__name")
-        .expanding()["absolute_margin_diff"]
-        .sum()
-        .rename("cumulative_margin_difference")
-        .reset_index(level=GROUP_BY_LVL, drop=True)
-    )
+    return consolidated_metrics[0]
 
 
 class Query(graphene.ObjectType):
@@ -297,77 +275,9 @@ class Query(graphene.ObjectType):
             prediction_query_set, additional_metric_values,
         )
 
-        metrics_df = (
-            pd.DataFrame(metric_values)
-            # We fill missing win probabilities with 0.5, because that's the equivalent
-            # of not picking a winner. 0 would represent an extreme prediction
-            # and result in large negative bits calculations.
-            .fillna({"predicted_win_probability": 0.5})
-            .fillna(0)
-            .assign(bits=_calculate_bits)
-            .assign(
-                cumulative_margin_difference=_calculate_cumulative_margin_difference,
-                cumulative_bits=_calculate_cumulative_bits,
-                cumulative_mean_absolute_error=_calculate_cumulative_mae,
-            )
-            .groupby(["match__round_number", "ml_model__name"])
-            .last()
-            .pipe(partial(_filter_by_round, round_number=max_match.round_number))
-        )
+        metrics_df = calculate_cumulative_metrics(metric_values, max_match.round_number)
 
-        assert metrics_df["ml_model__used_in_competitions"].all()
-
-        principle_data = (
-            metrics_df.query("ml_model__is_principle == True")
-            .reset_index(drop=False)
-            .set_index("match__id")
-            # We replace previously-filled values with NaNs to make it easier to fill
-            # missing principle metrics with metrics from the other competition models.
-            # It's okay if we NaNify a legitimate 0/0.5, because the other model(s)
-            # will just fill the NaN with the same neutral value.
-            .replace(
-                to_replace={
-                    "cumulative_mean_absolute_error": 0,
-                    "cumulative_margin_difference": 0,
-                    "cumulative_bits": 0,
-                    "predicted_margin": 0,
-                    "predicted_win_probability": 0.5,
-                },
-                value={
-                    "cumulative_mean_absolute_error": np.nan,
-                    "cumulative_margin_difference": np.nan,
-                    "cumulative_bits": np.nan,
-                    "predicted_margin": np.nan,
-                    "predicted_win_probability": np.nan,
-                },
-            )
-        )
-
-        non_principle_data = (
-            metrics_df.query("ml_model__is_principle == False")
-            .fillna(0)
-            .replace(
-                to_replace={"predicted_win_probability": 0.5},
-                value={"predicted_win_probability": 0},
-            )
-            .select_dtypes("number")
-            .groupby("match__id")
-            # We can sum because each prediction type will only have one model with values,
-            # and the rest of the rows will be zeros.
-            .sum()
-        )
-
-        consolidated_metrics = principle_data.fillna(non_principle_data).to_dict(
-            "records"
-        )
-
-        assert len(consolidated_metrics) == 1, (
-            "Latest round predictions should be in the form of a single data set "
-            "composed of all competition models, but multiple sets were calculated:\n"
-            f"{consolidated_metrics}"
-        )
-
-        return consolidated_metrics[0]
+        return _consolidate_competition_model_metrics(metrics_df)
 
     @staticmethod
     def resolve_fetch_ml_models(

--- a/backend/server/tests/unit/test_schema.py
+++ b/backend/server/tests/unit/test_schema.py
@@ -481,6 +481,77 @@ class TestSchema(TestCase):
             for model in data:
                 self.assertTrue(model["usedInCompetitions"])
 
+    def test_fetch_latest_round_metrics(self):
+        ml_models = list(MLModel.objects.filter(name__in=MODEL_NAMES))
+        YEAR = TWENTY_SEVENTEEN
+        MONTH = 6
+
+        for round_n in range(ROUND_COUNT):
+            for match_n in range(MATCH_COUNT):
+                FullMatchFactory(
+                    year=YEAR,
+                    round_number=(round_n + 1),
+                    start_date_time=timezone.make_aware(
+                        datetime(YEAR, MONTH, (round_n % 29) + 1, match_n * 5)
+                    ),
+                    prediction__ml_model=ml_models[0],
+                    prediction__force_correct=True,
+                    prediction_two__ml_model=ml_models[1],
+                    prediction_two__force_correct=True,
+                )
+
+        query = """
+            query {
+                fetchLatestRoundMetrics {
+                    season
+                    roundNumber
+                    cumulativeCorrectCount
+                    cumulativeAccuracy
+                    cumulativeMeanAbsoluteError
+                    cumulativeMarginDifference
+                    cumulativeBits
+                }
+            }
+        """
+
+        executed = self.client.execute(query)
+        print(executed)
+        data = executed["data"]["fetchLatestRoundMetrics"]
+
+        self.assertEqual(data["season"], YEAR)
+        self.assertEqual(data["roundNumber"], ROUND_COUNT)
+
+        self.assertGreater(data["cumulativeCorrectCount"], 0)
+        self.assertGreater(data["cumulativeMeanAbsoluteError"], 0)
+        self.assertGreater(data["cumulativeMarginDifference"], 0)
+        self.assertGreater(data["cumulativeAccuracy"], 0)
+        # Bits can be positive or negative, so we just want to make sure it's not 0,
+        # which would suggest a problem
+        self.assertNotEqual(data["cumulativeBits"], 0)
+
+        with self.subTest("when the last matches haven't been played yet"):
+            DAY = 3
+            fake_datetime = timezone.make_aware(datetime(YEAR, MONTH, DAY))
+
+            with freeze_time(fake_datetime):
+                past_executed = self.client.execute(
+                    query, variables={"mlModelName": "predictanator"}
+                )
+
+                data = past_executed["data"]["fetchLatestRoundMetrics"]
+
+                max_match_round = (
+                    Match.objects.all().order_by("-round_number").first().round_number
+                )
+                self.assertLess(data["roundNumber"], max_match_round)
+                # Last played match will be from day before, because "now" and the
+                # start time for "today's match" are equal
+                self.assertEqual(data["roundNumber"], DAY - 1)
+
+                self.assertGreater(data["cumulativeCorrectCount"], 0)
+                self.assertGreater(data["cumulativeMeanAbsoluteError"], 0)
+                self.assertGreater(data["cumulativeMarginDifference"], 0)
+
     def _assert_correct_prediction_results(self, results, expected_results):
         # graphene returns OrderedDicts instead of dicts, which makes asserting
         # on results a little more complicated

--- a/backend/server/tests/unit/test_schema.py
+++ b/backend/server/tests/unit/test_schema.py
@@ -515,7 +515,6 @@ class TestSchema(TestCase):
         """
 
         executed = self.client.execute(query)
-        print(executed)
         data = executed["data"]["fetchLatestRoundMetrics"]
 
         self.assertEqual(data["season"], YEAR)

--- a/backend/server/types.py
+++ b/backend/server/types.py
@@ -65,3 +65,26 @@ CleanPredictionData = TypedDict(
 )
 
 MlModel = TypedDict("MlModel", {"name": str, "filepath": str})
+
+RoundMetrics = TypedDict(
+    "RoundMetrics",
+    {
+        "match__start_date_time": datetime,
+        "match__round_number": int,
+        "ml_model__name": str,
+        "predicted_margin": int,
+        "predicted_win_probability": float,
+        "predicted_winner__name": str,
+        "ml_model__is_principle": bool,
+        "ml_model__used_in_competitions": bool,
+        "match__winner__name": str,
+        "match__margin": int,
+        "absolute_margin_diff": int,
+        "bits": float,
+        "cumulative_correct_count": int,
+        "cumulative_accuracy": float,
+        "cumulative_mean_absolute_error": float,
+        "cumulative_margin_difference": int,
+        "cumulative_bits": float,
+    },
+)

--- a/frontend/schema.json
+++ b/frontend/schema.json
@@ -130,6 +130,22 @@
             "deprecationReason": null
           },
           {
+            "name": "fetchLatestRoundMetrics",
+            "description": "Performance metrics for Tipresias models for the current season through the last-played round.",
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "OBJECT",
+                "name": "RoundMetricsType",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
             "name": "fetchMlModels",
             "description": null,
             "args": [
@@ -1065,30 +1081,6 @@
             },
             "isDeprecated": false,
             "deprecationReason": null
-          },
-          {
-            "name": "matches",
-            "description": null,
-            "args": [],
-            "type": {
-              "kind": "NON_NULL",
-              "name": null,
-              "ofType": {
-                "kind": "LIST",
-                "name": null,
-                "ofType": {
-                  "kind": "NON_NULL",
-                  "name": null,
-                  "ofType": {
-                    "kind": "OBJECT",
-                    "name": "MatchType",
-                    "ofType": null
-                  }
-                }
-              }
-            },
-            "isDeprecated": false,
-            "deprecationReason": null
           }
         ],
         "inputFields": null,
@@ -1331,6 +1323,129 @@
               "kind": "SCALAR",
               "name": "Boolean",
               "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
+        "inputFields": null,
+        "interfaces": [],
+        "enumValues": null,
+        "possibleTypes": null
+      },
+      {
+        "kind": "OBJECT",
+        "name": "RoundMetricsType",
+        "description": "Cumulative performance Metrics for Tipresias competition models.",
+        "fields": [
+          {
+            "name": "season",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "Int",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "roundNumber",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "Int",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "cumulativeCorrectCount",
+            "description": "Cumulative sum of correct tips for the given season",
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "Int",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "cumulativeAccuracy",
+            "description": "Cumulative mean of correct tips (i.e. accuracy) for the given season.",
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "Float",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "cumulativeMeanAbsoluteError",
+            "description": "Cumulative mean absolute error for the given season",
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "Float",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "cumulativeMarginDifference",
+            "description": "Cumulative difference between predicted margin and actual margin for the given season.",
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "Int",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "cumulativeBits",
+            "description": "Cumulative bits metric for the given season.",
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "Float",
+                "ofType": null
+              }
             },
             "isDeprecated": false,
             "deprecationReason": null

--- a/frontend/src/containers/Dashboard/index.js
+++ b/frontend/src/containers/Dashboard/index.js
@@ -6,6 +6,7 @@ import styled from 'styled-components/macro';
 import {
   FETCH_SEASON_METRICS_QUERY,
   FETCH_LATEST_ROUND_PREDICTIONS_QUERY,
+  FETCH_LATEST_ROUND_METRICS_QUERY,
 } from '../../graphql';
 import type { fetchSeasonModelMetrics } from '../../graphql/graphql-types/fetchSeasonModelMetrics';
 import type { fetchLatestRoundPredictions } from '../../graphql/graphql-types/fetchLatestRoundPredictions';
@@ -52,8 +53,6 @@ interface fetchLatestRoundPredictionsResponse {
 const Widget = styled.div`${WidgetStyles}`;
 
 const Dashboard = ({ years, models, metrics }: DashboardProps) => {
-  const [principleModel] = models.filter(item => item.isPrinciple);
-
   const latestYear = years[years.length - 1];
   const [year, setYear] = useState(latestYear);
 
@@ -205,36 +204,18 @@ const Dashboard = ({ years, models, metrics }: DashboardProps) => {
         </Widget>
 
         <Widget gridColumn="1 / -2">
-          <Query
-            query={FETCH_SEASON_METRICS_QUERY}
-            variables={{ season: latestYear, roundNumber: -1, forCompetitionOnly: true }}
-          >
-            {({ loading, error, data }: fetchSeasonModelMetricsResponse): Node => {
+          <Query query={FETCH_LATEST_ROUND_METRICS_QUERY}>
+            {({ loading, error, data }: fetchLatestRoundMetrics): Node => {
               if (loading) return <p>Brrrrr...</p>;
               if (error) return <StatusBar text={error.message} error />;
-              const { season, roundModelMetrics } = data.fetchSeasonModelMetrics;
-              const { roundNumber, modelMetrics } = roundModelMetrics[0];
-
-
-              // cumulativeCorrectCount
-              const { cumulativeCorrectCount } = modelMetrics.find(
-                item => (item.mlModel.name === principleModel.name),
-              ) || {};
-
-              // bits
-              const { cumulativeBits } = modelMetrics.find(
-                item => item.cumulativeBits !== 0,
-              ) || { cumulativeBits: 0 };
-
-              // cumulativeMarginDifference
-              const { cumulativeMarginDifference } = modelMetrics.find(
-                item => item.cumulativeMarginDifference !== 0,
-              ) || { cumulativeMarginDifference: 0 };
-
-              // cumulativeMeanAbsoluteError
-              const { cumulativeMeanAbsoluteError } = modelMetrics.find(
-                item => item.cumulativeMeanAbsoluteError !== 0,
-              ) || { cumulativeMeanAbsoluteError: 0 };
+              const {
+                season,
+                roundNumber,
+                cumulativeBits,
+                cumulativeMeanAbsoluteError,
+                cumulativeCorrectCount,
+                cumulativeMarginDifference,
+              } = data.fetchLatestRoundMetrics;
 
               return (
                 <Fragment>

--- a/frontend/src/containers/Dashboard/index.js
+++ b/frontend/src/containers/Dashboard/index.js
@@ -10,6 +10,7 @@ import {
 } from '../../graphql';
 import type { fetchSeasonModelMetrics } from '../../graphql/graphql-types/fetchSeasonModelMetrics';
 import type { fetchLatestRoundPredictions } from '../../graphql/graphql-types/fetchLatestRoundPredictions';
+import type { fetchLatestRoundMetrics } from '../../graphql/graphql-types/fetchLatestRoundMetrics';
 import LineChartMain from '../../components/LineChartMain';
 import Select from '../../components/Select';
 import Checkbox from '../../components/Checkbox';
@@ -48,6 +49,12 @@ interface fetchLatestRoundPredictionsResponse {
   loading: any;
   error: any;
   data: fetchLatestRoundPredictions;
+}
+
+interface fetchLatestRoundMetricsResponse {
+  loading: any;
+  error: any;
+  data: fetchLatestRoundMetrics;
 }
 
 const Widget = styled.div`${WidgetStyles}`;
@@ -205,7 +212,7 @@ const Dashboard = ({ years, models, metrics }: DashboardProps) => {
 
         <Widget gridColumn="1 / -2">
           <Query query={FETCH_LATEST_ROUND_METRICS_QUERY}>
-            {({ loading, error, data }: fetchLatestRoundMetrics): Node => {
+            {({ loading, error, data }: fetchLatestRoundMetricsResponse): Node => {
               if (loading) return <p>Brrrrr...</p>;
               if (error) return <StatusBar text={error.message} error />;
               const {

--- a/frontend/src/graphql/graphql-types/fetchLatestRoundMetrics.js
+++ b/frontend/src/graphql/graphql-types/fetchLatestRoundMetrics.js
@@ -1,0 +1,48 @@
+/* @flow */
+/* eslint-disable */
+// @generated
+// This file was automatically generated and should not be edited.
+
+// ====================================================
+// GraphQL query operation: fetchLatestRoundMetrics
+// ====================================================
+
+export type fetchLatestRoundMetrics_fetchLatestRoundMetrics = {
+  __typename: "RoundMetricsType",
+  season: number,
+  roundNumber: number,
+  /**
+   * Cumulative bits metric for the given season.
+   */
+  cumulativeBits: number,
+  /**
+   * Cumulative mean absolute error for the given season
+   */
+  cumulativeMeanAbsoluteError: number,
+  /**
+   * Cumulative sum of correct tips for the given season
+   */
+  cumulativeCorrectCount: number,
+  /**
+   * Cumulative difference between predicted margin and actual margin for the given season.
+   */
+  cumulativeMarginDifference: number,
+};
+
+export type fetchLatestRoundMetrics = {
+  /**
+   * Performance metrics for Tipresias models for the current season through the last-played round.
+   */
+  fetchLatestRoundMetrics: fetchLatestRoundMetrics_fetchLatestRoundMetrics
+};/* @flow */
+/* eslint-disable */
+// @generated
+// This file was automatically generated and should not be edited.
+
+//==============================================================
+// START Enums and Input Objects
+//==============================================================
+
+//==============================================================
+// END Enums and Input Objects
+//==============================================================

--- a/frontend/src/graphql/index.js
+++ b/frontend/src/graphql/index.js
@@ -69,6 +69,19 @@ export const FETCH_SEASON_METRICS_QUERY = gql`
   }
 `;
 
+export const FETCH_LATEST_ROUND_METRICS_QUERY = gql`
+  query fetchLatestRoundMetrics {
+    fetchLatestRoundMetrics {
+      season
+      roundNumber
+      cumulativeBits
+      cumulativeMeanAbsoluteError
+      cumulativeCorrectCount
+      cumulativeMarginDifference
+    }
+  }
+`;
+
 export const FETCH_CHART_PARAMETERS_QUERY = gql`
   query fetchSeasonPerformanceChartParameters {
     fetchSeasonPerformanceChartParameters {


### PR DESCRIPTION
Final step for the current GQL schema refactor. This creates `fetchLatestRoundMetrics` as its own query rather than a reuse of the season metrics query. I reduced duplication by refactoring out the metric calculation logic into its own shared module.