### PR TITLE
Fix tip submission

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -57,4 +57,4 @@ WORKDIR /app/backend
 
 EXPOSE ${PORT:-80}
 
-CMD gunicorn project.wsgi -b 0.0.0.0:80
+CMD gunicorn -b 0.0.0.0:80 -w 3 -t 600 --log-file=- --access-logfile=- project.wsgi

--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -28,4 +28,4 @@ COPY . .
 # Make port 8000 available for the app
 EXPOSE 8000
 
-CMD python3 manage.py runserver 0.0.0.0:8000
+CMD gunicorn -b 0.0.0.0:80000 -w 3 -t 600 --log-file=- --access-logfile=- project.wsgi

--- a/backend/server/views.py
+++ b/backend/server/views.py
@@ -34,4 +34,4 @@ def predictions(request: HttpRequest):
 
     Tipper().submit_tips()
 
-    return HttpResponse(status=200)
+    return HttpResponse("Success", status=200)

--- a/scripts/create_instance.sh
+++ b/scripts/create_instance.sh
@@ -2,7 +2,8 @@
 
 set -euo pipefail
 
-DROPLET_NAME=tipresias-app
+DROPLET_NAME=${PROJECT_ID}-app
+MEM_LIMIT=2
 
 echo Creating droplet...
 
@@ -10,7 +11,7 @@ DROPLET_IP=$(doctl compute droplet create \
   ${DROPLET_NAME} \
   --image docker-18-04 \
   --region sgp1 \
-  --size s-1vcpu-1gb \
+  --size s-1vcpu-${MEM_LIMIT}gb \
   --enable-monitoring \
   --enable-private-networking \
   --ssh-keys ${DIGITAL_OCEAN_SSH_KEYS} \
@@ -28,6 +29,6 @@ sleep 30
 # how to pass a file with an argument via --user-data/--user-data-file.
 # We use 'ssh' instead of 'doctl compute ssh' to be able to bypass key checking.
 ssh -oStrictHostKeyChecking=no root@${DROPLET_IP} \
-  "bash -s" -- < ./scripts/digital_ocean_server_setup.sh ${DIGITAL_OCEAN_USER}
+  "bash -s" -- < ./scripts/digital_ocean_server_setup.sh ${DIGITAL_OCEAN_USER} ${PROJECT_ID}
 
 echo Droplet configured!

--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -5,9 +5,13 @@ set -euo pipefail
 APP_DIR=/var/www/${PROJECT_ID}
 DOCKER_IMAGE=cfranklin11/${PROJECT_ID}_app:latest
 PORT=80
+TRAVIS=${TRAVIS:-""}
 
-sudo chmod 600 ~/.ssh/deploy_rsa
-sudo chmod 755 ~/.ssh
+if [ "${TRAVIS}" ]
+then
+  sudo chmod 600 ~/.ssh/deploy_rsa
+  sudo chmod 755 ~/.ssh
+fi
 
 docker pull ${DOCKER_IMAGE}
 docker build --cache-from ${DOCKER_IMAGE} -t ${DOCKER_IMAGE} .

--- a/scripts/digital_ocean_server_setup.sh
+++ b/scripts/digital_ocean_server_setup.sh
@@ -7,6 +7,7 @@ set -euo pipefail
 
 # Name of the user to create and grant sudo privileges
 USERNAME=$1
+APP_NAME=$2
 
 # Whether to copy over the root user's `authorized_keys` file to the new sudo
 # user.
@@ -73,13 +74,15 @@ fi
 ufw allow OpenSSH
 ufw --force enable
 
-# Set up Docker
-usermod -aG docker ${USERNAME}
-su - ${USERNAME}
+y | apt-get update && apt-get install fail2ban
 
 # Create directory for the app
-APP_DIR=/var/www/tipresias
+APP_DIR=/var/www/${APP_NAME}
 
 chown ${USER}: /var
 mkdir --parents ${APP_DIR}
 chown ${USER}: ${APP_DIR}
+
+# Set up Docker
+groupadd docker
+usermod -aG docker ${USERNAME}


### PR DESCRIPTION
All the bugs and closed connection errors I was getting in production were due to tips submissions (via Selenium) taking forever and Gunicorn timing out and shutting everything down. In a follow-up PR, I want to make tips submissions a background process, but for now I just want to get this working, so I increased the timeout to 10 minutes, which seems to be enough.