### PR TITLE
Make only root path return homepage

### DIFF
--- a/backend/project/urls.py
+++ b/backend/project/urls.py
@@ -33,4 +33,4 @@ urlpatterns = [  # pylint: disable=C0103
 ]
 
 if settings.ENVIRONMENT == "production":
-    urlpatterns.append(re_path(".*", TemplateView.as_view(template_name="index.html")))
+    urlpatterns.append(re_path("/", TemplateView.as_view(template_name="index.html")))


### PR DESCRIPTION
I can't remember why I left it such that any path returns the
home page after defining the few specific routes we use, but it
should just be '/', because it doesn't make sense to return the
homepage for '/foo' and '/bar' and whatever else anyone can think
of.