### PR TITLE
Update predictions & submit tips in tip command

### DIFF
--- a/backend/server/data_import.py
+++ b/backend/server/data_import.py
@@ -82,12 +82,12 @@ def _fetch_data(
     )
 
 
-def request_predictions(
+def fetch_prediction_data(
     year_range: Tuple[int, int],
     round_number: Optional[int] = None,
     ml_models: Optional[List[str]] = None,
     train_models: Optional[bool] = False,
-) -> None:
+) -> pd.DataFrame:
     """
     Fetch prediction data from machine_learning module.
 
@@ -105,20 +105,17 @@ def request_predictions(
     year_range_param = "-".join((str(min_year), str(max_year)))
     ml_model_param = None if ml_models is None else ",".join(ml_models)
 
-    try:
-        _fetch_data(
-            "predictions",
-            {
-                "year_range": year_range_param,
-                "round_number": round_number,
-                "ml_models": ml_model_param,
-                "train_models": train_models,
-            },
-        )
-    except requests.exceptions.ConnectionError:
-        # We catch ConnectionError, because generating data for predictions takes
-        # so long that the connection always gets terminated.
-        pass
+    prediction_data = _fetch_data(
+        "predictions",
+        {
+            "year_range": year_range_param,
+            "round_number": round_number,
+            "ml_models": ml_model_param,
+            "train_models": train_models,
+        },
+    )
+
+    return pd.DataFrame(prediction_data)
 
 
 def fetch_fixture_data(start_date: datetime, end_date: datetime) -> pd.DataFrame:

--- a/backend/server/management/commands/tip.py
+++ b/backend/server/management/commands/tip.py
@@ -17,4 +17,4 @@ class Command(BaseCommand):
         """Run 'tip' command."""
         tipper = Tipper(verbose=verbose)
         tipper.update_match_data()
-        tipper.request_predictions()
+        tipper.update_match_predictions()

--- a/backend/server/management/commands/tip.py
+++ b/backend/server/management/commands/tip.py
@@ -18,3 +18,4 @@ class Command(BaseCommand):
         tipper = Tipper(verbose=verbose)
         tipper.update_match_data()
         tipper.update_match_predictions()
+        tipper.submit_tips()

--- a/backend/server/tests/integration/management/commands/test_tip.py
+++ b/backend/server/tests/integration/management/commands/test_tip.py
@@ -40,7 +40,7 @@ class TestTip(TestCase):
         # It creates upcoming match records
         self.assertEqual(Match.objects.count(), ROW_COUNT)
         # It requests predictions
-        mock_data_import.request_predictions.assert_called()
+        mock_data_import.fetch_predictions.assert_called()
         self.assertEqual(Prediction.objects.count(), 0)
 
     def _stub_import_methods(self, mock_data_import):
@@ -52,9 +52,7 @@ class TestTip(TestCase):
         # We have 2 subtests in 2016 and 1 in 2017, which requires 3 fixture
         # and prediction data imports, but only 1 match results data import,
         # because it doesn't get called until 2017
-        mock_data_import.request_predictions = Mock(
-            side_effect=self._request_predictions
-        )
+        mock_data_import.fetch_predictions = Mock(side_effect=self._fetch_predictions)
         mock_data_import.fetch_fixture_data = Mock(return_value=fixture_return_values)
         mock_data_import.fetch_match_results_data = Mock(
             return_value=match_results_return_values
@@ -101,7 +99,7 @@ class TestTip(TestCase):
         factories.TeamFactory(name=match_data["away_team"])
 
     @staticmethod
-    def _request_predictions(
+    def _fetch_predictions(
         year_range,
         round_number=None,
         ml_models=None,


### PR DESCRIPTION
With the removal of the `POST` call to `tipresias` for updating predictions, we go back to handling to full tipping flow within the `tip` command, now with a greatly-extended timeout. This should complete the series of quick fixes to finally get this working, while I restructure the code to facilitate background jobs and maybe move back to more serverless services.