### PR TITLE
Fix tip submission

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -57,4 +57,4 @@ WORKDIR /app/backend
 
 EXPOSE ${PORT:-80}
 
-CMD gunicorn -b 0.0.0.0:80 -w 3 -t 600 --log-file=- --access-logfile=- project.wsgi
+CMD gunicorn -b 0.0.0.0:80 -w 3 -t 600 --access-logfile=- project.wsgi

--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -28,4 +28,4 @@ COPY . .
 # Make port 8000 available for the app
 EXPOSE 8000
 
-CMD gunicorn -b 0.0.0.0:80000 -w 3 -t 600 --log-file=- --access-logfile=- project.wsgi
+CMD gunicorn -b 0.0.0.0:80000 -w 3 -t 600 --access-logfile=- project.wsgi

--- a/backend/server/management/commands/tip.py
+++ b/backend/server/management/commands/tip.py
@@ -14,7 +14,15 @@ class Command(BaseCommand):
     """
 
     def handle(self, *_args, verbose=1, **_kwargs) -> None:  # pylint: disable=W0221
-        """Run 'tip' command."""
+        """
+        Run 'tip' command for end-to-end tipping process.
+
+        This includes:
+        1. Updating data for upcoming matches & backfilling past match data.
+        2. Updating or creating predictions for upcoming matches.
+        3. Submitting tips to competition websites
+            (footytips.com.au & Monash by default).
+        """
         tipper = Tipper(verbose=verbose)
         tipper.update_match_data()
         tipper.update_match_predictions()

--- a/backend/server/tipping.py
+++ b/backend/server/tipping.py
@@ -241,7 +241,7 @@ class FootyTipsSubmitter:
         }
 
     def _log_in(self):
-        self.browser.visit("https://www.footytips.com.au/tipping/afl/")
+        self.browser.visit("https://www.footytips.com.au/home")
 
         # Have to use second login form, because the first is some invisible Angular
         # something something


### PR DESCRIPTION
I got a timeout when trying to submit to footytips.com.au, and when checked the site via browser, it took _forever_ to load. It seems that they've changed the canonical home path, using 302 redirects to make it backwards compatible, but it's so larded down with ad code that it seems to have made Selenium time out.