### PR TITLE
Use docker-compose to run app in prod

### DIFF
--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -1,0 +1,13 @@
+version: "3.2"
+services:
+  app:
+    image: cfranklin11/tipresias_app:latest
+    ports:
+      - "80:80"
+    stdin_open: true
+    tty: true
+    env_file: .env
+    environment:
+      - DJANGO_SETTINGS_MODULE=project.settings.production
+      - DATABASE_NAME=${DATABASE_NAME:-tipresias}
+      - Node_ENV=production

--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -13,23 +13,19 @@ then
   sudo chmod 755 ~/.ssh
 fi
 
-docker pull ${DOCKER_IMAGE}
-docker build --cache-from ${DOCKER_IMAGE} -t ${DOCKER_IMAGE} .
-docker push ${DOCKER_IMAGE}
+# docker pull ${DOCKER_IMAGE}
+# docker build --cache-from ${DOCKER_IMAGE} -t ${DOCKER_IMAGE} .
+# docker push ${DOCKER_IMAGE}
+
+scp -i ~/.ssh/deploy_rsa -oStrictHostKeyChecking=no \
+  docker-compose.prod.yml \
+  ${DIGITAL_OCEAN_USER}@${PRODUCTION_HOST}:${APP_DIR}/docker-compose.yml
 
 RUN_APP="
   cd ${APP_DIR} \
     && docker pull ${DOCKER_IMAGE} \
-    && docker stop ${PROJECT_ID}_app \
-    && docker container rm ${PROJECT_ID}_app \
-    && docker run \
-      -d \
-      --env-file .env \
-      -p ${PORT}:${PORT} \
-      -e DJANGO_SETTINGS_MODULE=project.settings.production \
-      -e NODE_ENV=production \
-      --name ${PROJECT_ID}_app \
-      ${DOCKER_IMAGE}
+    && docker-compose stop \
+    && docker-compose up -d
 "
 
 # We use 'ssh' instead of 'doctl compute ssh' to be able to bypass key checking.

--- a/scripts/post_deploy.sh
+++ b/scripts/post_deploy.sh
@@ -2,8 +2,10 @@
 
 set -euo pipefail
 
+APP_DIR=/var/www/${PROJECT_ID}
+
 # This script runs the following commands:
-MIGRATE_DB="docker exec ${PROJECT_ID}_app python3 manage.py migrate"
+MIGRATE_DB="docker-compose run --rm app python3 manage.py migrate"
 
 # Re remove exited containers & prune images in order to avoid running out of disk space
 REMOVE_STALE_CONTAINERS="
@@ -17,6 +19,7 @@ PRUNE_IMAGES="yes | docker image prune"
 ssh -i ~/.ssh/deploy_rsa -oStrictHostKeyChecking=no \
   ${DIGITAL_OCEAN_USER}@${PRODUCTION_HOST} \
   "
+    cd ${APP_DIR}
     ${MIGRATE_DB}
     ${REMOVE_STALE_CONTAINERS}
     ${PRUNE_IMAGES}


### PR DESCRIPTION
This is a prerequisite for adding redis (at least without deploying
yet another server) for running background jobs.

This commit was part of a branch for implementing Redis job queues for long-running processes, but that's on hold while I debug some things, and the changes that I've already implemented in production are breaking deployments from other PRs.