### PR TITLE
Fix predictions in tipping

### DIFF
--- a/backend/server/models/prediction.py
+++ b/backend/server/models/prediction.py
@@ -5,6 +5,7 @@ from typing import Tuple, Optional
 from django.db import models, transaction
 from django.core.validators import MinValueValidator
 from django.utils.translation import gettext_lazy as _
+from django.utils import timezone
 from django.core.exceptions import ValidationError
 import numpy as np
 
@@ -30,7 +31,7 @@ class Prediction(models.Model):
 
     @classmethod
     def update_or_create_from_raw_data(
-        cls, prediction_data: CleanPredictionData
+        cls, prediction_data: CleanPredictionData, future_only=False
     ) -> None:
         """
         Convert raw prediction data to a Prediction model instance.
@@ -84,6 +85,10 @@ class Prediction(models.Model):
             )
 
         match = matches.first()
+
+        if future_only and match.start_date_time < timezone.now():
+            return None
+
         ml_model = MLModel.objects.get(name=prediction_data["ml_model"])
         matching_prediction_attributes = {"match": match, "ml_model": ml_model}
 

--- a/backend/server/tipping.py
+++ b/backend/server/tipping.py
@@ -118,6 +118,21 @@ class MonashSubmitter:
             if predicted_winner[competition_prediction_type] is not None
         }
 
+    @staticmethod
+    def _clean_numeric_input(
+        competition_prediction_type: PredictionType, prediction_value: float
+    ) -> str:
+        # Margin inputs are integers only, so float entries get converted to integers
+        # directly instead of rounded (e.g. 5.7 becomes 5)
+        prediction_number = (
+            prediction_value
+            if competition_prediction_type == "predicted_win_probability"
+            else round(prediction_value)
+        )
+
+        # Numeric value inputs are of type "text"
+        return str(prediction_number)
+
     def _login(self, competition: str) -> None:
         login_form = self.browser.find_by_css("form")
 
@@ -188,7 +203,7 @@ class MonashSubmitter:
             if predicted_winner is None:
                 continue
 
-            row_label_or_input.fill(str(predicted_winners[predicted_winner]))
+            row_label_or_input.fill(predicted_winners[predicted_winner])
 
     @staticmethod
     def _translate_team_name(element_text: str) -> str:

--- a/backend/server/tipping.py
+++ b/backend/server/tipping.py
@@ -426,7 +426,7 @@ class Tipper:
         home_away_df = pivot_team_matches_to_matches(prediction_data)
 
         for pred in home_away_df.replace({np.nan: None}).to_dict("records"):
-            Prediction.update_or_create_from_raw_data(pred)
+            Prediction.update_or_create_from_raw_data(pred, future_only=True)
 
         return None
 


### PR DESCRIPTION
Ran into a couple of bugs while trying to debug Selenium being cranky:

- Running the `tip` command updates all predictions for the current round, including for matches that have already been played, which is bad.
- Turns out that the Monash competition only accepts integer margin predictions and just truncates any floats.

Since we use `update_or_create_from_raw_data` in a few different contexts, I added a kwarg to prevent changing predictions for past matches, and updated the `MonashSubmitter` to properly clean the prediction inputs before filling out the form.