### PR TITLE
Disable javascript when submitting tips to footytips.com.au

### DIFF
--- a/backend/server/tipping.py
+++ b/backend/server/tipping.py
@@ -228,7 +228,9 @@ class FootyTipsSubmitter:
         browser: Selenium browser for navigating competition websites.
         verbose: How much information to print. 1 prints all messages; 0 prints none.
         """
-        self.browser = browser or Browser("firefox", headless=True)
+        self.browser = browser or Browser(
+            "firefox", headless=True, profile_preferences={"javascript.enabled": False}
+        )
         self.verbose = verbose
 
     def submit_tips(self, predicted_winners: List[PredictedWinner]) -> None:


### PR DESCRIPTION
Running tests on local, this speeds up the submission by roughly
25% (running about a minute rather than about a minute, 20
seconds), but doesn't seem to lower memory, which I think is the
main problem I'm having running this on prod. I'll probably just
have to increase the server size for the short term.