### PR TITLE
Fix browser test code coverage

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -56,7 +56,7 @@ after_script:
   # Also, trying to run the code coverage tool inside docker was more trouble than it's worth.
   - cd ./backend && ../cc-test-reporter format-coverage -t coverage.py -o ../coverage/codeclimate.backend.json && cd ..
   # Need to move coverage files to frontend, because filenames are relative to frontend root
-  - mv ./browser_test/coverage ./frontend
+  - sudo chmod 755 ./browser_test && sudo mv ./browser_test/coverage ./frontend
   - cd ./frontend && ../cc-test-reporter format-coverage -t lcov -o ../coverage/codeclimate.frontend.json && cd ..
   - ./cc-test-reporter sum-coverage ./coverage/codeclimate.*.json -p 2
   - if [[ "$TRAVIS_TEST_RESULT" == 0 ]]; then ./cc-test-reporter upload-coverage; fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -48,7 +48,10 @@ script:
   - ./scripts/update_frontend_gql_types.sh docker-compose.ci.yml
   - ./backend/scripts/integration_tests.sh docker-compose.ci.yml
   - ./scripts/browser_tests.sh docker-compose.ci.yml
-after_script:
+  # Code coverage
+  # Running code coverage commands in scripts instead of after_script,
+  # because after_script silently fails, and I don't check codeclimate often enough
+  # to catch problems early.
   # Only way I could get it to work was running format-coverage from each app's root.
   # Otherwise, it can't find files listed in coverage reports, because it uses $PWD,
   # and the --prefix option is to turn absolute paths into relative paths,

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -31,14 +31,6 @@ services:
     depends_on:
       - backend
     command: yarn start
-  storybook:
-    image: tipresias_frontend:latest
-    volumes:
-      - ./frontend:/app
-      - tipresias_node_modules:/app/node_modules
-    ports:
-      - "3333:3333"
-    command: yarn run storybook -h 0.0.0.0 -p 3333 --quiet
   browser_test:
     build: ./browser_test
     depends_on:

--- a/frontend/.babelrc
+++ b/frontend/.babelrc
@@ -1,9 +1,5 @@
 {
-  "env": {
-    "test": {
-      "plugins": [
-        "istanbul"
-      ]
-    }
-  }
+  "plugins": [
+    "istanbul"
+  ]
 }

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -4,7 +4,7 @@
   "private": true,
   "scripts": {
     "start": "react-app-rewired start",
-    "build": "react-app-rewired build",
+    "build": "react-scripts build",
     "test:eslint": "yarn run eslint 'src/**/*.js' --ext .jsx --ext .js",
     "test:flow": "yarn flow",
     "test:unit": "react-app-rewired test --env=jsdom",

--- a/scripts/browser_tests.sh
+++ b/scripts/browser_tests.sh
@@ -53,7 +53,7 @@ EXIT_CODE=$?
 
 #### CLEANUP ####
 # Need to stop before exiting to reset to non-test env vars
-docker-compose run --rm tipresias_db_1 psql \
+docker-compose exec db psql
   -U postgres \
   -d ${DATABASE_NAME} \
   --command "DROP DATABASE ${DATABASE_NAME}"


### PR DESCRIPTION
For some reason .babelrc isn't recognizing NODE_ENV or BABEL_ENV
so it always defaults to 'development'. I don't know if it's
babel or CRA or react rewired, and I don't feel like digging into
the internals. So, we'll just always use istanbul when running
a script with react rewired, and we'll just build with the
original CRA react-script command.

Also fixed up the `browser_test` script and removed the broken storybook service while I was at it.