### PR TITLE
Use Mechanical Soup for js-free sites

### DIFF
--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -17,6 +17,7 @@ gunicorn
 # Browser automation
 splinter==0.13.0
 selenium==3.141.0
+MechanicalSoup
 
 # Testing/Linting
 pylint==2.5.3

--- a/scripts/set_local_db_to_prod.sh
+++ b/scripts/set_local_db_to_prod.sh
@@ -23,7 +23,7 @@ docker-compose up -d db
 # Not ideal, but wait-for-it was listening for the port to be ready, but that
 # wasn't enough time for the DB to be ready to accept commands,
 # so we're sleeping instead
-sleep 4
+sleep 5
 
 cat $PWD/db/backups/${DATABASE_FILE} \
   | docker exec -i tipresias_db_1 psql -U postgres -d ${DATABASE_NAME}


### PR DESCRIPTION
I was planning on replacing selenium entirely with MechanicalSoup, but the FootyTips site isn't fully functional with basic requests, so I just replaced the use of selenium for submitting to Monash, which just uses basic markup.

I looked into Splash for replacing Selenium while still being able to run javascript, but it requires a separate docker container running the browser, which isn't as lightweight as I had hoped for. I suspect it still runs faster and uses less memory, but requiring a separate service means there isn't an easy way to refactor this into a serverless function, so it's not a high priority.