### PR TITLE
Fix tips submission

### DIFF
--- a/backend/server/models/prediction.py
+++ b/backend/server/models/prediction.py
@@ -34,7 +34,7 @@ class Prediction(models.Model):
     @classmethod
     def update_or_create_from_raw_data(
         cls, prediction_data: CleanPredictionData, future_only=False
-    ) -> None:
+    ) -> Optional["Prediction"]:
         """
         Convert raw prediction data to a Prediction model instance.
 
@@ -107,6 +107,8 @@ class Prediction(models.Model):
             prediction.full_clean()
             prediction.save()
             cls.update_correctness(prediction)
+
+        return prediction
 
     @classmethod
     def _calculate_predicted_margin(

--- a/backend/server/tests/fixtures/factories.py
+++ b/backend/server/tests/fixtures/factories.py
@@ -22,6 +22,7 @@ DEC = 12
 THIRTY_FIRST = 31
 MAR = 3
 ONE_WEEK = 7
+SIX_MONTHS_IN_WEEKS = 26
 
 # A full round with all teams playing each other currently has 9 matches.
 TYPICAL_N_MATCHES_PER_ROUND = 9
@@ -47,8 +48,11 @@ class TeamFactory(DjangoModelFactory):
 
 def _fake_datetime(match_factory, n, start_month_day=(MAR, FIRST)) -> datetime:
     round_week_delta = timedelta(days=ONE_WEEK)
-    start_round_week_delta = round_week_delta * math.ceil(
-        n / TYPICAL_N_MATCHES_PER_ROUND
+    start_round_week_delta = round_week_delta * (
+        # We cycle through six month periods, because the sequence doesn't reset
+        # between tests and eventually hits the end of the year for every test.
+        math.ceil(n / TYPICAL_N_MATCHES_PER_ROUND)
+        % SIX_MONTHS_IN_WEEKS
     )
     # Since we create match records per year, we don't want want dates running
     # into the next year.

--- a/backend/server/tests/fixtures/factories.py
+++ b/backend/server/tests/fixtures/factories.py
@@ -108,7 +108,7 @@ class MatchFactory(DjangoModelFactory):
 
     start_date_time = factory.LazyAttributeSequence(_fake_datetime)
     round_number = factory.Sequence(
-        lambda n: math.ceil(n / TYPICAL_N_MATCHES_PER_ROUND)
+        lambda n: math.ceil((n + 1) / TYPICAL_N_MATCHES_PER_ROUND)
         % N_ROUNDS_PER_REGULAR_SEASON
     )
     venue = factory.LazyFunction(

--- a/backend/server/tests/unit/test_views.py
+++ b/backend/server/tests/unit/test_views.py
@@ -22,7 +22,8 @@ class TestViews(TestCase):
             name="test_estimator", is_principal=True, used_in_competitions=True
         )
         self.matches = [
-            factories.FullMatchFactory(future=True) for _ in range(N_MATCHES)
+            factories.FullMatchFactory(future=True, round_number=5)
+            for _ in range(N_MATCHES)
         ]
         self.views = views
 

--- a/backend/server/tests/unit/test_views.py
+++ b/backend/server/tests/unit/test_views.py
@@ -21,7 +21,9 @@ class TestViews(TestCase):
         self.ml_model = factories.MLModelFactory(
             name="test_estimator", is_principal=True, used_in_competitions=True
         )
-        self.matches = [factories.FullMatchFactory() for _ in range(N_MATCHES)]
+        self.matches = [
+            factories.FullMatchFactory(future=True) for _ in range(N_MATCHES)
+        ]
         self.views = views
 
     def test_predictions(self):
@@ -115,6 +117,7 @@ class TestViews(TestCase):
             # It returns the updated predictions
             prediction_response = json.loads(response.content)
             self.assertEqual(len(prediction_response), N_MATCHES)
+
             for pred in prediction_response:
                 self.assertEqual(
                     {

--- a/backend/server/tests/unit/test_views.py
+++ b/backend/server/tests/unit/test_views.py
@@ -1,5 +1,7 @@
 # pylint: disable=missing-docstring
 
+import json
+
 from django.test import TestCase, RequestFactory
 from django.utils import timezone
 import pandas as pd
@@ -68,9 +70,21 @@ class TestViews(TestCase):
                 response = views.predictions(request)
 
                 # It creates predictions
-                self.assertEqual(Prediction.objects.count(), 9)
+                self.assertEqual(Prediction.objects.count(), N_MATCHES)
                 # It returns success response
                 self.assertEqual(response.status_code, 200)
+                # It returns the created predictions
+                prediction_response = json.loads(response.content)
+                self.assertEqual(len(prediction_response), N_MATCHES)
+                for pred in prediction_response:
+                    self.assertEqual(
+                        {
+                            "predicted_winner__name",
+                            "predicted_margin",
+                            "predicted_win_probability",
+                        },
+                        set(pred.keys()),
+                    )
 
         with self.subTest("with existing prediction records"):
             original_predicted_margins = list(
@@ -98,6 +112,18 @@ class TestViews(TestCase):
             self.assertEqual(original_predicted_margins, posted_predicted_margins)
             # It returns a success response
             self.assertEqual(response.status_code, 200)
+            # It returns the updated predictions
+            prediction_response = json.loads(response.content)
+            self.assertEqual(len(prediction_response), N_MATCHES)
+            for pred in prediction_response:
+                self.assertEqual(
+                    {
+                        "predicted_winner__name",
+                        "predicted_margin",
+                        "predicted_win_probability",
+                    },
+                    set(pred.keys()),
+                )
 
     def test_fixtures(self):
         max_round = Match.objects.order_by("-round_number").first().round_number

--- a/backend/server/views.py
+++ b/backend/server/views.py
@@ -13,7 +13,7 @@ from server import api
 from server.types import FixtureData, MatchData
 
 
-def predictions(request: HttpRequest):
+def predictions(request: HttpRequest, verbose=1):
     """Handle POST request to /predictions with prediction data in the body."""
     if request.method != "POST":
         return HttpResponse(status=405)
@@ -27,21 +27,11 @@ def predictions(request: HttpRequest):
 
     body = json.loads(request.body)
     prediction_data = body["data"]
-    prediction_records = []
 
     for pred in prediction_data:
-        prediction = Prediction.update_or_create_from_raw_data(pred)
+        Prediction.update_or_create_from_raw_data(pred)
 
-        if prediction is None:
-            continue
-
-        prediction_records.append(
-            {
-                "predicted_winner__name": prediction.predicted_winner.name,
-                "predicted_margin": prediction.predicted_margin,
-                "predicted_win_probability": prediction.predicted_win_probability,
-            },
-        )
+    prediction_records = list(api.fetch_latest_round_predictions(verbose=verbose))
 
     return HttpResponse(
         content=json.dumps(prediction_records),

--- a/backend/server/views.py
+++ b/backend/server/views.py
@@ -27,11 +27,27 @@ def predictions(request: HttpRequest):
 
     body = json.loads(request.body)
     prediction_data = body["data"]
+    prediction_records = []
 
     for pred in prediction_data:
-        Prediction.update_or_create_from_raw_data(pred)
+        prediction = Prediction.update_or_create_from_raw_data(pred)
 
-    return HttpResponse("Success", status=200)
+        if prediction is None:
+            continue
+
+        prediction_records.append(
+            {
+                "predicted_winner__name": prediction.predicted_winner.name,
+                "predicted_margin": prediction.predicted_margin,
+                "predicted_win_probability": prediction.predicted_win_probability,
+            },
+        )
+
+    return HttpResponse(
+        content=json.dumps(prediction_records),
+        content_type="application/json",
+        status=200,
+    )
 
 
 def fixtures(request: HttpRequest, verbose=1):
@@ -57,7 +73,7 @@ def fixtures(request: HttpRequest, verbose=1):
         cast(List[FixtureData], fixture_data), upcoming_round, verbose=verbose
     )
 
-    return HttpResponse("Success", status=200)
+    return HttpResponse("Success", content_type="application/json", status=200)
 
 
 def matches(request: HttpRequest, verbose=1):
@@ -82,4 +98,4 @@ def matches(request: HttpRequest, verbose=1):
         cast(List[MatchData], match_data), verbose=verbose
     )
 
-    return HttpResponse("Success", status=200)
+    return HttpResponse("Success", content_type="application/json", status=200)

--- a/tipping/src/tests/unit/test_api.py
+++ b/tipping/src/tests/unit/test_api.py
@@ -137,20 +137,18 @@ class TestApi(TestCase):
         )
         # It returns predictions organised by match
         self.assertEqual(
-            set(
-                [
-                    "home_team",
-                    "year",
-                    "round_number",
-                    "away_team",
-                    "ml_model",
-                    "home_predicted_margin",
-                    "away_predicted_margin",
-                    "home_predicted_win_probability",
-                    "away_predicted_win_probability",
-                ]
-            ),
-            set(prediction_response[0].keys()),
+            {
+                "home_team",
+                "year",
+                "round_number",
+                "away_team",
+                "ml_model",
+                "home_predicted_margin",
+                "away_predicted_margin",
+                "home_predicted_win_probability",
+                "away_predicted_win_probability",
+            },
+            set(prediction_response.columns),
         )
         self.assertEqual(N_MATCHES, len(prediction_response))
 
@@ -174,22 +172,20 @@ class TestApi(TestCase):
         )
         # It returns match data
         self.assertEqual(
-            set(
-                [
-                    "date",
-                    "year",
-                    "round",
-                    "round_number",
-                    "home_team",
-                    "away_team",
-                    "venue",
-                    "home_score",
-                    "away_score",
-                    "match_id",
-                    "crowd",
-                ]
-            ),
-            set(match_response[0].keys()),
+            {
+                "date",
+                "year",
+                "round",
+                "round_number",
+                "home_team",
+                "away_team",
+                "venue",
+                "home_score",
+                "away_score",
+                "match_id",
+                "crowd",
+            },
+            set(match_response.columns),
         )
         self.assertEqual(N_MATCHES, len(match_response))
 
@@ -205,8 +201,8 @@ class TestApi(TestCase):
         mock_data_import.fetch_ml_model_info.assert_called()
         # It returns ML model data
         self.assertEqual(
-            set(["name", "prediction_type", "trained_to", "data_set", "label_col",]),
-            set(ml_model_response[0].keys()),
+            {"name", "prediction_type", "trained_to", "data_set", "label_col"},
+            set(ml_model_response.columns),
         )
         self.assertEqual(N_ML_MODELS, len(ml_model_response))
 

--- a/tipping/src/tests/unit/test_helpers.py
+++ b/tipping/src/tests/unit/test_helpers.py
@@ -3,9 +3,14 @@
 from unittest import TestCase
 
 import pandas as pd
+import numpy as np
 
-from tipping.helpers import pivot_team_matches_to_matches
-from tests.fixtures.data_factories import fake_prediction_data
+from tests.fixtures.data_factories import fake_prediction_data, fake_match_results_data
+from tipping.helpers import pivot_team_matches_to_matches, convert_to_dict
+
+
+N_MATCHES = 9
+YEAR_RANGE = (2013, 2014)
 
 
 class TestHelpers(TestCase):
@@ -23,3 +28,18 @@ class TestHelpers(TestCase):
 
         self.assertNotIn("team", match_df.columns)
         self.assertNotIn("oppo_team", match_df.columns)
+
+    def test_convert_to_dict(self):
+        match_df = fake_match_results_data(N_MATCHES, YEAR_RANGE)
+        match_df.loc[:, "crowd"] = np.nan
+        match_records = convert_to_dict(match_df)
+
+        # It converts the df to a list of dicts
+        self.assertIsInstance(match_records, list)
+        self.assertIsInstance(match_records[0], dict)
+        self.assertEqual(set(match_df.columns), set(match_records[0].keys()))
+
+        # It converts pandas/numpy dtypes to Python equivalents
+        for match in match_records:
+            self.assertEqual(match["crowd"], None)
+            self.assertIsInstance(match["date"], str)

--- a/tipping/src/tipping/api.py
+++ b/tipping/src/tipping/api.py
@@ -109,12 +109,12 @@ def update_match_predictions(tips_submitters=None, verbose=1) -> None:
         print("Predictions received!")
 
     match_predictions = pivot_team_matches_to_matches(prediction_data)
-    data_export.update_match_predictions(match_predictions)
+    updated_prediction_records = data_export.update_match_predictions(match_predictions)
 
     if verbose == 1:
         print("Match predictions sent!")
 
-    if not match_predictions.any().any():
+    if not updated_prediction_records.any().any():
         if verbose == 1:
             print(
                 "No predictions found for the upcoming round. "
@@ -129,7 +129,7 @@ def update_match_predictions(tips_submitters=None, verbose=1) -> None:
     ]
 
     for submitter in tips_submitters:
-        submitter.submit_tips(match_predictions)
+        submitter.submit_tips(updated_prediction_records)
 
     return None
 

--- a/tipping/src/tipping/data_export.py
+++ b/tipping/src/tipping/data_export.py
@@ -1,12 +1,12 @@
 """Module for exporting data to the main Tipresias app."""
 
-from typing import Optional, Dict, Any, List
+from typing import Optional, Dict, Any
 from urllib.parse import urljoin
 
-import numpy as np
 import pandas as pd
 import requests
 
+from tipping.helpers import convert_to_dict
 from tipping import settings
 
 
@@ -35,11 +35,6 @@ def _send_data(path: str, body: Optional[Dict[str, Any]] = None) -> None:
     )
 
 
-def _convert_to_dict(data_frame: pd.DataFrame) -> List[Dict[str, Any]]:
-    type_conversion = {"date": str} if "date" in data_frame.columns else {}
-    return data_frame.replace({np.nan: None}).astype(type_conversion).to_dict("records")
-
-
 def update_fixture_data(fixture_data: pd.DataFrame, upcoming_round: int):
     """
     POST fixture data to main Tipresias app.
@@ -49,7 +44,7 @@ def update_fixture_data(fixture_data: pd.DataFrame, upcoming_round: int):
     fixture_data: Data for future matches.
     upcoming_round: Either the current round if ongoing or the next round to be played.
     """
-    body = {"upcoming_round": upcoming_round, "data": _convert_to_dict(fixture_data)}
+    body = {"upcoming_round": upcoming_round, "data": convert_to_dict(fixture_data)}
 
     _send_data("/fixtures", body=body)
 
@@ -63,7 +58,7 @@ def update_match_predictions(prediction_data: pd.DataFrame):
     prediction_data: Predictions from ML models, organised to have one match per row.
     """
     body = {
-        "data": _convert_to_dict(prediction_data),
+        "data": convert_to_dict(prediction_data),
     }
 
     _send_data("/predictions", body=body)
@@ -78,7 +73,7 @@ def update_match_results(match_data: pd.DataFrame):
     match_data: Data from played matches, especially finally scores.
     """
     body = {
-        "data": _convert_to_dict(match_data),
+        "data": convert_to_dict(match_data),
     }
 
     _send_data("/matches", body=body)

--- a/tipping/src/tipping/helpers.py
+++ b/tipping/src/tipping/helpers.py
@@ -1,7 +1,8 @@
 """Helper functions."""
 
-from typing import Dict, Callable
+from typing import Dict, Callable, List, Any
 import pandas as pd
+import numpy as np
 
 
 NON_METRIC_COLS = ["home_team", "away_team", "year", "round_number", "ml_model"]
@@ -54,3 +55,19 @@ def pivot_team_matches_to_matches(team_match_df: pd.DataFrame) -> pd.DataFrame:
         on=["home_team", "away_team", "year", "round_number", "ml_model"],
         how="inner",
     )
+
+
+def convert_to_dict(data_frame: pd.DataFrame) -> List[Dict[str, Any]]:
+    """
+    Convert DataFrame to list of record dicts with necessary dtype conversions.
+
+    Params:
+    -------
+    data_frame: Any old data frame you choose.
+
+    Returns:
+    --------
+    List of dicts.
+    """
+    type_conversion = {"date": str} if "date" in data_frame.columns else {}
+    return data_frame.replace({np.nan: None}).astype(type_conversion).to_dict("records")

--- a/tipping/src/tipping/tipping.py
+++ b/tipping/src/tipping/tipping.py
@@ -257,7 +257,7 @@ class FootyTipsSubmitter:
                 "username": os.environ["FOOTY_TIPS_USERNAME"],
                 "password": os.environ["FOOTY_TIPS_PASSWORD"],
                 "predictions": predictions,
-                "settings.team_translations": settings.TEAM_TRANSLATIONS,
+                "team_translations": settings.TEAM_TRANSLATIONS,
             },
         )
 

--- a/tipping/src/tipping/types.py
+++ b/tipping/src/tipping/types.py
@@ -6,6 +6,16 @@ from datetime import datetime
 from mypy_extensions import TypedDict
 from pandas import Timestamp
 
+
+MatchPrediction = TypedDict(
+    "MatchPrediction",
+    {
+        "predicted_winner__name": str,
+        "predicted_margin": float,
+        "predicted_win_probability": float,
+    },
+)
+
 CleanPredictionData = TypedDict(
     "CleanPredictionData",
     {


### PR DESCRIPTION
Lots of bugs to fix when you merge a giant PR all willy-nilly, especially without any real integration tests. The tips submitters are particularly difficult to test, since I don't want to be logging into sites and submitting random tips as part of my test suite, but I could probably mock them a bit closer to the metal. I should also have better integration tests for the app and the tipping functions, which I could get with a similar setup/teardown to what we have for browser tests.

This mostly just fixes typos & oversights from the restructuring PR, because there were some cases of arguments being incompatible with what the function was expecting, so I made transformation of data structures a bit more consistent.