### PR TITLE
Fix metrics query for when latest matches don't have results

### DIFF
--- a/backend/server/tests/unit/test_schema.py
+++ b/backend/server/tests/unit/test_schema.py
@@ -583,6 +583,17 @@ class TestSchema(TestCase):
         # which would suggest a problem
         self.assertNotEqual(data["cumulativeBits"], 0)
 
+        with self.subTest("when the last matches don't have updated results yet"):
+            TeamMatch.objects.filter(
+                match__start_date_time__year=YEAR, match__round_number=ROUND_COUNT
+            ).update(score=0)
+
+            executed = self.client.execute(query)
+            data = executed["data"]["fetchLatestRoundMetrics"]
+
+            # It fetches latest round with results
+            self.assertEqual(data["roundNumber"], ROUND_COUNT - 1)
+
         with self.subTest("when the last matches haven't been played yet"):
             DAY = 3
             fake_datetime = timezone.make_aware(datetime(YEAR, MONTH, DAY))


### PR DESCRIPTION
I updated the latest round metrics to filter out past matches
without results, but needed to update the latest match filter
as well to avoid errors from mismatched "max" round numbers.