### PR TITLE
Fallback to earlier predictions if matches don't have them

### DIFF
--- a/backend/server/graphql/types/season.py
+++ b/backend/server/graphql/types/season.py
@@ -147,14 +147,9 @@ class RoundPredictionType(graphene.ObjectType):
                     )
                 }
             )
+            .replace({np.nan: None})
             .to_dict("records")
         )
-
-        # to_dict converts None to Python's NaN, which boolean coerces to True,
-        # making is_correct True for all future matches
-        for pred in competition_predictions:
-            if math.isnan(pred["is_correct"]):
-                pred["is_correct"] = None
 
         return competition_predictions
 

--- a/backend/server/graphql/types/season.py
+++ b/backend/server/graphql/types/season.py
@@ -3,7 +3,6 @@
 from typing import List, cast, Optional, Callable
 from functools import partial
 from datetime import datetime
-import math
 
 from django.db.models import QuerySet
 import graphene

--- a/backend/server/tests/unit/test_schema.py
+++ b/backend/server/tests/unit/test_schema.py
@@ -1,4 +1,5 @@
 # pylint: disable=missing-docstring
+
 from datetime import datetime
 from dateutil import parser
 
@@ -380,6 +381,17 @@ class TestSchema(TestCase):
                 pred["isCorrect"] for pred in data["matchPredictions"]
             }
             self.assertEqual(set([None]), unique_is_correct_values)
+
+            with self.subTest("that don't have predictions yet"):
+                Prediction.objects.filter(
+                    match__start_date_time__gt=timezone.now()
+                ).delete()
+
+                executed = self.client.execute(query_string)
+                data = executed["data"]["fetchLatestRoundPredictions"]
+
+                # It returns predictions from the last round that has them
+                self.assertEqual(data["roundNumber"], max_round_number)
 
     # Keeping this in a separate test, because it requires special setup
     # to properly test metric calculations

--- a/tipping/serverless.yml
+++ b/tipping/serverless.yml
@@ -67,8 +67,8 @@ functions:
     handler: handler.update_match_predictions
     events:
       - schedule:
-          # Tuesday-Saturday, 9pm UTC (next day, 7am/8am Melbourne time, depending on DST)
-          rate: cron(0 21 ? * 3-7 *)
+          # Sunday-Saturday, 9pm UTC (next day, 7am/8am Melbourne time, depending on DST)
+          rate: cron(0 21 ? * 1-7 *)
           enabled: true
   update_match_results:
     handler: handler.update_match_results


### PR DESCRIPTION
By making our data updates less synchronised, we've uncovered
some unnoticed coupling in our data, like the fact that we
assumed that matches would always have predictions. That is no
longer the case, so we fall back to previous round's predictions
while we wait for them to catch up.