### PR TITLE
Add cumulativeCorrectCount to line chart metrics

### DIFF
--- a/frontend/src/containers/App/index.js
+++ b/frontend/src/containers/App/index.js
@@ -37,7 +37,12 @@ const App = () => {
   } = data;
 
 
-  const metrics = ['cumulativeAccuracy', 'cumulativeBits', 'cumulativeMeanAbsoluteError'];
+  const metrics = [
+    'cumulativeAccuracy',
+    'cumulativeBits',
+    'cumulativeMeanAbsoluteError',
+    'cumulativeCorrectCount',
+  ];
 
 
   return (


### PR DESCRIPTION
It doesn't make for a great visualisation due to the large
numbers and the small differences between models, but sometimes
I want to be able to compare models via the most-commonly used
tipping metric. And competition sites display totals rather than
means.