### PR TITLE
Use api module for updating prediction data

### DIFF
--- a/backend/server/tests/fixtures/data_factories.py
+++ b/backend/server/tests/fixtures/data_factories.py
@@ -184,6 +184,7 @@ def fake_prediction_data(
         match_data_for_pred = fake_fixture_data(1, (2018, 2019)).iloc[0, :]
     elif isinstance(match_data, Match):
         match_data_for_pred = {
+            "date": match_data.start_date_time,
             "home_team": match_data.teammatch_set.get(at_home=1).team.name,
             "away_team": match_data.teammatch_set.get(at_home=0).team.name,
             "year": match_data.start_date_time.year,
@@ -200,6 +201,7 @@ def fake_prediction_data(
     return pd.DataFrame(
         [
             {
+                "date": match_data_for_pred["date"],
                 "home_team": match_data_for_pred["home_team"],
                 "away_team": match_data_for_pred["away_team"],
                 "year": match_data_for_pred["year"],

--- a/backend/server/tests/integration/management/commands/test_seed_db.py
+++ b/backend/server/tests/integration/management/commands/test_seed_db.py
@@ -46,6 +46,7 @@ class TestSeedDb(TestCase):
         ).to_dict("records"):
 
             match_data = {
+                "date": match_result["date"],
                 "home_team": match_result["home_team"],
                 "away_team": match_result["away_team"],
                 "year": match_result["year"],

--- a/backend/server/tests/integration/test_urls.py
+++ b/backend/server/tests/integration/test_urls.py
@@ -19,7 +19,7 @@ class TestUrls(TestCase):
 
     def test_predictions(self):
         ml_model = MLModel.objects.get(is_principal=True)
-        matches = [factories.FullMatchFactory() for _ in range(N_MATCHES)]
+        matches = [factories.FullMatchFactory(future=True) for _ in range(N_MATCHES)]
         prediction_data = pd.concat(
             [
                 data_factories.fake_prediction_data(

--- a/backend/server/views.py
+++ b/backend/server/views.py
@@ -8,7 +8,6 @@ from dateutil import parser
 from django.http import HttpRequest, HttpResponse
 from django.conf import settings
 
-from server.models import Prediction
 from server import api
 from server.types import FixtureData, MatchData
 
@@ -28,9 +27,7 @@ def predictions(request: HttpRequest, verbose=1):
     body = json.loads(request.body)
     prediction_data = body["data"]
 
-    for pred in prediction_data:
-        Prediction.update_or_create_from_raw_data(pred)
-
+    api.update_future_match_predictions(prediction_data)
     prediction_records = list(api.fetch_latest_round_predictions(verbose=verbose))
 
     return HttpResponse(


### PR DESCRIPTION
I meant to use api for all view functions to keep as much logic
out of the views as possible, but forgot in the case of updating
predictions. This meant that we weren't applying to condition of
only updating predictions for future matches.