### PR TITLE
Rename match_results methods to matches

### DIFF
--- a/backend/server/management/commands/seed_db.py
+++ b/backend/server/management/commands/seed_db.py
@@ -27,11 +27,11 @@ class DataImporter:
         """
         return cast(List[MLModel], self._fetch_data("ml_models"))
 
-    def fetch_match_results(
+    def fetch_matches(
         self, start_date: str, end_date: str, fetch_data: bool = False
     ) -> List[MatchData]:
         """
-        Fetch results data for past matches.
+        Fetch data for past matches.
 
         Params:
         -------
@@ -44,7 +44,7 @@ class DataImporter:
 
         Returns:
         --------
-            List of match results data dicts.
+            List of match data dicts.
         """
         return cast(
             List[MatchData],
@@ -236,7 +236,7 @@ class Command(BaseCommand):
         return ml_models
 
     def _create_matches(self) -> None:
-        match_data = self.data_importer.fetch_match_results(
+        match_data = self.data_importer.fetch_matches(
             start_date=f"{self._year_range[0]}-01-01",
             end_date=f"{self._year_range[1] - 1}-12-31",
             fetch_data=self.fetch_data,

--- a/backend/server/tests/integration/management/commands/test_seed_db.py
+++ b/backend/server/tests/integration/management/commands/test_seed_db.py
@@ -63,7 +63,7 @@ class TestSeedDb(TestCase):
         mock_data_import.fetch_match_predictions = MagicMock(
             return_value=pd.concat(prediction_data).reset_index().to_dict("records")
         )
-        mock_data_import.fetch_match_results = MagicMock(
+        mock_data_import.fetch_matches = MagicMock(
             side_effect=self.__match_results_side_effect
         )
         mock_data_import.fetch_ml_models = MagicMock(

--- a/tipping/handler.py
+++ b/tipping/handler.py
@@ -70,7 +70,7 @@ def update_match_results(_event, _context, verbose=1):
 
     verbose: How much information to print. 1 prints all messages; 0 prints none.
     """
-    api.update_match_results(verbose=verbose)
+    api.update_matches(verbose=verbose)
 
     return _response("Success")
 
@@ -123,9 +123,9 @@ def fetch_match_predictions(event, _context):
     return _response(response_data)
 
 
-def fetch_match_results(event, _context) -> Response:
+def fetch_matches(event, _context) -> Response:
     """
-    Fetch results data for past matches.
+    Fetch data for past matches.
 
     Params:
     -------
@@ -139,7 +139,7 @@ def fetch_match_results(event, _context) -> Response:
 
     Returns:
     --------
-    List of match results data in a JSON body.
+    List of match data in a JSON body.
     """
     if not _request_is_authorized(event):
         return _response("Unauthorized", status_code=401)
@@ -151,7 +151,7 @@ def fetch_match_results(event, _context) -> Response:
     response_data = cast(
         List[MatchData],
         convert_to_dict(
-            api.fetch_match_results(event["start_date"], event["end_date"], **kwargs)
+            api.fetch_matches(event["start_date"], event["end_date"], **kwargs)
         ),
     )
 

--- a/tipping/src/tests/integration/test_tipping.py
+++ b/tipping/src/tests/integration/test_tipping.py
@@ -47,7 +47,7 @@ class TestTipper(TestCase):
         mock_data_import.fetch_fixture_data = Mock(
             side_effect=self.fixture_return_values[:1] + self.fixture_return_values
         )
-        mock_data_import.fetch_match_results_data = Mock(
+        mock_data_import.fetch_match_data = Mock(
             return_value=match_results_return_values[0]
         )
 

--- a/tipping/src/tests/unit/test_api.py
+++ b/tipping/src/tests/unit/test_api.py
@@ -153,21 +153,21 @@ class TestApi(TestCase):
         self.assertEqual(N_MATCHES, len(prediction_response))
 
     @patch("tipping.api.data_import")
-    def test_fetch_match_results(self, mock_data_import):
+    def test_fetch_matches(self, mock_data_import):
         matches = data_factories.fake_match_results_data(N_MATCHES, YEAR_RANGE)
-        mock_data_import.fetch_match_results_data = MagicMock(return_value=matches)
+        mock_data_import.fetch_match_data = MagicMock(return_value=matches)
 
         match_dates = np.random.choice(matches["date"], size=2)
         fetch_data = bool(np.random.randint(0, 2))
 
-        match_response = self.api.fetch_match_results(
+        match_response = self.api.fetch_matches(
             start_date=min(match_dates),
             end_date=max(match_dates),
             fetch_data=fetch_data,
         )
 
-        # It calls fetch_match_results_data with the same params
-        mock_data_import.fetch_match_results_data.assert_called_with(
+        # It calls fetch_match_data with the same params
+        mock_data_import.fetch_match_data.assert_called_with(
             min(match_dates), max(match_dates), fetch_data=fetch_data,
         )
         # It returns match data

--- a/tipping/src/tests/unit/test_data_export.py
+++ b/tipping/src/tests/unit/test_data_export.py
@@ -87,7 +87,7 @@ class TestDataExport(TestCase):
                 self.data_export.update_match_predictions(fake_predictions)
 
     @patch("tipping.data_export.requests")
-    def test_update_match_results(self, mock_requests):
+    def test_update_matches(self, mock_requests):
         mock_response = MagicMock()
         mock_response.status_code = 200
         mock_response.headers = {}
@@ -97,7 +97,7 @@ class TestDataExport(TestCase):
 
         url = settings.TIPRESIAS_APP + "/matches"
         fake_matches = data_factories.fake_match_results_data(N_MATCHES, YEAR_RANGE)
-        self.data_export.update_match_results(fake_matches)
+        self.data_export.update_matches(fake_matches)
 
         # It posts the data
         matches_response = fake_matches.astype({"date": str}).to_dict("records")

--- a/tipping/src/tipping/api.py
+++ b/tipping/src/tipping/api.py
@@ -134,9 +134,9 @@ def update_match_predictions(tips_submitters=None, verbose=1) -> None:
     return None
 
 
-def update_match_results(verbose=1) -> None:
+def update_matches(verbose=1) -> None:
     """
-    Fetch match results data and send them to the main app.
+    Fetch match data and send them to the main app.
 
     verbose: How much information to print. 1 prints all messages; 0 prints none.
     """
@@ -145,19 +145,19 @@ def update_match_results(verbose=1) -> None:
     end_of_year = datetime(right_now.year, DEC, THIRTY_FIRST)
 
     if verbose == 1:
-        print(f"Fetching match results for season {right_now.year}")
+        print(f"Fetching match data for season {right_now.year}")
 
-    match_data = data_import.fetch_match_results_data(
+    match_data = data_import.fetch_match_data(
         str(start_of_year), str(end_of_year), fetch_data=True
     )
 
     if verbose == 1:
-        print("Match results reveived!")
+        print("Match data reveived!")
 
-    data_export.update_match_results(match_data)
+    data_export.update_matches(match_data)
 
     if verbose == 1:
-        print("Match results sent!")
+        print("Match data sent!")
 
 
 def fetch_match_predictions(
@@ -192,7 +192,7 @@ def fetch_match_predictions(
     return pivot_team_matches_to_matches(prediction_data)
 
 
-def fetch_match_results(
+def fetch_matches(
     start_date: str, end_date: str, fetch_data: bool = False
 ) -> pd.DataFrame:
     """
@@ -211,9 +211,7 @@ def fetch_match_results(
     --------
         List of match results data dicts.
     """
-    return data_import.fetch_match_results_data(
-        start_date, end_date, fetch_data=fetch_data
-    )
+    return data_import.fetch_match_data(start_date, end_date, fetch_data=fetch_data)
 
 
 def fetch_ml_models() -> pd.DataFrame:

--- a/tipping/src/tipping/data_export.py
+++ b/tipping/src/tipping/data_export.py
@@ -68,7 +68,7 @@ def update_match_predictions(prediction_data: pd.DataFrame) -> pd.DataFrame:
     return pd.DataFrame(predictions)
 
 
-def update_match_results(match_data: pd.DataFrame):
+def update_matches(match_data: pd.DataFrame):
     """
     POST match data to main Tipresias app.
 

--- a/tipping/src/tipping/data_import.py
+++ b/tipping/src/tipping/data_import.py
@@ -137,11 +137,11 @@ def fetch_fixture_data(start_date: datetime, end_date: datetime) -> pd.DataFrame
     return fixtures
 
 
-def fetch_match_results_data(
+def fetch_match_data(
     start_date: str, end_date: str, fetch_data: bool = False
 ) -> pd.DataFrame:
     """
-    Fetch results data for past matches from machine_learning module.
+    Fetch data for past matches from machine_learning module.
 
     Params:
     -------
@@ -154,19 +154,19 @@ def fetch_match_results_data(
 
     Returns:
     --------
-    pandas.DataFrame with match results data.
+    pandas.DataFrame with match data.
     """
-    match_results = pd.DataFrame(
+    matches = pd.DataFrame(
         _fetch_data(
-            "match_results",
+            "matches",
             {"start_date": start_date, "end_date": end_date, "fetch_data": fetch_data},
         )
     )
 
-    if any(match_results):
-        return match_results.assign(date=_parse_dates)
+    if any(matches):
+        return matches.assign(date=_parse_dates)
 
-    return match_results
+    return matches
 
 
 def fetch_ml_model_info() -> pd.DataFrame:


### PR DESCRIPTION
This is in anticipation of adding a match results data source
for mid-round updates. I left `update_match_results` alone,
because it will eventually use the new API endpoint.