### PR TITLE
Add update_match_results function to regularly update scores

### DIFF
--- a/tipping/handler.py
+++ b/tipping/handler.py
@@ -75,6 +75,17 @@ def update_matches(_event, _context, verbose=1):
     return _response("Success")
 
 
+def update_match_results(_event, _context, verbose=1):
+    """
+    Fetch match data and send them to the main app.
+
+    verbose: How much information to print. 1 prints all messages; 0 prints none.
+    """
+    api.update_match_results(verbose=verbose)
+
+    return _response("Success")
+
+
 def fetch_match_predictions(event, _context):
     """
     Get match predictions from ML models.

--- a/tipping/handler.py
+++ b/tipping/handler.py
@@ -64,9 +64,9 @@ def update_match_predictions(_event, _context, verbose=1):
     return _response("Success")
 
 
-def update_match_results(_event, _context, verbose=1):
+def update_matches(_event, _context, verbose=1):
     """
-    Fetch match results data and send them to the main app.
+    Fetch match data and send them to the main app.
 
     verbose: How much information to print. 1 prints all messages; 0 prints none.
     """

--- a/tipping/serverless.yml
+++ b/tipping/serverless.yml
@@ -70,12 +70,12 @@ functions:
           # Sunday-Saturday, 9pm UTC (next day, 7am/8am Melbourne time, depending on DST)
           rate: cron(0 21 ? * 1-7 *)
           enabled: true
-  update_match_results:
-    handler: handler.update_match_results
+  update_matches:
+    handler: handler.update_matches
     events:
       - schedule:
-          # Monday-Tuesday, 9pm UTC (next day, 7am/8am Melbourne time, depending on DST)
-          rate: cron(0 21 ? * 2-3 *)
+          # Tuesday, 9pm UTC (next day, 7am/8am Melbourne time, depending on DST)
+          rate: cron(0 21 ? * 3 *)
           enabled: true
   fetch_match_predictions:
     handler: handler.fetch_match_predictions

--- a/tipping/serverless.yml
+++ b/tipping/serverless.yml
@@ -77,6 +77,15 @@ functions:
           # Tuesday, 9pm UTC (next day, 7am/8am Melbourne time, depending on DST)
           rate: cron(0 21 ? * 3 *)
           enabled: true
+  update_match_results:
+    handler: handler.update_match_results
+    events:
+      - schedule:
+          # TODO: This is running every day during Footy Mania, but should run
+          # Thurs-Sun during normal AFL rounds
+          # Every day, 2am-2pm UTC (next day, 12pm/1pm-12am/1am Melbourne time, depending on DST)
+          rate: cron(0 2-14/3 ? * * *)
+          enabled: true
   fetch_match_predictions:
     handler: handler.fetch_match_predictions
     events:

--- a/tipping/src/tests/fixtures/data_factories.py
+++ b/tipping/src/tests/fixtures/data_factories.py
@@ -1,7 +1,7 @@
 """Module for factory functions that create raw data objects."""
 
 from typing import List, Dict, Tuple, Union
-from datetime import datetime, timedelta
+from datetime import datetime, timedelta, date
 import itertools
 import pytz
 
@@ -170,6 +170,60 @@ def fake_fixture_data(row_count: int, year_range: Tuple[int, int]) -> pd.DataFra
     reduced_data = list(itertools.chain.from_iterable(data))
 
     return pd.DataFrame(list(reduced_data))
+
+
+def _results_by_match(round_number: int, team_names: CyclicalTeamNames):
+    home_team = team_names.next_team()
+    away_team = team_names.next_team()
+    winner = np.random.choice([home_team, away_team])
+    match_date = FAKE.date_time_between_dates(
+        **_min_max_datetimes_by_year(date.today().year)
+    )
+
+    return {
+        "date": str(match_date),
+        "tz": "+10:00",
+        "updated": str(match_date + timedelta(hours=3)),
+        "round": round_number,
+        "roundname": f"Round {round_number}",
+        "year": date.today().year,
+        "hbehinds": FAKE.pyint(1, 15),
+        "hgoals": FAKE.pyint(1, 15),
+        "hscore": FAKE.pyint(20, 120),
+        "hteam": home_team,
+        "hteamid": settings.TEAM_NAMES.index(home_team),
+        "abehinds": FAKE.pyint(1, 15),
+        "agoals": FAKE.pyint(1, 15),
+        "ascore": FAKE.pyint(20, 120),
+        "ateam": away_team,
+        "ateamid": settings.TEAM_NAMES.index(away_team),
+        "winner": winner,
+        "winnerteamid": settings.TEAM_NAMES.index(winner),
+        "is_grand_final": 0,
+        "complete": 100,
+        "is_final": 0,
+        "id": FAKE.pyint(1, 200),
+        "venue": np.random.choice(list(settings.VENUE_CITIES.keys())),
+    }
+
+
+def fake_match_results_data(row_count: int, round_number: int) -> pd.DataFrame:
+    """
+    Generate dummy data that replicates match results data.
+
+    Params
+    ------
+    row_count: Number of match rows to return
+
+    Returns
+    -------
+    DataFrame of match results data
+    """
+    team_names = CyclicalTeamNames()
+
+    return pd.DataFrame(
+        [_results_by_match(round_number, team_names) for _ in range(row_count)]
+    )
 
 
 def fake_prediction_data(

--- a/tipping/src/tests/fixtures/data_factories.py
+++ b/tipping/src/tests/fixtures/data_factories.py
@@ -117,7 +117,7 @@ def _matches_by_year(
     return [_matches_by_round(row_count, year) for year in range(*year_range)]
 
 
-def fake_match_results_data(
+def fake_match_data(
     row_count: int, year_range: Tuple[int, int], clean=False
 ) -> pd.DataFrame:
     """Return minimally-valid dummy match results data."""

--- a/tipping/src/tests/unit/test_api.py
+++ b/tipping/src/tests/unit/test_api.py
@@ -94,8 +94,6 @@ class TestApi(TestCase):
         mock_submitter.submit_tips = MagicMock()
 
         with self.subTest("with no future match records available"):
-            mock_data_import.fetch_fixture_data = MagicMock(return_value=pd.DataFrame())
-
             self.api.update_match_predictions(
                 tips_submitters=[mock_submitter, mock_submitter], verbose=0
             )
@@ -108,20 +106,17 @@ class TestApi(TestCase):
             mock_submitter.submit_tips.assert_not_called()
 
         with self.subTest("with at least one future match record"):
-            mock_data_import.fetch_fixture_data = MagicMock(
-                return_value=self.fixture_return_values[0]
-            )
+            with freeze_time(TIP_DATES[0]):
+                self.api.update_match_predictions(
+                    tips_submitters=[mock_submitter, mock_submitter], verbose=0
+                )
 
-            self.api.update_match_predictions(
-                tips_submitters=[mock_submitter, mock_submitter], verbose=0
-            )
-
-            # It fetches predictions
-            mock_data_import.fetch_prediction_data.assert_called()
-            # It sends predictions to Tipresias app
-            mock_data_export.update_match_predictions.assert_called()
-            # It submits tips to all competitions
-            self.assertEqual(mock_submitter.submit_tips.call_count, 2)
+                # It fetches predictions
+                mock_data_import.fetch_prediction_data.assert_called()
+                # It sends predictions to Tipresias app
+                mock_data_export.update_match_predictions.assert_called()
+                # It submits tips to all competitions
+                self.assertEqual(mock_submitter.submit_tips.call_count, 2)
 
     @patch("tipping.api.data_import")
     def test_fetch_match_predictions(self, mock_data_import):

--- a/tipping/src/tests/unit/test_api.py
+++ b/tipping/src/tests/unit/test_api.py
@@ -63,6 +63,23 @@ class TestApi(TestCase):
 
     @patch("tipping.api.data_export")
     @patch("tipping.api.data_import")
+    def test_update_matches(self, mock_data_import, mock_data_export):
+        this_year = datetime.now().year
+        matches = data_factories.fake_match_data(N_MATCHES, (this_year, this_year + 1))
+
+        mock_data_import.fetch_match_data = MagicMock(return_value=matches)
+        mock_data_export.update_matches = MagicMock()
+
+        self.api.update_matches(verbose=0)
+
+        # It posts data to main app
+        mock_data_export.update_matches.assert_called()
+        call_args = mock_data_export.update_matches.call_args[0]
+        data_are_equal = (call_args[0] == matches).all().all()
+        self.assertTrue(data_are_equal)
+
+    @patch("tipping.api.data_export")
+    @patch("tipping.api.data_import")
     def test_update_match_predictions(self, mock_data_import, mock_data_export):
         mock_data_export.update_match_predictions = MagicMock()
         mock_data_import.fetch_prediction_data = MagicMock(
@@ -108,7 +125,7 @@ class TestApi(TestCase):
 
     @patch("tipping.api.data_import")
     def test_fetch_match_predictions(self, mock_data_import):
-        matches = data_factories.fake_match_results_data(N_MATCHES, YEAR_RANGE)
+        matches = data_factories.fake_match_data(N_MATCHES, YEAR_RANGE)
         predictions = pd.concat(
             [
                 data_factories.fake_prediction_data(match)
@@ -154,7 +171,7 @@ class TestApi(TestCase):
 
     @patch("tipping.api.data_import")
     def test_fetch_matches(self, mock_data_import):
-        matches = data_factories.fake_match_results_data(N_MATCHES, YEAR_RANGE)
+        matches = data_factories.fake_match_data(N_MATCHES, YEAR_RANGE)
         mock_data_import.fetch_match_data = MagicMock(return_value=matches)
 
         match_dates = np.random.choice(matches["date"], size=2)

--- a/tipping/src/tests/unit/test_data_export.py
+++ b/tipping/src/tests/unit/test_data_export.py
@@ -96,7 +96,7 @@ class TestDataExport(TestCase):
         mock_requests.post = MagicMock(return_value=mock_response)
 
         url = settings.TIPRESIAS_APP + "/matches"
-        fake_matches = data_factories.fake_match_results_data(N_MATCHES, YEAR_RANGE)
+        fake_matches = data_factories.fake_match_data(N_MATCHES, YEAR_RANGE)
         self.data_export.update_matches(fake_matches)
 
         # It posts the data

--- a/tipping/src/tests/unit/test_data_export.py
+++ b/tipping/src/tests/unit/test_data_export.py
@@ -109,4 +109,33 @@ class TestDataExport(TestCase):
             mock_response.status_code = 400
 
             with self.assertRaisesRegex(Exception, "Bad response"):
-                self.data_export.update_match_predictions(fake_matches)
+                self.data_export.update_matches(fake_matches)
+
+    @patch("tipping.data_export.requests")
+    def test_update_match_results(self, mock_requests):
+        mock_response = MagicMock()
+        mock_response.status_code = 200
+        mock_response.headers = {}
+        mock_response.text = "Stuff happened"
+
+        mock_requests.post = MagicMock(return_value=mock_response)
+
+        url = settings.TIPRESIAS_APP + "/match_results"
+        fake_match_results = data_factories.fake_match_results_data(
+            N_MATCHES, YEAR_RANGE
+        )
+        self.data_export.update_match_results(fake_match_results)
+
+        # It posts the data
+        match_results_response = fake_match_results.astype({"date": str}).to_dict(
+            "records"
+        )
+        mock_requests.post.assert_called_with(
+            url, json={"data": match_results_response}, headers={}
+        )
+
+        with self.subTest("when the status code isn't 2xx"):
+            mock_response.status_code = 400
+
+            with self.assertRaisesRegex(Exception, "Bad response"):
+                self.data_export.update_match_results(fake_match_results)

--- a/tipping/src/tests/unit/test_helpers.py
+++ b/tipping/src/tests/unit/test_helpers.py
@@ -5,7 +5,7 @@ from unittest import TestCase
 import pandas as pd
 import numpy as np
 
-from tests.fixtures.data_factories import fake_prediction_data, fake_match_results_data
+from tests.fixtures.data_factories import fake_prediction_data, fake_match_data
 from tipping.helpers import pivot_team_matches_to_matches, convert_to_dict
 
 
@@ -30,7 +30,7 @@ class TestHelpers(TestCase):
         self.assertNotIn("oppo_team", match_df.columns)
 
     def test_convert_to_dict(self):
-        match_df = fake_match_results_data(N_MATCHES, YEAR_RANGE)
+        match_df = fake_match_data(N_MATCHES, YEAR_RANGE)
         match_df.loc[:, "crowd"] = np.nan
         match_records = convert_to_dict(match_df)
 

--- a/tipping/src/tipping/api.py
+++ b/tipping/src/tipping/api.py
@@ -169,6 +169,35 @@ def update_matches(verbose=1) -> None:
         print("Match data sent!")
 
 
+def update_match_results(verbose=1) -> None:
+    """
+    Fetch minimal match results data and send them to the main app.
+
+    verbose: How much information to print. 1 prints all messages; 0 prints none.
+    """
+    matches_from_current_round = _fetch_current_round_fixture(verbose)
+
+    if matches_from_current_round is None:
+        return None
+
+    current_round = matches_from_current_round["round_number"].min()
+
+    if verbose == 1:
+        print(f"Fetching match results for round {current_round}")
+
+    match_results_data = data_import.fetch_match_results_data(current_round)
+
+    if verbose == 1:
+        print("Match results data received!")
+
+    data_export.update_match_results(match_results_data)
+
+    if verbose == 1:
+        print("Match data sent!")
+
+    return None
+
+
 def fetch_match_predictions(
     year_range: str,
     round_number: Optional[int] = None,

--- a/tipping/src/tipping/api.py
+++ b/tipping/src/tipping/api.py
@@ -1,6 +1,6 @@
 """External-facing API for fetching and updating application data."""
 
-from typing import Optional, List, Tuple
+from typing import Optional, List
 from datetime import datetime
 from warnings import warn
 import pytz
@@ -17,62 +17,78 @@ JAN = 1
 FIRST = 1
 
 
-def _select_upcoming_matches(
-    fixture_data_frame: pd.DataFrame, right_now: datetime
-) -> Tuple[Optional[int], Optional[pd.DataFrame]]:
+def _select_matches_from_current_round(
+    fixture_data_frame: pd.DataFrame, beginning_of_today: datetime
+) -> Optional[pd.DataFrame]:
     if not fixture_data_frame.any().any():
         warn(
             "Fixture for the upcoming round haven't been posted yet, "
             "so there's nothing to tip. Try again later."
         )
 
-        return None, None
+        return None
 
     latest_match_date = fixture_data_frame["date"].max()
 
-    if right_now > latest_match_date:
+    if beginning_of_today > latest_match_date:
         warn(
-            f"No matches found after {right_now}. The latest match "
+            f"No matches found after {beginning_of_today}. The latest match "
             f"found is at {latest_match_date}\n"
         )
 
-        return None, None
+        return None
 
-    upcoming_round = int(
-        fixture_data_frame.query("date > @right_now").loc[:, "round_number"].min()
+    current_round = int(  # pylint: disable=unused-variable
+        fixture_data_frame.query("date > @beginning_of_today")
+        .loc[:, "round_number"]
+        .min()
     )
-    fixture_for_upcoming_round = fixture_data_frame.query(
-        "round_number == @upcoming_round"
+    fixture_for_current_round = fixture_data_frame.query(
+        "round_number == @current_round"
     )
 
-    return upcoming_round, fixture_for_upcoming_round
+    return fixture_for_current_round
 
 
-def update_fixture_data(verbose=1) -> None:
-    """
-    Fetch fixture data and send upcoming match data to the main app.
-
-    verbose: How much information to print. 1 prints all messages; 0 prints none.
-    """
+def _fetch_current_round_fixture(verbose) -> Optional[pd.DataFrame]:
     right_now = datetime.now(tz=pytz.UTC)
-    year = right_now.year
+    beginning_of_today = right_now.replace(hour=0, minute=0, second=0, microsecond=0)
+    beginning_of_this_year = datetime(
+        beginning_of_today.year, JAN, FIRST, tzinfo=pytz.UTC
+    )
+    end_of_this_year = datetime(
+        beginning_of_today.year, DEC, THIRTY_FIRST, tzinfo=pytz.UTC
+    )
 
     if verbose == 1:
-        print(f"Fetching fixture for {year}...\n")
+        print(f"Fetching fixture for matches after {beginning_of_today}...\n")
 
     fixture_data_frame = data_import.fetch_fixture_data(
-        start_date=datetime(year, 1, 1, tzinfo=pytz.UTC),
-        end_date=datetime(year, 12, 31, tzinfo=pytz.UTC),
+        start_date=beginning_of_this_year, end_date=end_of_this_year,
     )
 
-    upcoming_round, upcoming_matches = _select_upcoming_matches(
+    matches_from_current_round = _select_matches_from_current_round(
         fixture_data_frame, right_now
     )
 
-    if upcoming_round is None or upcoming_matches is None:
+    return matches_from_current_round
+
+
+def update_fixture_data(verbose: int = 1) -> None:
+    """
+    Fetch fixture data and send upcoming match data to the main app.
+
+    Params:
+    -------
+    verbose: How much information to print. 1 prints all messages; 0 prints none.
+    """
+    matches_from_current_round = _fetch_current_round_fixture(verbose)
+
+    if matches_from_current_round is None:
         return None
 
-    data_export.update_fixture_data(upcoming_matches, upcoming_round)
+    current_round = matches_from_current_round["round_number"].drop_duplicates().iloc[0]
+    data_export.update_fixture_data(matches_from_current_round, current_round)
 
     return None
 
@@ -83,26 +99,19 @@ def update_match_predictions(tips_submitters=None, verbose=1) -> None:
 
     verbose: How much information to print. 1 prints all messages; 0 prints none.
     """
-    right_now = datetime.now(tz=pytz.UTC)
-    end_of_year = datetime(right_now.year, DEC, THIRTY_FIRST, tzinfo=pytz.UTC)
-    upcoming_matches = data_import.fetch_fixture_data(right_now, end_of_year)
+    matches_from_current_round = _fetch_current_round_fixture(verbose)
 
-    if not upcoming_matches.any().any():
-        if verbose == 1:
-            print("There are no upcoming matches to predict.")
+    if matches_from_current_round is None:
         return None
 
-    next_match = upcoming_matches.sort_values("date").iloc[0, :]
-    upcoming_round = int(next_match["round_number"])
-    upcoming_season = int(next_match["year"])
+    current_round = matches_from_current_round["round_number"].min()
+    current_season = matches_from_current_round["date"].min().year
 
     if verbose == 1:
-        print(
-            "Fetching predictions for round " f"{upcoming_round}, {upcoming_season}..."
-        )
+        print("Fetching predictions for round " f"{current_round}, {current_season}...")
 
     prediction_data = data_import.fetch_prediction_data(
-        f"{upcoming_season}-{upcoming_season + 1}", round_number=upcoming_round,
+        f"{current_season}-{current_season + 1}", round_number=current_round,
     )
 
     if verbose == 1:

--- a/tipping/src/tipping/api.py
+++ b/tipping/src/tipping/api.py
@@ -161,7 +161,7 @@ def update_matches(verbose=1) -> None:
     )
 
     if verbose == 1:
-        print("Match data reveived!")
+        print("Match data received!")
 
     data_export.update_matches(match_data)
 

--- a/tipping/src/tipping/data_export.py
+++ b/tipping/src/tipping/data_export.py
@@ -81,3 +81,18 @@ def update_matches(match_data: pd.DataFrame):
     }
 
     _send_data("/matches", body=body)
+
+
+def update_match_results(match_results_data: pd.DataFrame):
+    """
+    POST match results data to main Tipresias app.
+
+    Params:
+    -------
+    match_results_data: Minimal results data from played matches.
+    """
+    body = {
+        "data": convert_to_dict(match_results_data),
+    }
+
+    _send_data("/match_results", body=body)

--- a/tipping/src/tipping/data_import.py
+++ b/tipping/src/tipping/data_import.py
@@ -169,6 +169,28 @@ def fetch_match_data(
     return matches
 
 
+def fetch_match_results_data(round_number: int) -> pd.DataFrame:
+    """
+    Fetch minimal match results data.
+
+    Params:
+    -------
+    round_number: Fetch results for the given round.
+
+    Returns:
+    --------
+    pandas.DataFrame with match data.
+    """
+    match_results = pd.DataFrame(
+        _fetch_data("match_results", {"round_number": round_number},)
+    )
+
+    if any(match_results):
+        return match_results.assign(date=_parse_dates)
+
+    return match_results
+
+
 def fetch_ml_model_info() -> pd.DataFrame:
     """
     Fetch general info about all saved ML models.


### PR DESCRIPTION
Depending on weekly updates from AFLTables meant that we have
been unable to display real-time prediction results on the
Tipresias site. More-frequent updates will improve the UI, because
we won't show past matches as all being incorrect anymore.