### PR TITLE
Display prediction values as floats to one decimal place

### DIFF
--- a/backend/server/graphql/types/season.py
+++ b/backend/server/graphql/types/season.py
@@ -64,7 +64,7 @@ class MatchPredictionType(graphene.ObjectType):
 
     match__start_date_time = graphene.NonNull(graphene.DateTime, name="startDateTime")
     predicted_winner__name = graphene.NonNull(graphene.String, name="predictedWinner")
-    predicted_margin = graphene.NonNull(graphene.Int)
+    predicted_margin = graphene.NonNull(graphene.Float)
     predicted_win_probability = graphene.NonNull(graphene.Float)
     is_correct = graphene.Boolean()
 

--- a/frontend/schema.json
+++ b/frontend/schema.json
@@ -1325,7 +1325,7 @@
               "name": null,
               "ofType": {
                 "kind": "SCALAR",
-                "name": "Int",
+                "name": "Float",
                 "ofType": null
               }
             },

--- a/frontend/src/containers/Dashboard/dataTransformerTable.js
+++ b/frontend/src/containers/Dashboard/dataTransformerTable.js
@@ -30,15 +30,16 @@ const dataTransformerTable = (
     acc[currentIndex] = acc[currentIndex] || [];
 
     const [date] = startDateTime.split('T');
+    const formattedpredictedMargin = (Math.round(predictedMargin * 10) / 10).toString();
     const formattedWinProbability = `
-      ${(Math.round(predictedWinProbability * 100)).toString()}%
+      ${(Math.round(predictedWinProbability * 1000) / 10).toString()}%
     `;
     const resultIcon = determineResultIcon(isCorrect);
 
     acc[currentIndex] = [
       date,
       predictedWinner,
-      predictedMargin.toString(),
+      formattedpredictedMargin,
       formattedWinProbability,
       resultIcon,
     ];


### PR DESCRIPTION
For close matches, integers made it difficult to to see when
margin and win probability disagreed on the winner.