### PR TITLE
Improve error message by including teammatch data

### DIFF
--- a/backend/server/models/match.py
+++ b/backend/server/models/match.py
@@ -178,7 +178,12 @@ class Match(models.Model):
 
         assert match_result.any().any(), (
             "Didn't find any match data rows that matched match record:\n"
-            f"{self.__dict__}"
+            "{\n"
+            f"    start_date_time: {self.start_date_time},\n"
+            f"    round_number: {self.round_number},\n"
+            f"    venue: {self.venue},\n"
+            f"    teammatch_set: {self.teammatch_set.values('team__name', 'at_home')}"
+            "}"
         )
 
         return True

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -44,6 +44,7 @@ services:
       DATA_SCIENCE_SERVICE: http://host.docker.internal:8008
       TIPRESIAS_APP: http://backend:8000
       AWS_SHARED_CREDENTIALS_FILE: .aws/credentials
+      ROLLBAR_TOKEN: rollbar_token
     ports:
       - "3333:3333"
     stdin_open: true


### PR DESCRIPTION
The teammatch data gets left out, because it's still a query
set when we call __dict__.