### PR TITLE
Move Django ORM details to model classes

### DIFF
--- a/backend/server/db.py
+++ b/backend/server/db.py
@@ -1,0 +1,148 @@
+"""Module for connecting models with the database."""
+
+from __future__ import annotations
+from typing import Tuple, Dict
+
+from django.db import models
+
+
+class DBRecordCollection:
+    """Collection of team records that can trigger further DB queries."""
+
+    def __init__(self, records_collection: models.QuerySet):
+        self.records_collection = records_collection
+
+    def __len__(self):
+        return len(self.records_collection)
+
+    def __iter__(self):
+        return (team for team in self.records_collection)
+
+    def delete(self) -> Tuple[int, Dict[str, int]]:
+        """Delete all team match records in the collection."""
+        return self.records_collection.delete()
+
+    def count(self) -> int:
+        """
+        Get the number of team match records in the collection.
+
+        Returns:
+        --------
+        Count of team match records.
+        """
+        return self.records_collection.count()
+
+    def order_by(self, ordering_attribute: str) -> DBRecordCollection:
+        """
+        Order the collection elements by the given attribute(s).
+
+        Params:
+        -------
+        ordering_attribute: Name of the attribute. Optionally prepend '-'
+            to sort in descending order.
+
+        Returns:
+        --------
+        Sorted team match collection.
+        """
+        return self.records_collection.order_by(ordering_attribute)
+
+    def update(self, **attributes) -> DBRecordCollection:
+        """
+        Update all TeamMatch records in the collection with the given attribute values.
+
+        Params:
+        -------
+        attributes: TeamMatch attribute values to update.
+
+        Returns:
+        --------
+        Count of updated records.
+        """
+        return self.records_collection.update(**attributes)
+
+
+class DBQuery(models.Model):
+    """Interface for performing database queries."""
+
+    @classmethod
+    def create(cls, **attributes) -> models.Model:
+        """
+        Create a TeamMatch record in the database.
+
+        Params:
+        -------
+        attributes: TeamMatch attributes for the created record.
+
+        Returns:
+        --------
+        An instance of the created team match.
+        """
+        return cls.objects.create(**attributes)
+
+    @classmethod
+    def count(cls) -> int:
+        """
+        Get the number of TeamMatch records in the database.
+
+        Returns:
+        --------
+        Count of team match records.
+        """
+        return cls.objects.count()
+
+    @classmethod
+    def get(cls, **attributes) -> models.Model:
+        """
+        Get a TeamMatch record that matches the given attributes from the database.
+
+        Params:
+        -------
+        attributes: TeamMatch attributes for the created record.
+
+        Returns:
+        --------
+        The requested team match record.
+        """
+        return cls.objects.get(**attributes)
+
+    @classmethod
+    def get_or_create(cls, **attributes) -> Tuple[models.Model, bool]:
+        """
+        Get a TeamMatch record that matches the given attributes or create it if missing.
+
+        Params:
+        -------
+        attributes: TeamMatch attributes for the requested/created record.
+
+        Returns:
+        --------
+        The requested team match record and whether it was created.
+        """
+        return cls.objects.get_or_create(**attributes)
+
+    @classmethod
+    def all(cls) -> DBRecordCollection:
+        """
+        Get all TeamMatch records from the database.
+
+        Returns:
+        --------
+        A list of team match records.
+        """
+        return DBRecordCollection(cls.objects.all())
+
+    @classmethod
+    def filter(cls, **attributes) -> DBRecordCollection:
+        """
+        Get all TeamMatch records that match the given filter values.
+
+        Params:
+        -------
+        attributes: TeamMatch attributes to filter by.
+
+        Returns:
+        --------
+        A list of team match records.
+        """
+        return DBRecordCollection(cls.objects.filter(**attributes))

--- a/backend/server/graphql/calculations.py
+++ b/backend/server/graphql/calculations.py
@@ -75,7 +75,7 @@ def _calculate_absolute_margin_difference():
 
 def _get_match_winner_name():
     return Subquery(
-        TeamMatch.objects.filter(match_id=OuterRef("match_id"))
+        TeamMatch.filter(match_id=OuterRef("match_id"))
         .order_by("-score")
         .values_list("team__name")[:1]
     )
@@ -90,7 +90,8 @@ def _calculate_tip_points():
 
 
 def cumulative_metrics_query(
-    prediction_query_set: QuerySet, additional_values: Optional[List[str]] = None,
+    prediction_query_set: QuerySet,
+    additional_values: Optional[List[str]] = None,
 ) -> List[Dict[str, Any]]:
     """
     Chain methods onto a Prediction query set to calculate cumulative model metrics.

--- a/backend/server/models/prediction.py
+++ b/backend/server/models/prediction.py
@@ -130,9 +130,9 @@ class Prediction(models.Model):
             predicted_margin = np.mean(np.abs([home_margin, away_margin]))
 
         if home_margin > away_margin:
-            predicted_winner = Team.objects.get(name=home_team)
+            predicted_winner = Team.get(name=home_team)
         elif away_margin > home_margin:
-            predicted_winner = Team.objects.get(name=away_team)
+            predicted_winner = Team.get(name=away_team)
         else:
             raise ValueError(
                 "Predicted home and away margins are equal, which is basically "
@@ -167,7 +167,7 @@ class Prediction(models.Model):
         predicted_winner_name = (
             home_team if home_probability > away_probability else away_team
         )
-        predicted_winner = Team.objects.get(name=predicted_winner_name)
+        predicted_winner = Team.get(name=predicted_winner_name)
 
         return predicted_win_probability, predicted_winner
 

--- a/backend/server/models/team.py
+++ b/backend/server/models/team.py
@@ -1,9 +1,33 @@
 """Data model for AFL teams."""
 
+from __future__ import annotations
+from typing import Tuple, Dict
+
 from django.db import models
 from django.conf import settings
 from django.core.exceptions import ValidationError
 from django.utils.translation import gettext_lazy as _
+from mypy_extensions import TypedDict
+
+
+TeamRecord = TypedDict("TeamRecord", {"name": str, "id": int})
+
+
+class TeamCollection:
+    """Collection of team records that can trigger further DB queries."""
+
+    def __init__(self, teams: models.QuerySet):
+        self.teams = teams
+
+    def __len__(self):
+        return len(self.teams)
+
+    def __iter__(self):
+        return (team for team in self.teams)
+
+    def delete(self) -> Tuple[int, Dict[str, int]]:
+        """Delete all team records in the collection."""
+        return self.teams.delete()
 
 
 def validate_name(name: str) -> None:
@@ -18,3 +42,70 @@ class Team(models.Model):
     """Data model for AFL teams."""
 
     name = models.CharField(max_length=100, unique=True, validators=[validate_name])
+
+    @classmethod
+    def create(cls, **attributes) -> Team:
+        """
+        Create a Team record in the database.
+
+        Params:
+        -------
+        attributes: Team attributes for the created record.
+
+        Returns:
+        --------
+        An instance of the created team.
+        """
+        return cls.objects.create(**attributes)
+
+    @classmethod
+    def count(cls) -> int:
+        """
+        Get the number of Team records in the database.
+
+        Returns:
+        --------
+        Count of team records.
+        """
+        return cls.objects.count()
+
+    @classmethod
+    def get(cls, **attributes) -> Team:
+        """
+        Get a Team record that matches the given attributes from the database.
+
+        Params:
+        -------
+        attributes: Team attributes for the created record.
+
+        Returns:
+        --------
+        The requested team record.
+        """
+        return cls.objects.get(**attributes)
+
+    @classmethod
+    def get_or_create(cls, **attributes) -> Tuple[Team, bool]:
+        """
+        Get a Team record that matches the given attributes or create it if missing.
+
+        Params:
+        -------
+        attributes: Team attributes for the requested/created record.
+
+        Returns:
+        --------
+        The requested team record and whether it was created.
+        """
+        return cls.objects.get_or_create(**attributes)
+
+    @classmethod
+    def all(cls) -> TeamCollection:
+        """
+        Get all Team records from the database.
+
+        Returns:
+        --------
+        A list of team records.
+        """
+        return TeamCollection(cls.objects.all())

--- a/backend/server/models/team_match.py
+++ b/backend/server/models/team_match.py
@@ -1,7 +1,7 @@
 """Data model for the join table for matches and teams."""
 
 from __future__ import annotations
-from typing import Type, TypeVar, Union, Tuple, Dict
+from typing import Type, TypeVar, Union, Tuple
 
 from django.db import models, transaction
 import pandas as pd
@@ -17,62 +17,6 @@ T = TypeVar("T", bound="TeamMatch")
 NO_SCORE = 0
 
 
-class TeamMatchCollection:
-    """Collection of team records that can trigger further DB queries."""
-
-    def __init__(self, team_matches: models.QuerySet):
-        self.team_matches = team_matches
-
-    def __len__(self):
-        return len(self.team_matches)
-
-    def __iter__(self):
-        return (team for team in self.team_matches)
-
-    def delete(self) -> Tuple[int, Dict[str, int]]:
-        """Delete all team match records in the collection."""
-        return self.team_matches.delete()
-
-    def count(self) -> int:
-        """
-        Get the number of team match records in the collection.
-
-        Returns:
-        --------
-        Count of team match records.
-        """
-        return self.team_matches.count()
-
-    def order_by(self, ordering_attribute: str) -> TeamMatchCollection:
-        """
-        Order the collection elements by the given attribute(s).
-
-        Params:
-        -------
-        ordering_attribute: Name of the attribute. Optionally prepend '-'
-            to sort in descending order.
-
-        Returns:
-        --------
-        Sorted team match collection.
-        """
-        return self.team_matches.order_by(ordering_attribute)
-
-    def update(self, **attributes) -> TeamMatchCollection:
-        """
-        Update all TeamMatch records in the collection with the given attribute values.
-
-        Params:
-        -------
-        attributes: TeamMatch attribute values to update.
-
-        Returns:
-        --------
-        Count of updated records.
-        """
-        return self.team_matches.update(**attributes)
-
-
 class TeamMatch(models.Model):
     """Data model for the join table for matches and teams."""
 
@@ -80,88 +24,6 @@ class TeamMatch(models.Model):
     match = models.ForeignKey(Match, on_delete=models.CASCADE)
     at_home = models.BooleanField()
     score = models.PositiveSmallIntegerField(default=0)
-
-    @classmethod
-    def create(cls, **attributes) -> Team:
-        """
-        Create a TeamMatch record in the database.
-
-        Params:
-        -------
-        attributes: TeamMatch attributes for the created record.
-
-        Returns:
-        --------
-        An instance of the created team match.
-        """
-        return cls.objects.create(**attributes)
-
-    @classmethod
-    def count(cls) -> int:
-        """
-        Get the number of TeamMatch records in the database.
-
-        Returns:
-        --------
-        Count of team match records.
-        """
-        return cls.objects.count()
-
-    @classmethod
-    def get(cls, **attributes) -> Team:
-        """
-        Get a TeamMatch record that matches the given attributes from the database.
-
-        Params:
-        -------
-        attributes: TeamMatch attributes for the created record.
-
-        Returns:
-        --------
-        The requested team match record.
-        """
-        return cls.objects.get(**attributes)
-
-    @classmethod
-    def get_or_create(cls, **attributes) -> Tuple[Team, bool]:
-        """
-        Get a TeamMatch record that matches the given attributes or create it if missing.
-
-        Params:
-        -------
-        attributes: TeamMatch attributes for the requested/created record.
-
-        Returns:
-        --------
-        The requested team match record and whether it was created.
-        """
-        return cls.objects.get_or_create(**attributes)
-
-    @classmethod
-    def all(cls) -> TeamMatchCollection:
-        """
-        Get all TeamMatch records from the database.
-
-        Returns:
-        --------
-        A list of team match records.
-        """
-        return TeamMatchCollection(cls.objects.all())
-
-    @classmethod
-    def filter(cls, **attributes) -> TeamMatchCollection:
-        """
-        Get all TeamMatch records that match the given filter values.
-
-        Params:
-        -------
-        attributes: TeamMatch attributes to filter by.
-
-        Returns:
-        --------
-        A list of team match records.
-        """
-        return TeamMatchCollection(cls.objects.filter(**attributes))
 
     @classmethod
     def get_or_create_from_raw_data(

--- a/backend/server/models/team_match.py
+++ b/backend/server/models/team_match.py
@@ -1,6 +1,7 @@
 """Data model for the join table for matches and teams."""
 
-from typing import Type, TypeVar, Union, Tuple
+from __future__ import annotations
+from typing import Type, TypeVar, Union, Tuple, Dict
 
 from django.db import models, transaction
 import pandas as pd
@@ -16,6 +17,62 @@ T = TypeVar("T", bound="TeamMatch")
 NO_SCORE = 0
 
 
+class TeamMatchCollection:
+    """Collection of team records that can trigger further DB queries."""
+
+    def __init__(self, team_matches: models.QuerySet):
+        self.team_matches = team_matches
+
+    def __len__(self):
+        return len(self.team_matches)
+
+    def __iter__(self):
+        return (team for team in self.team_matches)
+
+    def delete(self) -> Tuple[int, Dict[str, int]]:
+        """Delete all team match records in the collection."""
+        return self.team_matches.delete()
+
+    def count(self) -> int:
+        """
+        Get the number of team match records in the collection.
+
+        Returns:
+        --------
+        Count of team match records.
+        """
+        return self.team_matches.count()
+
+    def order_by(self, ordering_attribute: str) -> TeamMatchCollection:
+        """
+        Order the collection elements by the given attribute(s).
+
+        Params:
+        -------
+        ordering_attribute: Name of the attribute. Optionally prepend '-'
+            to sort in descending order.
+
+        Returns:
+        --------
+        Sorted team match collection.
+        """
+        return self.team_matches.order_by(ordering_attribute)
+
+    def update(self, **attributes) -> TeamMatchCollection:
+        """
+        Update all TeamMatch records in the collection with the given attribute values.
+
+        Params:
+        -------
+        attributes: TeamMatch attribute values to update.
+
+        Returns:
+        --------
+        Count of updated records.
+        """
+        return self.team_matches.update(**attributes)
+
+
 class TeamMatch(models.Model):
     """Data model for the join table for matches and teams."""
 
@@ -23,6 +80,88 @@ class TeamMatch(models.Model):
     match = models.ForeignKey(Match, on_delete=models.CASCADE)
     at_home = models.BooleanField()
     score = models.PositiveSmallIntegerField(default=0)
+
+    @classmethod
+    def create(cls, **attributes) -> Team:
+        """
+        Create a TeamMatch record in the database.
+
+        Params:
+        -------
+        attributes: TeamMatch attributes for the created record.
+
+        Returns:
+        --------
+        An instance of the created team match.
+        """
+        return cls.objects.create(**attributes)
+
+    @classmethod
+    def count(cls) -> int:
+        """
+        Get the number of TeamMatch records in the database.
+
+        Returns:
+        --------
+        Count of team match records.
+        """
+        return cls.objects.count()
+
+    @classmethod
+    def get(cls, **attributes) -> Team:
+        """
+        Get a TeamMatch record that matches the given attributes from the database.
+
+        Params:
+        -------
+        attributes: TeamMatch attributes for the created record.
+
+        Returns:
+        --------
+        The requested team match record.
+        """
+        return cls.objects.get(**attributes)
+
+    @classmethod
+    def get_or_create(cls, **attributes) -> Tuple[Team, bool]:
+        """
+        Get a TeamMatch record that matches the given attributes or create it if missing.
+
+        Params:
+        -------
+        attributes: TeamMatch attributes for the requested/created record.
+
+        Returns:
+        --------
+        The requested team match record and whether it was created.
+        """
+        return cls.objects.get_or_create(**attributes)
+
+    @classmethod
+    def all(cls) -> TeamMatchCollection:
+        """
+        Get all TeamMatch records from the database.
+
+        Returns:
+        --------
+        A list of team match records.
+        """
+        return TeamMatchCollection(cls.objects.all())
+
+    @classmethod
+    def filter(cls, **attributes) -> TeamMatchCollection:
+        """
+        Get all TeamMatch records that match the given filter values.
+
+        Params:
+        -------
+        attributes: TeamMatch attributes to filter by.
+
+        Returns:
+        --------
+        A list of team match records.
+        """
+        return TeamMatchCollection(cls.objects.filter(**attributes))
 
     @classmethod
     def get_or_create_from_raw_data(

--- a/backend/server/models/team_match.py
+++ b/backend/server/models/team_match.py
@@ -71,7 +71,7 @@ class TeamMatch(models.Model):
     def _create_from_raw_data(cls, match: Match, match_data, at_home: bool) -> T:
         team_prefix = "home" if at_home else "away"
         team_name = match_data[f"{team_prefix}_team"]
-        team, _was_created = Team.objects.get_or_create(name=team_name)
+        team, _was_created = Team.get_or_create(name=team_name)
 
         team_score = match_data.get(f"{team_prefix}_score", 0)
         team_match = TeamMatch(

--- a/backend/server/tests/integration/management/commands/test_seed_db.py
+++ b/backend/server/tests/integration/management/commands/test_seed_db.py
@@ -63,7 +63,7 @@ class TestSeedDb(TestCase):
     def test_handle(self):
         self.seed_command.handle(year_range=f"{self.years[0]}-{self.years[1]}")
 
-        self.assertGreater(Team.objects.count(), 0)
+        self.assertGreater(Team.count(), 0)
         self.assertEqual(MLModel.objects.count(), 1)
 
         expected_match_count = len(
@@ -117,6 +117,6 @@ class TestSeedDb(TestCase):
 
     @staticmethod
     def __clear_db():
-        Team.objects.all().delete()
+        Team.all().delete()
         Match.objects.all().delete()
         MLModel.objects.all().delete()

--- a/backend/server/tests/integration/management/commands/test_seed_db.py
+++ b/backend/server/tests/integration/management/commands/test_seed_db.py
@@ -73,11 +73,11 @@ class TestSeedDb(TestCase):
         )
         self.assertEqual(Match.objects.count(), expected_match_count)
         self.assertEqual(
-            TeamMatch.objects.count(),
+            TeamMatch.count(),
             expected_match_count * 2,
         )
         self.assertEqual(Prediction.objects.count(), expected_match_count)
-        self.assertEqual(TeamMatch.objects.filter(score=0).count(), 0)
+        self.assertEqual(TeamMatch.filter(score=0).count(), 0)
 
     def test_handle_errors(self):
         with self.subTest(

--- a/backend/server/tests/integration/test_api.py
+++ b/backend/server/tests/integration/test_api.py
@@ -64,7 +64,7 @@ class TestApi(TestCase):
 
             with self.subTest("with no existing match records in DB"):
                 self.assertEqual(Match.objects.count(), 0)
-                self.assertEqual(TeamMatch.objects.count(), 0)
+                self.assertEqual(TeamMatch.count(), 0)
 
                 self.api.update_fixture_data(
                     future_fixture_data, min_future_round, verbose=0
@@ -72,15 +72,11 @@ class TestApi(TestCase):
 
                 # It creates records
                 self.assertEqual(Match.objects.count(), len(future_fixture_data))
-                self.assertEqual(
-                    TeamMatch.objects.count(), len(future_fixture_data) * 2
-                )
+                self.assertEqual(TeamMatch.count(), len(future_fixture_data) * 2)
 
             with self.subTest("with the match records already saved in the DB"):
                 self.assertEqual(Match.objects.count(), len(future_fixture_data))
-                self.assertEqual(
-                    TeamMatch.objects.count(), len(future_fixture_data) * 2
-                )
+                self.assertEqual(TeamMatch.count(), len(future_fixture_data) * 2)
 
                 self.api.update_fixture_data(
                     future_fixture_data, min_future_round, verbose=0
@@ -88,9 +84,7 @@ class TestApi(TestCase):
 
                 # It doesn't create new records
                 self.assertEqual(Match.objects.count(), len(future_fixture_data))
-                self.assertEqual(
-                    TeamMatch.objects.count(), len(future_fixture_data) * 2
-                )
+                self.assertEqual(TeamMatch.count(), len(future_fixture_data) * 2)
 
         with freeze_time(TIP_DATES[1]):
             right_now = timezone.now()  # pylint: disable=unused-variable
@@ -117,7 +111,7 @@ class TestApi(TestCase):
             TeamMatch.get_or_create_from_raw_data(match, fixture_datum)
 
         with freeze_time(TIP_DATES[1]):
-            self.assertEqual(TeamMatch.objects.filter(score__gt=0).count(), 0)
+            self.assertEqual(TeamMatch.filter(score__gt=0).count(), 0)
             self.assertEqual(Prediction.objects.filter(is_correct=True).count(), 0)
 
             self.api.backfill_recent_match_results(
@@ -126,7 +120,7 @@ class TestApi(TestCase):
 
             # It updates scores for past matches
             self.assertEqual(
-                TeamMatch.objects.filter(
+                TeamMatch.filter(
                     match__start_date_time__lt=timezone.now(), score=0
                 ).count(),
                 0,

--- a/backend/server/tests/unit/models/test_match.py
+++ b/backend/server/tests/unit/models/test_match.py
@@ -22,8 +22,8 @@ class TestMatch(TestCase):
         self.match = Match.objects.create(
             start_date_time=match_datetime, round_number=5, venue="Corporate Stadium"
         )
-        self.home_team = Team.objects.create(name="Richmond")
-        self.away_team = Team.objects.create(name="Melbourne")
+        self.home_team = Team.create(name="Richmond")
+        self.away_team = Team.create(name="Melbourne")
 
         self.match.teammatch_set.create(
             team=self.home_team, match=self.match, at_home=True, score=50
@@ -218,7 +218,7 @@ class TestMatch(TestCase):
             else match_result["away_team"]
         )
 
-        winner = Team.objects.get(name=winner_name)
+        winner = Team.get(name=winner_name)
         match.prediction_set.update(predicted_winner=winner)
         # We expect a data frame, so can't reuse the match_result series
         match.update_result(match_results.iloc[:1, :])

--- a/backend/server/tests/unit/models/test_prediction.py
+++ b/backend/server/tests/unit/models/test_prediction.py
@@ -17,8 +17,8 @@ class TestPrediction(TestCase):
         )
         self.ml_model = MLModel.objects.create(name="test_model")
 
-        self.home_team = Team.objects.create(name="Richmond")
-        self.away_team = Team.objects.create(name="Melbourne")
+        self.home_team = Team.create(name="Richmond")
+        self.away_team = Team.create(name="Melbourne")
 
         self.match.teammatch_set.create(team=self.home_team, at_home=True, score=150)
         self.match.teammatch_set.create(team=self.away_team, at_home=False, score=100)
@@ -44,8 +44,8 @@ class TestPrediction(TestCase):
                     round_number=5,
                     venue="Corporate Stadium",
                 )
-                future_home_team = Team.objects.create(name="Collingwood")
-                future_away_team = Team.objects.create(name="GWS")
+                future_home_team = Team.create(name="Collingwood")
+                future_away_team = Team.create(name="GWS")
 
                 future_match.teammatch_set.create(
                     team=future_home_team, at_home=True, score=0

--- a/backend/server/tests/unit/models/test_team.py
+++ b/backend/server/tests/unit/models/test_team.py
@@ -1,8 +1,24 @@
 # pylint: disable=missing-docstring
+
+from typing import List, Tuple
+
 from django.test import TestCase
 from django.core.exceptions import ValidationError
+from django.conf import settings
+import numpy as np
 
 from server.models import Team
+from server.models.team import TeamCollection
+
+
+def _create_random_teams() -> Tuple[int, List[str]]:
+    team_count = np.random.randint(1, len(settings.TEAM_NAMES))
+    team_names = np.random.permutation(settings.TEAM_NAMES)
+
+    for n in range(team_count):
+        Team.create(name=team_names[n])
+
+    return team_count, team_names
 
 
 class TestTeam(TestCase):
@@ -20,7 +36,82 @@ class TestTeam(TestCase):
                 team.full_clean()
 
         with self.subTest("with duplicate team name"):
-            Team.objects.create(name="Richmond")
+            Team.create(name="Richmond")
 
             with self.assertRaises(ValidationError):
                 self.team.full_clean()
+
+    def test_count(self):
+        team_count, _ = _create_random_teams()
+
+        # It returns number of teams in DB
+        self.assertEqual(Team.count(), team_count)
+
+    def test_create(self):
+        self.assertEqual(Team.count(), 0)
+
+        team_name = np.random.choice(settings.TEAM_NAMES)
+        team = Team.create(name=team_name)
+
+        # It creates a DB record
+        self.assertEqual(Team.count(), 1)
+        # It returns the create team
+        self.assertIsInstance(team, Team)
+        self.assertEqual(team.name, team_name)
+
+    def test_get(self):
+        team_count, team_names = _create_random_teams()
+
+        team_name = team_names[np.random.randint(0, team_count)]
+        team = Team.get(name=team_name)
+
+        # It returns the requested team
+        self.assertIsInstance(team, Team)
+        self.assertEqual(team.name, team_name)
+
+    def test_all(self):
+        team_count, _ = _create_random_teams()
+
+        teams = Team.all()
+
+        # It returns all teams
+        self.assertEqual(len(teams), team_count)
+
+    def test_get_or_create(self):
+        with self.subTest("when it doesn't exist yet"):
+            self.assertEqual(Team.count(), 0)
+            team_name = np.random.choice(settings.TEAM_NAMES)
+            team, was_created = Team.get_or_create(name=team_name)
+
+            # It creates the team
+            self.assertEqual(Team.count(), 1)
+            # It returns the team record
+            self.assertIsInstance(team, Team)
+            self.assertEqual(team.name, team_name)
+            # It returns that the team was created
+            self.assertTrue(was_created)
+
+        with self.subTest("when it already exists"):
+            team, was_created = Team.get_or_create(name=team_name)
+
+            # It doesn't create a new team
+            self.assertEqual(Team.count(), 1)
+            # It returns the team record
+            self.assertIsInstance(team, Team)
+            self.assertEqual(team.name, team_name)
+            # It returns that the team wasn't created
+            self.assertFalse(was_created)
+
+
+class TestTeamCollection(TestCase):
+    def setUp(self):
+        _create_random_teams()
+
+        self.team_collection = TeamCollection(Team.all())
+
+    def test_delete(self):
+        self.assertGreater(Team.count(), 0)
+        self.team_collection.delete()
+
+        # It deletes the team records
+        self.assertEqual(Team.count(), 0)

--- a/backend/server/tests/unit/models/test_team_match.py
+++ b/backend/server/tests/unit/models/test_team_match.py
@@ -1,24 +1,40 @@
 # pylint: disable=missing-docstring
+
+from typing import Tuple, List
+
 from django.test import TestCase
+import numpy as np
 
 from server.models import TeamMatch
-from server.tests.fixtures.factories import MatchFactory, TeamMatchFactory
+from server.models.team_match import TeamMatchCollection
+from server.tests.fixtures.factories import MatchFactory, TeamMatchFactory, TeamFactory
 from server.tests.fixtures import data_factories
+
+ARBITRARY_TEAM_MATCH_LIMIT = 20
+
+
+def _create_random_team_matches(
+    count: int = ARBITRARY_TEAM_MATCH_LIMIT,
+) -> Tuple[int, List[str]]:
+    team_match_count = np.random.randint(1, count)
+
+    return team_match_count, [TeamMatchFactory() for _ in range(team_match_count)]
 
 
 class TestTeamMatch(TestCase):
     def setUp(self):
         self.match = MatchFactory()
+        self.team = TeamFactory()
         self.fixture_data = data_factories.fake_fixture_data().to_dict("records")
 
     def test_get_or_create_from_raw_data(self):
-        self.assertEqual(TeamMatch.objects.count(), 0)
+        self.assertEqual(TeamMatch.count(), 0)
 
         team_matches = TeamMatch.get_or_create_from_raw_data(
             self.match, self.fixture_data[0]
         )
 
-        self.assertEqual(TeamMatch.objects.count(), 2)
+        self.assertEqual(TeamMatch.count(), 2)
 
         for team_match in team_matches:
             self.assertIsInstance(team_match, TeamMatch)
@@ -30,7 +46,7 @@ class TestTeamMatch(TestCase):
                 self.match, self.fixture_data[0]
             )
 
-            self.assertEqual(TeamMatch.objects.count(), 2)
+            self.assertEqual(TeamMatch.count(), 2)
             self.assertEqual(team_matches, existing_team_matches)
 
             with self.subTest("but teams in match data are different"):
@@ -62,3 +78,146 @@ class TestTeamMatch(TestCase):
         team_match.update_score(match_result)
 
         self.assertEqual(team_match.score, match_result["home_score"])
+
+    def test_count(self):
+        team_match_count, _ = _create_random_team_matches()
+
+        # It returns number of teams in DB
+        self.assertEqual(TeamMatch.count(), team_match_count)
+
+    def test_create(self):
+        self.assertEqual(TeamMatch.count(), 0)
+
+        team = TeamMatch.create(
+            match=self.match, team=self.team, at_home=np.random.randint(0, 2)
+        )
+
+        # It creates a DB record
+        self.assertEqual(TeamMatch.count(), 1)
+        # It returns the create team match
+        self.assertIsInstance(team, TeamMatch)
+        self.assertEqual(team.match.id, self.match.id)
+
+    def test_get(self):
+        team_match_count, team_matches = _create_random_team_matches()
+        random_team_match = team_matches[np.random.randint(0, team_match_count)]
+
+        team_match = TeamMatch.get(
+            match__start_date_time=random_team_match.match.start_date_time,
+            team__name=random_team_match.team.name,
+        )
+
+        # It returns the requested team match
+        self.assertIsInstance(team_match, TeamMatch)
+        self.assertEqual(team_match.match.id, random_team_match.match.id)
+        self.assertEqual(team_match.team.id, random_team_match.team.id)
+
+    def test_all(self):
+        team_match_count, _ = _create_random_team_matches()
+
+        team_matches = TeamMatch.all()
+
+        # It returns all team matches
+        self.assertEqual(len(team_matches), team_match_count)
+
+    def test_filter(self):
+        _, team_matches = _create_random_team_matches(count=100)
+        team_names = np.array([team_match.team.name for team_match in team_matches])
+        unique_team_names, team_name_counts = np.unique(team_names, return_counts=True)
+
+        index = np.random.randint(len(unique_team_names))
+        record_count = team_name_counts[index]
+        team_name = unique_team_names[index]
+
+        team_matches = TeamMatch.filter(team__name=team_name)
+
+        # It returns filtered team matches
+        self.assertEqual(len(team_matches), record_count)
+        self.assertTrue(
+            all([team_match.team.name == team_name for team_match in team_matches])
+        )
+
+    def test_get_or_create(self):
+        at_home = np.random.randint(0, 2)
+
+        with self.subTest("when it doesn't exist yet"):
+            self.assertEqual(TeamMatch.count(), 0)
+            team_match, was_created = TeamMatch.get_or_create(
+                match=self.match, team=self.team, at_home=at_home
+            )
+
+            # It creates the team match
+            self.assertEqual(TeamMatch.count(), 1)
+            # It returns the team match record
+            self.assertIsInstance(team_match, TeamMatch)
+            self.assertEqual(team_match.match.id, self.match.id)
+            self.assertEqual(team_match.team.id, self.team.id)
+            # It returns that the team match was created
+            self.assertTrue(was_created)
+
+        with self.subTest("when it already exists"):
+            team_match, was_created = TeamMatch.get_or_create(
+                match=self.match, team=self.team, at_home=at_home
+            )
+
+            # It doesn't create a new team match
+            self.assertEqual(TeamMatch.count(), 1)
+            # It returns the team match record
+            self.assertIsInstance(team_match, TeamMatch)
+            self.assertEqual(team_match.match.id, self.match.id)
+            self.assertEqual(team_match.team.id, self.team.id)
+            # It returns that the team match wasn't created
+            self.assertFalse(was_created)
+
+
+class TestTeamMatchCollection(TestCase):
+    def setUp(self):
+        _create_random_team_matches()
+
+        self.team_match_collection = TeamMatchCollection(TeamMatch.all())
+
+    def test_delete(self):
+        self.assertGreater(TeamMatch.count(), 0)
+        self.team_match_collection.delete()
+
+        # It deletes the team records
+        self.assertEqual(TeamMatch.count(), 0)
+
+    def test_count(self):
+        self.assertEqual(self.team_match_collection.count(), TeamMatch.count())
+
+    def test_order_by(self):
+        sorted_team_scores = np.sort(
+            [team_match.score for team_match in self.team_match_collection]
+        )
+        sorted_team_matches = self.team_match_collection.order_by("score")
+
+        scores_are_sorted = np.all(
+            sorted_team_scores
+            == np.array([team_match.score for team_match in sorted_team_matches])
+        )
+
+        self.assertTrue(scores_are_sorted)
+
+    def test_update(self):
+        team_match_scores = [
+            team_match.score for team_match in self.team_match_collection
+        ]
+        unique_team_match_scores = np.unique(team_match_scores)
+
+        # Not all team names are the same
+        self.assertNotEqual(len(unique_team_match_scores), 1)
+
+        n_updated_team_matches = self.team_match_collection.update(
+            score=team_match_scores[np.random.randint(len(team_match_scores) - 1)]
+        )
+
+        # It returns count of updated records
+        self.assertEqual(n_updated_team_matches, len(self.team_match_collection))
+
+        unique_updated_team_match_scores = np.unique(
+            [team_match.score for team_match in self.team_match_collection]
+        )
+
+        # It updates the given attribute for all team matches in the collection
+        self.assertEqual(len(unique_updated_team_match_scores), 1)

--- a/backend/server/tests/unit/test_schema.py
+++ b/backend/server/tests/unit/test_schema.py
@@ -480,9 +480,9 @@ class TestSchema(TestCase):
 
             with freeze_time(fake_datetime):
                 # Need to set scores for "future" matches to 0
-                TeamMatch.objects.filter(
-                    match__start_date_time__gte=fake_datetime
-                ).update(score=0)
+                TeamMatch.filter(match__start_date_time__gte=fake_datetime).update(
+                    score=0
+                )
 
                 past_executed = self.client.execute(
                     query, variables={"mlModelName": "predictanator"}
@@ -596,7 +596,7 @@ class TestSchema(TestCase):
         self.assertNotEqual(data["cumulativeBits"], 0)
 
         with self.subTest("when the last matches don't have updated results yet"):
-            TeamMatch.objects.filter(
+            TeamMatch.filter(
                 match__start_date_time__year=YEAR, match__round_number=ROUND_COUNT
             ).update(score=0)
 

--- a/backend/server/tests/unit/test_views.py
+++ b/backend/server/tests/unit/test_views.py
@@ -257,7 +257,7 @@ class TestViews(TestCase):
         matches = {"data": match_results_data}
 
         # Pretend the scores haven't been updated yet
-        TeamMatch.objects.all().update(score=0)
+        TeamMatch.all().update(score=0)
         self.assertEqual(Match.objects.filter(teammatch__score__gt=0).count(), 0)
 
         with self.subTest("GET request"):
@@ -294,10 +294,8 @@ class TestViews(TestCase):
 
                 # It updates match scores
                 self.assertEqual(
-                    TeamMatch.objects.filter(score__gt=0).count(),
-                    TeamMatch.objects.filter(
-                        match__start_date_time__lt=timezone.now()
-                    ).count(),
+                    TeamMatch.filter(score__gt=0).count(),
+                    TeamMatch.filter(match__start_date_time__lt=timezone.now()).count(),
                 )
                 # It returns success response
                 self.assertEqual(response.status_code, 200)


### PR DESCRIPTION
This hides the Django-specific `objects` method call from DB
queries inside the model classes to make it easier to move to a
different ORM for working with FaunaDB.