### PR TITLE
Remove ORM functionality that doesn't exist in FaunaDB

### DIFF
--- a/backend/server/graphql/schema.py
+++ b/backend/server/graphql/schema.py
@@ -11,10 +11,7 @@ import numpy as np
 
 from server.models import Prediction, Match, MLModel
 from server.types import RoundMetrics
-from server.graphql.calculations import (
-    cumulative_metrics_query,
-    calculate_cumulative_metrics,
-)
+from server.graphql.calculations import calculate_cumulative_metrics
 from .types import (
     SeasonType,
     PredictionType,
@@ -269,17 +266,29 @@ class Query(graphene.ObjectType):
             .first()
         )
 
-        prediction_query_set = Prediction.objects.filter(
-            match__start_date_time__year=max_match_with_results.year,
-            ml_model__used_in_competitions=True,
-        )
-        additional_metric_values = [
-            "match__start_date_time__year",
-            "match__id",
-            "ml_model__is_principal",
-        ]
-        metric_values = cumulative_metrics_query(
-            prediction_query_set, additional_metric_values,
+        metric_values = (
+            Prediction.objects.filter(
+                match__start_date_time__year=max_match_with_results.year,
+                ml_model__used_in_competitions=True,
+                # We don't want to include matches without results, which would impact
+                # mean-based metrics like accuracy and MAE
+                match__teammatch__score__gt=0,
+            )
+            .select_related("ml_model", "match")
+            .values(
+                "match__id",
+                "match__margin",
+                "match__winner__name",
+                "match__round_number",
+                "match__start_date_time",
+                "ml_model__is_principal",
+                "ml_model__name",
+                "ml_model__used_in_competitions",
+                "predicted_margin",
+                "predicted_winner__name",
+                "predicted_win_probability",
+                "is_correct",
+            )
         )
 
         metrics_df = calculate_cumulative_metrics(

--- a/backend/server/graphql/types/season.py
+++ b/backend/server/graphql/types/season.py
@@ -106,7 +106,7 @@ class RoundPredictionType(graphene.ObjectType):
                 "predicted_win_probability",
                 "is_correct",
             )
-        )
+        ).sort_values("match__start_date_time")
 
         principal_predictions = predictions.query(
             "ml_model__is_principal == True"

--- a/backend/server/management/commands/send_email.py
+++ b/backend/server/management/commands/send_email.py
@@ -47,19 +47,18 @@ class Command(BaseCommand):
         upcoming_match_year = upcoming_match.start_date_time.year
         upcoming_round = upcoming_match.round_number
 
-        upcoming_matches = (
-            Match.objects.filter(
-                start_date_time__gt=timezone.make_aware(
-                    datetime(upcoming_match_year, JAN, FIRST)
-                ),
-                round_number=upcoming_round,
-            )
-            .prefetch_related("teammatch_set", "prediction_set")
-            .order_by("start_date_time")
-        )
+        upcoming_matches = Match.objects.filter(
+            start_date_time__gt=timezone.make_aware(
+                datetime(upcoming_match_year, JAN, FIRST)
+            ),
+            round_number=upcoming_round,
+        ).prefetch_related("teammatch_set", "prediction_set")
 
         prediction_rows = [
-            self.__map_prediction_to_row(match) for match in upcoming_matches
+            self.__map_prediction_to_row(match)
+            for match in sorted(
+                upcoming_matches, key=lambda match: match.start_date_time
+            )
         ]
 
         self.__send_tips_email(prediction_rows, upcoming_round)

--- a/backend/server/tests/fixtures/data_factories.py
+++ b/backend/server/tests/fixtures/data_factories.py
@@ -92,7 +92,14 @@ def _fake_match_data_for_pred(match_data):
             ]
         )
 
-    return fake_fixture_data(fixtures=match_data)
+    ROUND_COLS = set(["round", "round_number"])
+    match_data_for_fixture = (
+        match_data.drop("round", axis=1)
+        if ROUND_COLS & set(match_data.columns) == ROUND_COLS
+        else match_data
+    )
+
+    return fake_fixture_data(fixtures=match_data_for_fixture)
 
 
 def fake_prediction_data(

--- a/backend/server/tests/fixtures/factories.py
+++ b/backend/server/tests/fixtures/factories.py
@@ -196,13 +196,17 @@ class PredictionFactory(DjangoModelFactory):
 
         force_correct = factory.Trait(
             predicted_winner=factory.LazyAttribute(
-                lambda pred: pred.match.teammatch_set.order_by("-score").first().team
+                lambda pred: max(
+                    pred.match.teammatch_set.all(), key=lambda pred: pred.score
+                ).team
             )
         )
 
         force_incorrect = factory.Trait(
             predicted_winner=factory.LazyAttribute(
-                lambda pred: pred.match.teammatch_set.order_by("score").first().team
+                lambda pred: min(
+                    pred.match.teammatch_set.all(), key=lambda pred: pred.score
+                ).team
             )
         )
 

--- a/backend/server/tests/integration/test_api.py
+++ b/backend/server/tests/integration/test_api.py
@@ -194,11 +194,8 @@ class TestApi(TestCase):
         for idx in range(MATCH_COUNT * 2):
             factories.FullMatchFactory(future=(idx % 2 == 0), with_predictions=True)
 
-        next_match = (
-            Match.objects.filter(start_date_time__gt=timezone.now())
-            .order_by("start_date_time")
-            .first()
-        )
+        future_matches = Match.objects.filter(start_date_time__gt=timezone.now())
+        next_match = min(future_matches, key=lambda match: match.start_date_time)
 
         latest_predictions = self.api.fetch_latest_round_predictions()
         latest_matches = Match.objects.filter(

--- a/backend/server/tests/unit/test_schema.py
+++ b/backend/server/tests/unit/test_schema.py
@@ -275,10 +275,11 @@ class TestSchema(TestCase):
             data = executed["data"]["fetchSeasonModelMetrics"]["roundModelMetrics"]
 
             self.assertEqual(len(data), 1)
-            self.assertEqual(
-                data[0]["roundNumber"],
-                Match.objects.order_by("round_number").last().round_number,
-            )
+
+            max_round_number = max(
+                Match.objects.all(), key=lambda match: match.round_number
+            ).round_number
+            self.assertEqual(data[0]["roundNumber"], max_round_number)
 
     def test_fetch_latest_round_predictions(self):
         ml_models = list(MLModel.objects.all())
@@ -435,6 +436,7 @@ class TestSchema(TestCase):
             """
 
         with self.subTest("for a 'Win Probability' model"):
+            print("win probability")
             executed = self.client.execute(
                 query, variables={"mlModelName": "accurate_af"}
             )
@@ -495,10 +497,9 @@ class TestSchema(TestCase):
                     "roundModelMetrics"
                 ][0]
 
-                max_match_round = (
-                    Match.objects.all().order_by("-round_number").first().round_number
-                )
-
+                max_match_round = max(
+                    Match.objects.all(), key=lambda match: match.round_number
+                ).round_number
                 self.assertLess(data["roundNumber"], max_match_round)
                 # Last played match will be from day before, because "now" and the
                 # start time for "today's match" are equal
@@ -620,9 +621,9 @@ class TestSchema(TestCase):
 
                 data = past_executed["data"]["fetchLatestRoundMetrics"]
 
-                max_match_round = (
-                    Match.objects.all().order_by("-round_number").first().round_number
-                )
+                max_match_round = max(
+                    Match.objects.all(), key=lambda match: match.round_number
+                ).round_number
                 self.assertLess(data["roundNumber"], max_match_round)
                 # Last played match will be from day before, because "now" and the
                 # start time for "today's match" are equal


### PR DESCRIPTION
I'm offloading some SQL query logic onto in-memory code (often `pandas`) to make the transition to FaunaDB a little less huge. For now, this means doing all aggregation/cumulative calculations in data frames and all ordering outside an ORM query.