### PR TITLE
Fix filtering for `update_match_results`

### DIFF
--- a/tipping/src/tests/fixtures/data_factories.py
+++ b/tipping/src/tests/fixtures/data_factories.py
@@ -53,12 +53,16 @@ def fake_match_data(
         else match_results
     )
 
-    return match_results.rename(
-        columns={
-            "season": "year",
-            "home_points": "home_score",
-            "away_points": "away_score",
-        }
+    return (
+        match_results.rename(
+            columns={
+                "season": "year",
+                "home_points": "home_score",
+                "away_points": "away_score",
+            }
+        )
+        # Recreates data cleaning performed in data_import
+        .assign(date=lambda df: pd.to_datetime(df["date"], utc=True))
     )
 
 
@@ -82,7 +86,7 @@ def fake_fixture_data(
         fixtures.rename(columns={"season": "year", "round": "round_number"}).drop(
             "season_game", axis=1, errors="ignore"
         )
-        # Recreates data cleaning performed in views.fixtures
+        # Recreates data cleaning performed in data_import
         .assign(date=lambda df: pd.to_datetime(df["date"], utc=True))
     )
 

--- a/tipping/src/tipping/api.py
+++ b/tipping/src/tipping/api.py
@@ -64,11 +64,12 @@ def _fetch_current_round_fixture(verbose) -> Optional[pd.DataFrame]:
         print(f"Fetching fixture for matches after {beginning_of_today}...\n")
 
     fixture_data_frame = data_import.fetch_fixture_data(
-        start_date=beginning_of_this_year, end_date=end_of_this_year,
+        start_date=beginning_of_this_year,
+        end_date=end_of_this_year,
     )
 
     matches_from_current_round = _select_matches_from_current_round(
-        fixture_data_frame, right_now
+        fixture_data_frame, beginning_of_today
     )
 
     return matches_from_current_round
@@ -111,7 +112,8 @@ def update_match_predictions(tips_submitters=None, verbose=1) -> None:
         print("Fetching predictions for round " f"{current_round}, {current_season}...")
 
     prediction_data = data_import.fetch_prediction_data(
-        f"{current_season}-{current_season + 1}", round_number=current_round,
+        f"{current_season}-{current_season + 1}",
+        round_number=current_round,
     )
 
     if verbose == 1:

--- a/tipping/src/tipping/api.py
+++ b/tipping/src/tipping/api.py
@@ -18,7 +18,7 @@ FIRST = 1
 
 
 def _select_matches_from_current_round(
-    fixture_data_frame: pd.DataFrame, beginning_of_today: datetime
+    fixture_data_frame: pd.DataFrame, beginning_of_today: datetime, after=True
 ) -> Optional[pd.DataFrame]:
     if not fixture_data_frame.any().any():
         warn(
@@ -30,7 +30,7 @@ def _select_matches_from_current_round(
 
     latest_match_date = fixture_data_frame["date"].max()
 
-    if beginning_of_today > latest_match_date:
+    if beginning_of_today > latest_match_date and after:
         warn(
             f"No matches found after {beginning_of_today}. The latest match "
             f"found is at {latest_match_date}\n"
@@ -38,11 +38,14 @@ def _select_matches_from_current_round(
 
         return None
 
+    date_comparison = ">" if after else "<"
+    latest_round_numbers = fixture_data_frame.query(
+        f"date {date_comparison} @beginning_of_today"
+    ).loc[:, "round_number"]
     current_round = int(  # pylint: disable=unused-variable
-        fixture_data_frame.query("date > @beginning_of_today")
-        .loc[:, "round_number"]
-        .min()
+        latest_round_numbers.min() if after else latest_round_numbers.max()
     )
+
     fixture_for_current_round = fixture_data_frame.query(
         "round_number == @current_round"
     )
@@ -50,7 +53,7 @@ def _select_matches_from_current_round(
     return fixture_for_current_round
 
 
-def _fetch_current_round_fixture(verbose) -> Optional[pd.DataFrame]:
+def _fetch_current_round_fixture(verbose, after=True) -> Optional[pd.DataFrame]:
     right_now = datetime.now(tz=pytz.UTC)
     beginning_of_today = right_now.replace(hour=0, minute=0, second=0, microsecond=0)
     beginning_of_this_year = datetime(
@@ -61,7 +64,8 @@ def _fetch_current_round_fixture(verbose) -> Optional[pd.DataFrame]:
     )
 
     if verbose == 1:
-        print(f"Fetching fixture for matches after {beginning_of_today}...\n")
+        preposition = "after" if after else "up to"
+        print(f"Fetching fixture for matches {preposition} {beginning_of_today}...\n")
 
     fixture_data_frame = data_import.fetch_fixture_data(
         start_date=beginning_of_this_year,
@@ -69,7 +73,7 @@ def _fetch_current_round_fixture(verbose) -> Optional[pd.DataFrame]:
     )
 
     matches_from_current_round = _select_matches_from_current_round(
-        fixture_data_frame, beginning_of_today
+        fixture_data_frame, beginning_of_today, after=after
     )
 
     return matches_from_current_round
@@ -177,7 +181,7 @@ def update_match_results(verbose=1) -> None:
 
     verbose: How much information to print. 1 prints all messages; 0 prints none.
     """
-    matches_from_current_round = _fetch_current_round_fixture(verbose)
+    matches_from_current_round = _fetch_current_round_fixture(verbose, after=False)
 
     if matches_from_current_round is None:
         return None


### PR DESCRIPTION
A previous fix was incomplete, as the filtering function was still selecting for matches after the current date time rather than matches after the beginning of the current date, which meant that the last match of the round always got missed. In addition to fixing the bug, I added a param to allow `update_match_results` to define the current round as the that of the most-recent match rather than the next match. This makes sense since updating match results is more concerned with past matches, whereas fixtures/predictions are more concerned with future matches. It's a little hacky, but it works and the overall functionality is similar enough to just leave it for now.