### PR TITLE
Add serverless prune to delete old versions & layers of functions

### DIFF
--- a/tipping/package-lock.json
+++ b/tipping/package-lock.json
@@ -8136,6 +8136,15 @@
                 }
             }
         },
+        "serverless-prune-plugin": {
+            "version": "1.4.3",
+            "resolved": "https://registry.npmjs.org/serverless-prune-plugin/-/serverless-prune-plugin-1.4.3.tgz",
+            "integrity": "sha512-gsZF3oLs5rFdp6ynjiWf5cuXZ4DZrAhxRd5Zf2gfH/43kPqtZMZzUqcGYbHh1OXbOzogdn8fEg5d4Q3xxWwRBA==",
+            "dev": true,
+            "requires": {
+                "bluebird": "^3.4.7"
+            }
+        },
         "serverless-python-requirements": {
             "version": "5.1.0",
             "resolved": "https://registry.npmjs.org/serverless-python-requirements/-/serverless-python-requirements-5.1.0.tgz",

--- a/tipping/package.json
+++ b/tipping/package.json
@@ -22,6 +22,7 @@
   "devDependencies": {
     "fauna-shell": "^0.11.5",
     "serverless": "^2.9.0",
-    "serverless-offline": "^6.8.0"
+    "serverless-offline": "^6.8.0",
+    "serverless-prune-plugin": "^1.4.3"
   }
 }

--- a/tipping/serverless.yml
+++ b/tipping/serverless.yml
@@ -44,10 +44,15 @@ provider:
 plugins:
   - serverless-offline
   - serverless-python-requirements
+  - serverless-prune-plugin
 
 custom:
   pythonRequirements:
     dockerizePip: false # We run sls inside Docker already
+  prune:
+    automatic: true
+    includeLayers: true
+    number: 3
 
 package:
   include:


### PR DESCRIPTION
I didn't realise that Serverless Framework saves ALL versions
of functions forever, so I ended up running up against the
Lambda storage limit. This will still save a few versions while
automatically deleting old ones on deploy, as God intended.