### PR TITLE
Use slim and prod-specific requirements

### DIFF
--- a/tipping/Dockerfile
+++ b/tipping/Dockerfile
@@ -19,7 +19,7 @@ COPY package.json package-lock.json ./
 RUN npm install
 
 # Install Python dependencies
-COPY requirements.txt .
+COPY requirements.txt requirements.prod.txt ./
 RUN pip3 install --upgrade pip -r requirements.txt
 
 # Add the rest of the code

--- a/tipping/requirements.prod.txt
+++ b/tipping/requirements.prod.txt
@@ -1,0 +1,13 @@
+# Data packages
+numpy
+pandas>=0.23.0,<1.2
+
+# App packages
+requests
+pytz
+simplejson
+rollbar
+gql==3.0.0a3
+
+# Browser automation
+MechanicalSoup

--- a/tipping/requirements.txt
+++ b/tipping/requirements.txt
@@ -1,16 +1,4 @@
-# Data packages
-numpy
-pandas>=0.23.0,<1.2
-
-# App packages
-requests
-pytz
-simplejson
-rollbar
-gql==3.0.0a3
-
-# Browser automation
-MechanicalSoup
+-r requirements.prod.txt
 
 # Testing/Linting
 pylint==2.6.0

--- a/tipping/serverless.yml
+++ b/tipping/serverless.yml
@@ -49,6 +49,8 @@ plugins:
 custom:
   pythonRequirements:
     dockerizePip: false # We run sls inside Docker already
+    slim: true
+    fileName: requirements.prod.txt
   prune:
     automatic: true
     includeLayers: true


### PR DESCRIPTION
This should reduce the code bundle size a bit, which will
hopefully get us under the 50MB limit. If not, we can try using
a layer for dependencies, which I believe has a 250MB limit.