### PR TITLE
Fix pylint recursion bug by fixing pandas version to previous patch

### DIFF
--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -1,5 +1,5 @@
 # Data packages
-numpy
+numpy==1.19.4
 pandas==1.1.4
 
 # App packages

--- a/tipping/requirements.prod.txt
+++ b/tipping/requirements.prod.txt
@@ -1,5 +1,5 @@
 # Data packages
-numpy
+numpy==1.19.4
 pandas==1.1.4
 
 # App packages

--- a/tipping/requirements.prod.txt
+++ b/tipping/requirements.prod.txt
@@ -1,6 +1,6 @@
 # Data packages
 numpy
-pandas>=0.23.0,<1.2
+pandas==1.1.4
 
 # App packages
 requests

--- a/tipping/requirements.prod.txt
+++ b/tipping/requirements.prod.txt
@@ -4,7 +4,6 @@ pandas==1.1.4
 
 # App packages
 requests
-pytz
 simplejson
 rollbar
 gql==3.0.0a3


### PR DESCRIPTION
The latest version of `pandas` (1.1.5) breaks `pylint`. I also took the opportunity to fix `numpy`'s version and remove `pytz` from `requirements.txt`.