### PR TITLE
Update dependabot config

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,32 +4,29 @@ updates:
   directory: "/tipping"
   schedule:
     interval: monthly
-    time: "19:00"
-  open-pull-requests-limit: 10
+  open-pull-requests-limit: 25
 - package-ecosystem: npm
   directory: "/tipping"
   schedule:
     interval: monthly
-    time: "19:00"
-  open-pull-requests-limit: 10
+  open-pull-requests-limit: 25
 - package-ecosystem: pip
   directory: "/tipping"
   schedule:
     interval: weekly
-    time: "19:00"
-  open-pull-requests-limit: 10
+    day: wednesday
+  open-pull-requests-limit: 25
 - package-ecosystem: npm
   directory: "/browser_test"
   schedule:
     interval: weekly
-    time: "19:00"
-  open-pull-requests-limit: 10
+    day: sunday
+  open-pull-requests-limit: 25
 - package-ecosystem: docker
   directory: "/backend"
   schedule:
     interval: monthly
-    time: "19:00"
-  open-pull-requests-limit: 10
+  open-pull-requests-limit: 25
   ignore:
   - dependency-name: python
     versions:
@@ -39,8 +36,7 @@ updates:
   directory: "/frontend"
   schedule:
     interval: monthly
-    time: "19:00"
-  open-pull-requests-limit: 10
+  open-pull-requests-limit: 25
   ignore:
   - dependency-name: node
     versions:
@@ -50,11 +46,11 @@ updates:
   directory: "/backend"
   schedule:
     interval: weekly
-    time: "19:00"
-  open-pull-requests-limit: 10
+    day: monday
+  open-pull-requests-limit: 25
 - package-ecosystem: npm
   directory: "/frontend"
   schedule:
     interval: weekly
-    time: "19:00"
-  open-pull-requests-limit: 10
+    day: friday
+  open-pull-requests-limit: 25

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -27,21 +27,11 @@ updates:
   schedule:
     interval: monthly
   open-pull-requests-limit: 25
-  ignore:
-  - dependency-name: python
-    versions:
-    - "> 3.8.1.pre.slim.pre.buster"
-    - "< 3.9"
 - package-ecosystem: docker
   directory: "/frontend"
   schedule:
     interval: monthly
   open-pull-requests-limit: 25
-  ignore:
-  - dependency-name: node
-    versions:
-    - "> 13.5.0.pre.buster.pre.slim"
-    - "< 13.6"
 - package-ecosystem: pip
   directory: "/backend"
   schedule:


### PR DESCRIPTION
This was auto-generated when Dependabot migrated to GitHub/v2, and some of the settings are out of date. Others were stifling PRs too much, which was preventing enough dependencies from being updated each week to keep up with all the new versions coming out.