### PR TITLE
Fix up CI odds and ends

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -44,3 +44,7 @@ updates:
     interval: weekly
     day: friday
   open-pull-requests-limit: 25
+  ignore:
+    # Because it's breaking builds now, and it's annoying to fix,
+    # and I want to move to typescript eventually
+    - dependency-name: "flow-bin"

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -13,6 +13,7 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - name: Set up code coverage monitoring
+        if: ${{ github.ref == 'refs/heads/main' }}
         run: |
           curl -L https://codeclimate.com/downloads/test-reporter/test-reporter-latest-linux-amd64 > ./cc-test-reporter
           chmod +x ./cc-test-reporter

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Tipresias
 
-[![Build Status](https://travis-ci.com/tipresias/tipresias.svg?branch=main)](https://travis-ci.com/tipresias/tipresias)
+![build](https://github.com/tipresias/tipresias/workflows/build/badge.svg)
 <a href="https://codeclimate.com/github/tipresias/tipresias/maintainability"><img src="https://api.codeclimate.com/v1/badges/b6a40f7f72b307763b88/maintainability" /></a>
 <a href="https://codeclimate.com/github/tipresias/tipresias/test_coverage"><img src="https://api.codeclimate.com/v1/badges/b6a40f7f72b307763b88/test_coverage" /></a>
 


### PR DESCRIPTION
We were skipping the upload of test coverage on non-main branches, but I forgot to skip the test coverage setup step as well. Also, I'm skipping `flow-bin`, because it's annoying, and I want to migrate over to a Gatsby/Typescript setup for `frontend` eventually.