### PR TITLE
Downgrade version of CodeClimate test coverage binary

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -15,7 +15,7 @@ jobs:
       - name: Set up code coverage monitoring
         if: ${{ github.ref == 'refs/heads/main' }}
         run: |
-          curl -L https://codeclimate.com/downloads/test-reporter/test-reporter-latest-linux-amd64 > ./cc-test-reporter
+          curl -L https://codeclimate.com/downloads/test-reporter/test-reporter-0.6.3-linux-amd64 > ./cc-test-reporter
           chmod +x ./cc-test-reporter
           ./cc-test-reporter before-build
       - name: Build images


### PR DESCRIPTION
Something in the 'latest' version breaks when we try to run it
in CI. It says that the binary is not executable. The older
version works as expected.