### PR TITLE
Fix frontend build during deployment

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -97,6 +97,7 @@ deploy_rsa.enc
 *.sql
 data_science
 db/backups
+.github
 
 # GCP files
 .gcloud

--- a/Dockerfile
+++ b/Dockerfile
@@ -8,9 +8,11 @@ WORKDIR /app
 # Build static files
 RUN yarn run build \
   && mkdir -p frontend/build/root \
-  # Have to move all static files other than index.html to root/
-  # for whitenoise middleware
-  && mv build/*.ico build/*.js build/*.json frontend/build/root/ \
+  # Have to move all static files other than index.html to 'root'
+  # for whitenoise middleware.
+  # Moving all files except one is more complicated than I would have guessed
+  # and varies by shell implementation, hence the convoluted command below.
+  && find frontend/build -type f -maxdepth 1 -not -name index.html -exec mv {} frontend/build/root \; \
   && mv build/* frontend/build/
 
 # Using Python base image instead of backend image, because we leave out


### PR DESCRIPTION
With a major version update, react-scripts changed the structure
of their build directory, which broke the previous 'mv' command
with empty file globs. Moving all except 'index.html' is more
robust to these sorts of changes, but requires a slightly
convoluted command in order to work in Docker's bash shell.