### PR TITLE
Update prediction data in FaunaDB

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,6 +66,8 @@ Seed the DB with raw data:
 
 - `docker-compose run --rm backend python3 -Wi manage.py test`
   - Note: Pass CI=true as an env var to skip some of the longer end-to-end tests.
+  - The `tipping` service uses `pytest` rather than Django's test runner.
+    - For watch mode, run `docker-compose run --rm tipping ptw -c -n -- <pytest args>` (`-c` clears output between runs, `-n` means "no beep" on test failures).
 - Linting: `docker-compose run --rm backend pylint --disable=R <python modules you want to lint>`
   - Note: `-d=R` disables refactoring checks for quicker, less-opinionated linting. Remove that option if you want to include those checks.
 - Type checking: `docker-compose run mypy <python modules you want to check>`

--- a/tipping/pytest.ini
+++ b/tipping/pytest.ini
@@ -1,0 +1,3 @@
+[pytest-watch]
+clear = True
+nobeep = True

--- a/tipping/requirements.txt
+++ b/tipping/requirements.txt
@@ -7,6 +7,7 @@ black
 pytest
 pytest-env
 faker==5.0.2
+pytest-watch
 mypy>=0.70
 freezegun==1.0.0
 factory_boy

--- a/tipping/src/tests/fixtures/data_factories.py
+++ b/tipping/src/tests/fixtures/data_factories.py
@@ -9,6 +9,7 @@ import pandas as pd
 from candystore import CandyStore
 
 from tipping import settings
+from tipping.helpers import pivot_team_matches_to_matches
 
 
 FAKE = Faker()
@@ -173,6 +174,7 @@ def fake_prediction_data(
     fixtures: Optional[pd.DataFrame] = None,
     ml_model_name="test_estimator",
     predict_margin=True,
+    pivot_home_away=False,
 ) -> pd.DataFrame:
     """
     Return minimally-valid prediction data.
@@ -191,7 +193,7 @@ def fake_prediction_data(
     fixture_data = fake_fixture_data(fixtures)
     match_count = len(fixture_data)
 
-    return pd.concat(
+    prediction_data = pd.concat(
         [_build_team_matches(fixture_data, team_type) for team_type in TEAM_TYPES]
     ).assign(
         predicted_margin=np.random.rand(match_count * 2) * 50
@@ -202,6 +204,11 @@ def fake_prediction_data(
         else np.random.rand(match_count * 2),
         ml_model=ml_model_name,
     )
+
+    if pivot_home_away:
+        return pivot_team_matches_to_matches(prediction_data)
+
+    return prediction_data
 
 
 def fake_ml_model_data(n_models: int = 1) -> pd.DataFrame:

--- a/tipping/src/tests/fixtures/factories.py
+++ b/tipping/src/tests/fixtures/factories.py
@@ -191,6 +191,11 @@ class MatchFactory(TippingFactory):
         size=2,
     )
 
+    @factory.post_generation
+    def calculate_winner(obj, _create, _extracted, **_kwargs):
+        "Assign correct winner to the given match."
+        obj.winner = obj._calculate_winner()
+
     @classmethod
     def _create(cls, model_class, *args, **kwargs):
         model_instance = model_class(**kwargs)

--- a/tipping/src/tests/fixtures/factories.py
+++ b/tipping/src/tests/fixtures/factories.py
@@ -5,8 +5,9 @@ import math
 
 import factory
 from faker import Faker
+import numpy as np
 
-from tipping.models import Team, Match, TeamMatch
+from tipping.models import Team, Match, TeamMatch, MLModel
 from tipping import settings
 
 FAKE = Faker()
@@ -120,6 +121,28 @@ class TeamFactory(TippingFactory):
         model = Team
 
     name = factory.Faker("company")
+
+    @classmethod
+    def _create(cls, model_class, *args, **kwargs):
+        model_instance = model_class(**kwargs)
+        model_instance.create()
+        return model_instance
+
+
+class MLModelFactory(TippingFactory):
+    """Factory class for the MLModel data model."""
+
+    class Meta:
+        """Factory attributes for recreating the associated model's attributes."""
+
+        model = MLModel
+
+    name = factory.Faker("company")
+    is_principal = False
+    used_in_competitions = False
+    prediction_type = factory.LazyFunction(
+        lambda: np.random.choice(MLModel.PREDICTION_TYPES)
+    )
 
     @classmethod
     def _create(cls, model_class, *args, **kwargs):

--- a/tipping/src/tests/fixtures/factories.py
+++ b/tipping/src/tests/fixtures/factories.py
@@ -165,11 +165,7 @@ class MatchFactory(TippingFactory):
         lambda n: math.ceil((n + 1) / TYPICAL_N_MATCHES_PER_ROUND)
         % N_ROUNDS_PER_REGULAR_SEASON
     )
-    venue = factory.LazyFunction(
-        lambda: settings.VENUES[
-            FAKE.pyint(min_value=0, max_value=(len(settings.VENUES) - 1))
-        ]
-    )
+    venue = factory.LazyFunction(lambda: np.random.choice(settings.VENUES))
 
     class Params:
         """Params for modifying the factory's default attributes."""

--- a/tipping/src/tests/integration/models/test_ml_model.py
+++ b/tipping/src/tests/integration/models/test_ml_model.py
@@ -1,4 +1,4 @@
-# pylint: disable=missing-docstring
+# pylint: disable=missing-docstring,unused-argument
 
 import pytest
 from faker import Faker
@@ -32,9 +32,7 @@ FAKE = Faker()
         ),
     ],
 )
-def test_unique_value_constraint(
-    faunadb_client, unique_attribute, error, message
-):  # pylint: disable=unused-argument
+def test_unique_value_constraint(faunadb_client, unique_attribute, error, message):
     MLModelFactory.create(**unique_attribute)
     ml_model = MLModelFactory.build(**unique_attribute)
 
@@ -69,7 +67,7 @@ def test_saving_valid_ml_model(faunadb_client):
     assert result["findMLModelByID"]["_id"]
 
 
-def test_fetching_all_ml_models(faunadb_client):  # pylint: disable=unused-argument
+def test_fetching_all_ml_models(faunadb_client):
     ml_model_count = np.random.randint(1, 11)
 
     for _ in range(ml_model_count):
@@ -83,3 +81,16 @@ def test_fetching_all_ml_models(faunadb_client):  # pylint: disable=unused-argum
 
     # It returns all ML models in the DB
     assert len(result) == ml_model_count
+
+
+def test_finding_an_ml_model_by_name(faunadb_client):
+    ml_models = MLModelFactory.create_batch(3)
+    ml_model = ml_models[-1]
+
+    found_ml_model = MLModel.find_by_name(name=ml_model.name)
+
+    # It returns an MLModel instance
+    assert isinstance(found_ml_model, MLModel)
+
+    # It returns the queried MLModel record
+    assert found_ml_model.name == ml_model.name

--- a/tipping/src/tests/integration/models/test_ml_model.py
+++ b/tipping/src/tests/integration/models/test_ml_model.py
@@ -67,3 +67,19 @@ def test_saving_valid_ml_model(faunadb_client):
     query = "query { findMLModelByID(id: %s) { _id } }" % (saved_ml_model.id)
     result = faunadb_client.graphql(query)
     assert result["findMLModelByID"]["_id"]
+
+
+def test_fetching_all_ml_models(faunadb_client):  # pylint: disable=unused-argument
+    ml_model_count = np.random.randint(1, 11)
+
+    for _ in range(ml_model_count):
+        MLModelFactory.create()
+
+    result = MLModel.all()
+
+    # It returns MLModel objects
+    for ml_model in result:
+        assert isinstance(ml_model, MLModel)
+
+    # It returns all ML models in the DB
+    assert len(result) == ml_model_count

--- a/tipping/src/tests/integration/models/test_ml_model.py
+++ b/tipping/src/tests/integration/models/test_ml_model.py
@@ -1,0 +1,69 @@
+# pylint: disable=missing-docstring
+
+import pytest
+from faker import Faker
+import numpy as np
+
+from tests.fixtures.factories import MLModelFactory
+from tipping.db.faunadb import GraphQLError
+from tipping.models import MLModel
+from tipping.models.base_model import ValidationError
+
+
+FAKE = Faker()
+
+
+@pytest.mark.parametrize(
+    ["unique_attribute", "error", "message"],
+    [
+        ({"name": FAKE.company()}, GraphQLError, r"instance not unique"),
+        (
+            {"is_principal": True},
+            ValidationError,
+            r"duplicate principal ML models not allowed",
+        ),
+        (
+            {
+                "used_in_competitions": True,
+                "prediction_type": np.random.choice(MLModel.PREDICTION_TYPES),
+            },
+            ValidationError,
+            r"duplicate prediction types not allowed for competitions",
+        ),
+    ],
+)
+def test_unique_value_constraint(
+    faunadb_client, unique_attribute, error, message
+):  # pylint: disable=unused-argument
+    MLModelFactory.create(**unique_attribute)
+    ml_model = MLModelFactory.build(**unique_attribute)
+
+    # It raises a ValidationError
+    with pytest.raises(error, match=message):
+        ml_model.create()
+
+    # It doesn't save the ml_model
+    query = """
+        query {
+            allMLModels {
+                data {
+                    _id
+                }
+            }
+        }
+    """
+    result = faunadb_client.graphql(query)
+    assert len(result["allMLModels"]["data"]) == 1
+
+
+def test_saving_valid_ml_model(faunadb_client):
+    ml_model = MLModelFactory.build()
+    saved_ml_model = ml_model.create()
+
+    # It returns the saved ml_model
+    assert saved_ml_model == ml_model
+
+    # It saves the ml_model in the DB
+    query = "query { findMLModelByID(id: %s) { _id } }" % (saved_ml_model.id)
+    result = faunadb_client.graphql(query)
+    assert result["findMLModelByID"]["_id"]

--- a/tipping/src/tests/integration/models/test_prediction.py
+++ b/tipping/src/tests/integration/models/test_prediction.py
@@ -1,0 +1,27 @@
+# pylint: disable=missing-docstring
+
+from faker import Faker
+import numpy as np
+
+from tests.fixtures.factories import PredictionFactory, MatchFactory, MLModelFactory
+
+
+FAKE = Faker()
+
+
+def test_saving_valid_prediction(faunadb_client):
+    match = MatchFactory.create()
+    ml_model = MLModelFactory.create()
+    predicted_winner = np.random.choice(match.team_matches).team
+    prediction = PredictionFactory.build(
+        match=match, ml_model=ml_model, predicted_winner=predicted_winner
+    )
+    saved_prediction = prediction.create()
+
+    # It returns the saved prediction
+    assert saved_prediction == prediction
+
+    # It saves the prediction in the DB
+    query = "query { findPredictionByID(id: %s) { _id } }" % (saved_prediction.id)
+    result = faunadb_client.graphql(query)
+    assert result["findPredictionByID"]["_id"]

--- a/tipping/src/tests/integration/models/test_prediction.py
+++ b/tipping/src/tests/integration/models/test_prediction.py
@@ -2,6 +2,7 @@
 
 from faker import Faker
 import numpy as np
+import pandas as pd
 
 from tests.fixtures.factories import PredictionFactory, MatchFactory, MLModelFactory
 from tests.fixtures.data_factories import fake_prediction_data
@@ -48,3 +49,59 @@ def test_updating_valid_prediction(faunadb_client):  # pylint: disable=unused-ar
     # The original prediction has updated attribute values
     assert prediction.was_correct == updated_was_correct
     assert prediction.predicted_margin == updated_predicted_margin
+
+
+def test_updating_or_creating_prediction_from_raw_data(faunadb_client):
+    ml_model = MLModelFactory.create()
+    match = MatchFactory.create()
+    prediction_data = fake_prediction_data(
+        ml_model_name=ml_model.name, pivot_home_away=True
+    )
+
+    old_prediction_data = prediction_data.iloc[0, :].to_dict()
+    old_prediction_data["year"] = match.season
+    old_prediction_data["round_number"] = match.round_number
+    for team_match in match.team_matches:
+        if team_match.at_home:
+            old_prediction_data["home_team"] = team_match.team.name
+        else:
+            old_prediction_data["away_team"] = team_match.team.name
+
+    created_prediction = Prediction.update_or_create_from_raw_data(
+        pd.Series(old_prediction_data)
+    )
+
+    # It saves the prediction in the DB
+    query = "query { findPredictionByID(id: %s) { _id } }" % (created_prediction.id)
+    result = faunadb_client.graphql(query)
+    assert result["findPredictionByID"]["_id"]
+
+    new_prediction_data = prediction_data.iloc[1, :]
+
+    updated_prediction = Prediction.update_or_create_from_raw_data(
+        pd.Series(
+            {
+                **old_prediction_data,
+                **{
+                    "home_predicted_margin": new_prediction_data[
+                        "home_predicted_margin"
+                    ],
+                    "home_predicted_win_probability": new_prediction_data[
+                        "home_predicted_win_probability"
+                    ],
+                },
+            }
+        )
+    )
+
+    # It updates the same prediction
+    assert created_prediction.id == updated_prediction.id
+    assert (
+        updated_prediction.predicted_margin is None
+        or created_prediction.predicted_margin != updated_prediction.predicted_margin
+    )
+    assert (
+        updated_prediction.predicted_win_probability is None
+        or created_prediction.predicted_win_probability
+        != updated_prediction.predicted_win_probability
+    )

--- a/tipping/src/tests/integration/models/test_prediction.py
+++ b/tipping/src/tests/integration/models/test_prediction.py
@@ -4,7 +4,8 @@ from faker import Faker
 import numpy as np
 
 from tests.fixtures.factories import PredictionFactory, MatchFactory, MLModelFactory
-
+from tests.fixtures.data_factories import fake_prediction_data
+from tipping.models import Prediction
 
 FAKE = Faker()
 
@@ -25,3 +26,25 @@ def test_saving_valid_prediction(faunadb_client):
     query = "query { findPredictionByID(id: %s) { _id } }" % (saved_prediction.id)
     result = faunadb_client.graphql(query)
     assert result["findPredictionByID"]["_id"]
+
+
+def test_updating_valid_prediction(faunadb_client):  # pylint: disable=unused-argument
+    original_predicted_margin = np.random.random() * 50
+    prediction = PredictionFactory.create(
+        predicted_margin=original_predicted_margin, was_correct=None
+    )
+    updated_was_correct = True
+    prediction.was_correct = updated_was_correct
+    updated_predicted_margin = original_predicted_margin + 5
+    updated_prediction = prediction.update(predicted_margin=updated_predicted_margin)
+
+    # It returns a prediction
+    assert isinstance(updated_prediction, Prediction)
+
+    # The returned prediction has the updated attribute values
+    assert updated_prediction.was_correct == updated_was_correct
+    assert updated_prediction.predicted_margin == updated_predicted_margin
+
+    # The original prediction has updated attribute values
+    assert prediction.was_correct == updated_was_correct
+    assert prediction.predicted_margin == updated_predicted_margin

--- a/tipping/src/tests/unit/models/test_match.py
+++ b/tipping/src/tests/unit/models/test_match.py
@@ -1,13 +1,14 @@
 # pylint: disable=missing-docstring,redefined-outer-name
 
 from unittest.mock import patch
-from datetime import date
+from datetime import date, timedelta
 
 import pytest
 from faker import Faker
 import numpy as np
+import freezegun
 
-from tests.fixtures.factories import TeamFactory, MatchFactory
+from tests.fixtures.factories import TeamFactory, MatchFactory, TeamMatchFactory
 from tests.fixtures.data_factories import fake_fixture_data
 from tests.helpers.model_helpers import assert_deep_equal_attributes
 from tipping.models.base_model import ValidationError
@@ -153,3 +154,40 @@ def test_getting_or_creating_match_from_raw_data_with_errors(mock_graphql):
     # It raises an AssertionError
     with pytest.raises(AssertionError, match=error_message):
         Match.get_or_create_from_raw_data(fixture_data)
+
+
+@pytest.mark.parametrize(
+    ["delta_hours", "has_been_played"], [(-1, False), (1, False), (4, True)]
+)
+def test_has_been_played(delta_hours, has_been_played):
+    match = MatchFactory.build()
+    fake_now_datetime = match.start_date_time + timedelta(hours=delta_hours)
+
+    with freezegun.freeze_time(fake_now_datetime):
+        assert match.has_been_played == has_been_played
+
+
+drawn_team_matches = TeamMatchFactory.build_batch(2, score=np.random.randint(0, 100))
+unequal_team_matches = [
+    drawn_team_matches[0],
+    TeamMatchFactory.build(
+        score=(drawn_team_matches[0].score + np.random.randint(0, 25))
+    ),
+]
+
+
+@pytest.mark.parametrize(
+    ["delta_hours", "team_matches", "is_draw"],
+    [
+        (-1, drawn_team_matches, False),
+        (4, unequal_team_matches, False),
+        (4, drawn_team_matches, True),
+    ],
+)
+def test_is_draw(delta_hours, team_matches, is_draw):
+    match = MatchFactory.build()
+    match.team_matches = team_matches
+    fake_now_datetime = match.start_date_time + timedelta(hours=delta_hours)
+
+    with freezegun.freeze_time(fake_now_datetime):
+        assert match.is_draw == is_draw

--- a/tipping/src/tests/unit/models/test_ml_model.py
+++ b/tipping/src/tests/unit/models/test_ml_model.py
@@ -1,0 +1,53 @@
+# pylint: disable=missing-docstring
+
+from unittest.mock import patch
+
+import pytest
+from faker import Faker
+
+from tests.fixtures.factories import MLModelFactory
+from tipping.models.base_model import ValidationError
+from tipping.models import MLModel
+
+
+FAKE = Faker()
+
+
+@pytest.mark.parametrize(
+    ["invalid_attribute", "error_message"],
+    [
+        ({"name": ""}, "empty values not allowed"),
+        ({"name": None}, "null value not allowed"),
+        ({"name": 42}, "string"),
+        ({"prediction_type": "good"}, "unallowed value good"),
+    ],
+)
+@patch("tipping.models.base_model.FaunadbClient.graphql")
+def test_saving_invalid_ml_model(mock_graphql, invalid_attribute, error_message):
+    ml_model = MLModelFactory.build(**invalid_attribute)
+
+    # It raises a ValidateionError
+    with pytest.raises(ValidationError, match=error_message):
+        ml_model.create()
+
+    # It doesn't save the ml_model
+    mock_graphql.assert_not_called()
+
+
+def test_from_db_response():
+    ml_model = MLModelFactory.build(add_id=True)
+    db_record = {
+        "name": ml_model.name,
+        "isPrincipal": ml_model.is_principal,
+        "usedInCompetitions": ml_model.used_in_competitions,
+        "predictionType": ml_model.prediction_type,
+        "_id": ml_model.id,
+    }
+
+    ml_model_from_record = MLModel.from_db_response(db_record)
+
+    # It returns an ml_model object
+    assert isinstance(ml_model_from_record, MLModel)
+
+    # It has matching attributes
+    assert ml_model.attributes == ml_model_from_record.attributes

--- a/tipping/src/tests/unit/models/test_prediction.py
+++ b/tipping/src/tests/unit/models/test_prediction.py
@@ -1,4 +1,4 @@
-# pylint: disable=missing-docstring
+# pylint: disable=missing-docstring,unused-argument
 
 from unittest.mock import patch
 
@@ -115,3 +115,16 @@ def test_from_db_response():
 
     # It has matching attributes
     assert_deep_equal_attributes(prediction, prediction_from_record)
+
+
+@patch("tipping.models.base_model.FaunadbClient.graphql")
+def test_updating_correctness(mock_graphql):
+    prediction = PredictionFactory.build(add_id=True)
+
+    was_correct = prediction.was_correct
+    prediction.was_correct = not was_correct
+
+    prediction.update_correctness()
+
+    # It updates correctness per associated match results
+    assert prediction.was_correct == was_correct

--- a/tipping/src/tests/unit/models/test_prediction.py
+++ b/tipping/src/tests/unit/models/test_prediction.py
@@ -1,0 +1,79 @@
+# pylint: disable=missing-docstring
+
+from unittest.mock import patch
+
+import pytest
+from faker import Faker
+
+from tests.fixtures.factories import (
+    PredictionFactory,
+    MatchFactory,
+    TeamFactory,
+    MLModelFactory,
+)
+from tests.helpers.model_helpers import assert_deep_equal_attributes
+from tipping.models.base_model import ValidationError
+from tipping.models import Prediction
+
+
+FAKE = Faker()
+
+
+@pytest.mark.parametrize(
+    ["invalid_attribute", "error_message"],
+    [
+        ({"predicted_margin": -5.3}, "min value is 0.0"),
+        ({"predicted_win_probability": -0.3}, "min value is 0.0"),
+    ],
+)
+@patch("tipping.models.base_model.FaunadbClient.graphql")
+def test_saving_invalid_prediction(mock_graphql, invalid_attribute, error_message):
+    prediction = PredictionFactory.build(**invalid_attribute)
+
+    # It raises a ValidateionError
+    with pytest.raises(ValidationError, match=error_message):
+        prediction.create()
+
+    # It doesn't save the prediction
+    mock_graphql.assert_not_called()
+
+
+def test_from_db_response():
+    match = MatchFactory.build(add_id=True, team_matches__add_id=True)
+    print(match.attributes)
+    prediction = PredictionFactory.build(match=match, add_id=True)
+    predicted_winner = TeamFactory.build(add_id=True)
+    ml_model = MLModelFactory.build(add_id=True)
+    db_record = {
+        "_id": prediction.id,
+        "match": {
+            "startDateTime": match.start_date_time.isoformat(),
+            "season": match.season,
+            "roundNumber": match.round_number,
+            "venue": match.venue,
+            "margin": match.margin,
+            "winner": None
+            if match.winner is None
+            else {"name": match.winner.name, "_id": match.winner.id},
+            "_id": match.id,
+        },
+        "mlModel": {
+            "_id": ml_model.id,
+            "name": ml_model.name,
+            "predictionType": ml_model.prediction_type,
+            "isPrincipal": ml_model.is_principal,
+            "usedInCompetitions": ml_model.used_in_competitions,
+        },
+        "predictedWinner": {"_id": predicted_winner.id, "name": predicted_winner.name},
+        "predictedMargin": prediction.predicted_margin,
+        "predictedWinProbability": prediction.predicted_win_probability,
+        "wasCorrect": prediction.was_correct,
+    }
+
+    prediction_from_record = Prediction.from_db_response(db_record)
+
+    # It returns an prediction object
+    assert isinstance(prediction_from_record, Prediction)
+
+    # It has matching attributes
+    assert_deep_equal_attributes(prediction, prediction_from_record)

--- a/tipping/src/tipping/db/schema.gql
+++ b/tipping/src/tipping/db/schema.gql
@@ -6,7 +6,7 @@ type Match {
   winner: Team
   margin: Int
   teamMatches: [TeamMatch!] @relation
-  predictons: [Prediction] @relation
+  predictions: [Prediction] @relation
 }
 
 type Team {
@@ -46,5 +46,6 @@ type Query {
   filterMatchesBySeason(season: Int): [Match!]
   filterMLModelsBy(usedInCompetitions: Boolean): [MLModel!]
   findTeamByName(name: String!): Team
-  findMLModelBy(isPrincipal: Boolean): MLModel
+  findMLModelByIsPrincipal(isPrincipal: Boolean): MLModel
+  findMLModelByName(name: String): MLModel
 }

--- a/tipping/src/tipping/db/schema.gql
+++ b/tipping/src/tipping/db/schema.gql
@@ -26,7 +26,7 @@ type Prediction {
   predictedWinner: Team!
   predictedMargin: Float
   predictedWinProbability: Float
-  isCorrect: Boolean
+  wasCorrect: Boolean
 }
 
 type MLModel {

--- a/tipping/src/tipping/db/schema.gql
+++ b/tipping/src/tipping/db/schema.gql
@@ -22,16 +22,15 @@ type TeamMatch {
 
 type Prediction {
   match: Match!
-  mlModel: MlModel!
+  mlModel: MLModel!
   predictedWinner: Team!
   predictedMargin: Float
   predictedWinProbability: Float
   isCorrect: Boolean
 }
 
-type MlModel {
+type MLModel {
   name: String! @unique
-  description: String
   isPrincipal: Boolean!
   usedInCompetitions: Boolean!
   predictionType: String!
@@ -40,10 +39,12 @@ type MlModel {
 
 type Query {
   allMatches: [Match!]
+  allMLModels: [MLModel!]
   allTeams: [Team!]
   allTeamMatches: [TeamMatch!]
   allPredictions: [Prediction!]
-  allMlModels: [MlModel!]
   filterMatchesBySeason(season: Int): [Match!]
+  filterMLModelsBy(usedInCompetitions: Boolean): [MLModel!]
   findTeamByName(name: String!): Team
+  findMLModelBy(isPrincipal: Boolean): MLModel
 }

--- a/tipping/src/tipping/models/__init__.py
+++ b/tipping/src/tipping/models/__init__.py
@@ -2,3 +2,4 @@
 
 from .team import Team
 from .match import Match, TeamMatch
+from .ml_model import MLModel

--- a/tipping/src/tipping/models/__init__.py
+++ b/tipping/src/tipping/models/__init__.py
@@ -3,3 +3,4 @@
 from .team import Team
 from .match import Match, TeamMatch
 from .ml_model import MLModel
+from .prediction import Prediction

--- a/tipping/src/tipping/models/base_model.py
+++ b/tipping/src/tipping/models/base_model.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 from typing import Dict, Any
 import re
 
-from cerberus import Validator
+from cerberus import Validator, TypeDefinition
 
 from tipping.db.faunadb import FaunadbClient
 
@@ -17,7 +17,13 @@ class BaseModel:
     """Abstract base model from which all models inherit."""
 
     def __init__(self, validator: Validator = Validator):
-        self._validator = validator(self._schema, purge_unknown=True)
+        validator_type = TypeDefinition("validator", (Validator,), ())
+        Validator.types_mapping["validator"] = validator_type
+        base_schema = {
+            "_validator": {"type": "validator"},
+            "id": {"type": "string", "nullable": True},
+        }
+        self._validator = validator({**base_schema, **self._schema})
         self.id = None
 
     @classmethod

--- a/tipping/src/tipping/models/ml_model.py
+++ b/tipping/src/tipping/models/ml_model.py
@@ -139,6 +139,35 @@ class MLModel(BaseModel):
 
         return _MLModelRecordCollection(records=records)
 
+    @classmethod
+    def find_by_name(cls, name: Optional[str] = None) -> Optional[MLModel]:
+        """Fetch an ML model from the DB by name.
+
+        Params:
+        -------
+        name: Name of the ML model to be fetched.
+
+        Returns:
+        --------
+        An MLModel with the given name.
+        """
+        query = """
+            query($name: String) {
+                findMLModelByName(name: $name) {
+                    _id
+                    name
+                    isPrincipal
+                    predictionType
+                    usedInCompetitions
+                }
+            }
+        """
+        variables = {"name": name}
+
+        result = cls.db_client().graphql(query, variables)
+
+        return cls.from_db_response(result["findMLModelByName"])
+
     def create(self) -> MLModel:
         """Create the ml_model in the DB."""
         self.validate()
@@ -180,12 +209,12 @@ class MLModel(BaseModel):
 
         query = """
             query {
-                findMLModelBy(isPrincipal: true) { _id }
+                findMLModelByIsPrincipal(isPrincipal: true) { _id }
             }
         """
 
         result = self.db_client().graphql(query)
-        principal_model = result["findMLModelBy"]
+        principal_model = result["findMLModelByIsPrincipal"]
 
         if principal_model is None or principal_model["_id"] == self.id:
             return None

--- a/tipping/src/tipping/models/ml_model.py
+++ b/tipping/src/tipping/models/ml_model.py
@@ -1,0 +1,146 @@
+"""Data model for AFL ml_models."""
+
+from __future__ import annotations
+from typing import Optional, Dict, Any
+
+from .base_model import BaseModel, ValidationError
+
+
+class MLModel(BaseModel):
+    """Data model for ML models."""
+
+    PREDICTION_TYPES = ("margin", "win_probability")
+
+    def __init__(
+        self,
+        name: Optional[str] = None,
+        is_principal: Optional[bool] = None,
+        used_in_competitions: Optional[bool] = None,
+        prediction_type: Optional[str] = None,
+    ):  # pylint: disable=redefined-builtin
+        """
+        Params:
+        -------
+        name: Name of the ML model.
+        is_principal: Whether it's the principal model for determining predicted winners.
+        used_in_competitions: Whether it's used for predictions submitted
+            to tipping competitions.
+        prediction_type: Label for type of prediction: margin or win_probability
+        """
+        super().__init__()
+
+        self.name = name
+        self.is_principal = is_principal
+        self.used_in_competitions = used_in_competitions
+        self.prediction_type = prediction_type
+
+    @classmethod
+    def from_db_response(cls, record: Dict[str, Any]) -> MLModel:
+        """Convert a DB record object into an instance of MLModel.
+
+        Params:
+        -------
+        record: GraphQL response dictionary that represents the ml_model record.
+
+        Returns:
+        --------
+        A MLModel with the attributes of the ml_model record.
+        """
+        ml_model = MLModel(
+            name=record["name"],
+            is_principal=record["isPrincipal"],
+            used_in_competitions=record["usedInCompetitions"],
+            prediction_type=record["predictionType"],
+        )
+        ml_model.id = record["_id"]
+
+        return ml_model
+
+    def create(self) -> MLModel:
+        """Create the ml_model in the DB."""
+        self.validate()
+        self._validate_one_principal_model()
+        self._validate_unique_competition_prediction_types()
+
+        query = """
+            mutation(
+                $name: String!
+                $isPrincipal: Boolean!
+                $usedInCompetitions: Boolean!
+                $predictionType: String!
+            ) {
+                createMLModel(data: {
+                    name: $name,
+                    isPrincipal: $isPrincipal,
+                    usedInCompetitions: $usedInCompetitions,
+                    predictionType: $predictionType
+                }) {
+                    _id
+                }
+            }
+        """
+        variables = {
+            "name": self.name,
+            "isPrincipal": self.is_principal,
+            "usedInCompetitions": self.used_in_competitions,
+            "predictionType": self.prediction_type,
+        }
+
+        result = self.db_client().graphql(query, variables)
+        self.id = result["createMLModel"]["_id"]
+
+        return self
+
+    def _validate_one_principal_model(self):
+        if not self.is_principal:
+            return
+
+        query = """
+            query {
+                findMLModelBy(isPrincipal: true) { _id }
+            }
+        """
+
+        result = self.db_client().graphql(query)
+        principal_model = result["findMLModelBy"]
+
+        if principal_model is None or principal_model["_id"] == self.id:
+            return None
+
+        raise ValidationError("duplicate principal ML models not allowed")
+
+    def _validate_unique_competition_prediction_types(self):
+        if not self.used_in_competitions:
+            return
+
+        query = """
+            query {
+                filterMLModelsBy(usedInCompetitions: true) {
+                    data { _id }
+                }
+            }
+        """
+
+        result = self.db_client().graphql(query)
+        competition_models = result["filterMLModelsBy"]["data"]
+
+        if not any(competition_models) or {"_id": self.id} in competition_models:
+            return None
+
+        raise ValidationError("duplicate prediction types not allowed for competitions")
+
+    @property
+    def _schema(self):
+        return {
+            "name": {
+                "type": "string",
+                "empty": False,
+            },
+            "is_principal": {
+                "type": "boolean",
+            },
+            "used_in_competitions": {
+                "type": "boolean",
+            },
+            "prediction_type": {"type": "string", "allowed": self.PREDICTION_TYPES},
+        }

--- a/tipping/src/tipping/models/prediction.py
+++ b/tipping/src/tipping/models/prediction.py
@@ -1,0 +1,140 @@
+"""Data model for AFL predictions."""
+
+from __future__ import annotations
+from typing import Optional, Dict, Any
+
+from cerberus import Validator, TypeDefinition
+
+from .match import Match
+from .ml_model import MLModel
+from .team import Team
+from .base_model import BaseModel
+
+
+class Prediction(BaseModel):
+    """Data model for predictions."""
+
+    PREDICTION_TYPES = ("margin", "win_probability")
+
+    def __init__(  # pylint: disable=too-many-arguments
+        self,
+        match: Optional[Match] = None,
+        ml_model: Optional[MLModel] = None,
+        predicted_winner: Optional[Team] = None,
+        predicted_margin: Optional[float] = None,
+        predicted_win_probability: Optional[float] = None,
+        was_correct: Optional[bool] = None,
+    ):
+        """
+        Params:
+        -------
+        match: Match for which the prediction is made.
+        ml_model: The ML model that made the prediction.
+        predicted_winner: The team that is predicted to win the match.
+        predicted_margin: Number of points by which the predicted winner
+            is predicted to win by.
+        predicted_win_probability: The expected probability of the predicted winner
+            actually winning.
+        was_correct: Whether the predicted winner actually won.
+        """
+        match_type = TypeDefinition("match", (Match,), ())
+        Validator.types_mapping["match"] = match_type
+        team_type = TypeDefinition("team", (Team,), ())
+        Validator.types_mapping["team"] = team_type
+        ml_model_type = TypeDefinition("ml_model", (MLModel,), ())
+        Validator.types_mapping["ml_model"] = ml_model_type
+
+        super().__init__(Validator)
+
+        self.match = match
+        self.ml_model = ml_model
+        self.predicted_winner = predicted_winner
+        self.predicted_margin = predicted_margin
+        self.predicted_win_probability = predicted_win_probability
+        self.was_correct = was_correct
+
+    @classmethod
+    def from_db_response(cls, record: Dict[str, Any]) -> Prediction:
+        """Convert a DB record object into an instance of Prediction.
+
+        Params:
+        -------
+        record: GraphQL response dictionary that represents the prediction record.
+
+        Returns:
+        --------
+        A Prediction with the attributes of the prediction record.
+        """
+        match = Match.from_db_response(record["match"])
+        ml_model = MLModel.from_db_response(record["mlModel"])
+        predicted_winner = Team.from_db_response(record["predictedWinner"])
+        prediction = Prediction(
+            match=match,
+            ml_model=ml_model,
+            predicted_winner=predicted_winner,
+            predicted_margin=record["predictedMargin"],
+            predicted_win_probability=record["predictedWinProbability"],
+            was_correct=record["wasCorrect"],
+        )
+        prediction.id = record["_id"]
+
+        return prediction
+
+    def create(self) -> Prediction:
+        """Create the prediction in the DB."""
+        self.validate()
+
+        query = """
+            mutation(
+                $matchId: ID!,
+                $mlModelId: ID!,
+                $predictedWinnerId: ID!,
+                $predictedMargin: Float,
+                $predictedWinProbability: Float,
+                $wasCorrect: Boolean
+            ) {
+                createPrediction(data: {
+                    match: { connect: $matchId },
+                    mlModel: { connect: $mlModelId },
+                    predictedWinner: { connect: $predictedWinnerId },
+                    predictedMargin: $predictedMargin,
+                    predictedWinProbability: $predictedWinProbability,
+                    wasCorrect: $wasCorrect
+                }) {
+                    _id
+                }
+            }
+        """
+        variables = {
+            "matchId": self.match and self.match.id,
+            "mlModelId": self.ml_model and self.ml_model.id,
+            "predictedWinnerId": self.predicted_winner and self.predicted_winner.id,
+            "predictedMargin": self.predicted_margin,
+            "predictedWinProbability": self.predicted_win_probability,
+            "wasCorrect": self.was_correct,
+        }
+
+        result = self.db_client().graphql(query, variables)
+        self.id = result["createPrediction"]["_id"]
+
+        return self
+
+    @property
+    def _schema(self):
+        return {
+            "match": {"type": "match", "check_with": self._idfulness},
+            "ml_model": {"type": "ml_model", "check_with": self._idfulness},
+            "predicted_winner": {"type": "team", "check_with": self._idfulness},
+            "predicted_margin": {"type": "float", "min": 0.0, "nullable": True},
+            "predicted_win_probability": {
+                "type": "float",
+                "min": 0.0,
+                "nullable": True,
+            },
+            "was_correct": {"type": "boolean", "nullable": True},
+        }
+
+    @staticmethod
+    def _idfulness(field, value, error):
+        if value and value.id is None:
+            error(field, "must have an ID")

--- a/tipping/src/tipping/models/prediction.py
+++ b/tipping/src/tipping/models/prediction.py
@@ -1,10 +1,13 @@
 """Data model for AFL predictions."""
 
 from __future__ import annotations
-from typing import Optional, Dict, Any
+from typing import Optional, Dict, Any, Union, Literal, cast, Tuple
+from datetime import datetime, timezone
 
 from cerberus import Validator, TypeDefinition
 from mypy_extensions import TypedDict
+import numpy as np
+import pandas as pd
 
 from .match import Match
 from .ml_model import MLModel
@@ -12,17 +15,8 @@ from .team import Team
 from .base_model import BaseModel, ValidationError
 
 
-PredictionAttributes = TypedDict(
-    "PredictionAttributes",
-    {
-        "match": Match,
-        "ml_model": MLModel,
-        "predicted_winner": Team,
-        "predicted_margin": float,
-        "predicted_win_probability": float,
-        "was_correct": bool,
-    },
-    total=False,
+MatchingAttributes = TypedDict(
+    "MatchingAttributes", {"match": Match, "ml_model": MLModel}
 )
 
 
@@ -69,7 +63,9 @@ class Prediction(BaseModel):
         self.was_correct = was_correct
 
     @classmethod
-    def from_db_response(cls, record: Dict[str, Any]) -> Prediction:
+    def from_db_response(  # pylint: disable=arguments-differ
+        cls, record: Dict[str, Any], match: Optional[Match] = None
+    ) -> Prediction:
         """Convert a DB record object into an instance of Prediction.
 
         Params:
@@ -80,7 +76,7 @@ class Prediction(BaseModel):
         --------
         A Prediction with the attributes of the prediction record.
         """
-        match = Match.from_db_response(record["match"])
+        match = match or Match.from_db_response(record["match"])
         ml_model = MLModel.from_db_response(record["mlModel"])
         predicted_winner = Team.from_db_response(record["predictedWinner"])
         prediction = Prediction(
@@ -94,6 +90,84 @@ class Prediction(BaseModel):
         prediction.id = record["_id"]
 
         return prediction
+
+    @classmethod
+    def update_or_create_from_raw_data(
+        cls, prediction_data: pd.Series, future_only=False
+    ) -> Optional["Prediction"]:
+        """
+        Convert raw prediction data to a Prediction model instance.
+
+        Tries to find and update existing prediction for the given
+        match/model combination, and creates new one if none is found.
+
+        Params:
+        -------
+        prediction_data: Dictionary that include prediction data for two teams
+            that are playing each other in a given match.
+
+        Returns:
+        --------
+            Unsaved Prediction model instance.
+        """
+        predicted_margin, predicted_margin_winner = cls._calculate_predictions(
+            prediction_data, "margin"
+        )
+        (
+            predicted_win_probability,
+            predicted_proba_winner,
+        ) = cls._calculate_predictions(prediction_data, "win_probability")
+
+        # For now, each estimator predicts margins or win probabilities, but not both.
+        # If we eventually have an estimator that predicts both, we're defaulting
+        # to the predicted winner by margin, but we may want to revisit this
+        predicted_winner = predicted_margin_winner or predicted_proba_winner
+
+        assert predicted_winner is not None, (
+            "Each prediction should have a predicted_winner:\n" f"{prediction_data}"
+        )
+
+        match, ml_model = cls._matching_relations_for_update(
+            prediction_data, future_only
+        )
+
+        if (match is None) or (ml_model is None):
+            return None
+
+        match_ml_model_name = (
+            lambda prediction: prediction.ml_model.name == ml_model.name
+        )
+
+        matching_predictions = filter(
+            match_ml_model_name,
+            match.predictions,
+        )
+
+        try:
+            prediction = next(matching_predictions)
+            prediction.update(
+                predicted_margin=predicted_margin,
+                predicted_win_probability=predicted_win_probability,
+                predicted_winner=predicted_winner,
+            )
+        except StopIteration:
+            prediction = Prediction(
+                match=match,
+                ml_model=ml_model,
+                predicted_margin=predicted_margin,
+                predicted_win_probability=predicted_win_probability,
+                predicted_winner=predicted_winner,
+            )
+            prediction.create()
+
+        prediction.update_correctness()
+
+        return prediction
+
+    def update_correctness(self) -> Prediction:
+        """Update the was_correct attribute based on associated team_match scores."""
+        self.was_correct = self._calculate_whether_correct()
+        return self.update()
 
     def create(self) -> Prediction:
         """Create the prediction in the DB."""
@@ -202,3 +276,151 @@ class Prediction(BaseModel):
     def _idfulness(field, value, error):
         if value and value.id is None:
             error(field, "must have an ID")
+
+    @classmethod
+    def _calculate_predictions(
+        cls,
+        prediction_data: pd.Series,
+        prediction_type: Union[Literal["margin"], Literal["win_probability"]],
+    ) -> Tuple[Optional[float], Optional[Team]]:
+        home_prediction_key = cast(
+            Union[
+                Literal["home_predicted_margin"],
+                Literal["home_predicted_win_probability"],
+            ],
+            f"home_predicted_{prediction_type}",
+        )
+        away_prediction_key = cast(
+            Union[
+                Literal["away_predicted_margin"],
+                Literal["away_predicted_win_probability"],
+            ],
+            f"away_predicted_{prediction_type}",
+        )
+
+        home_predicted_result = prediction_data[home_prediction_key]
+        away_predicted_result = prediction_data[away_prediction_key]
+
+        if home_predicted_result is None or away_predicted_result is None:
+            return None, None
+
+        assert home_predicted_result != away_predicted_result, (
+            "Home and away predictions are equal, which is basically impossible, "
+            "so figure out what's going on:\n"
+            f"{prediction_data}"
+        )
+
+        predicted_result = (
+            cls._calculate_predicted_margin(
+                home_predicted_result, away_predicted_result
+            )
+            if prediction_type == "margin"
+            else cls._calculate_predicted_win_probability(
+                home_predicted_result, away_predicted_result
+            )
+        )
+
+        return predicted_result, cls._calculate_predicted_winner(
+            prediction_data, home_predicted_result, away_predicted_result
+        )
+
+    @classmethod
+    def _calculate_predicted_margin(cls, home_margin, away_margin) -> float:
+        both_predicted_to_win = home_margin > 0 and away_margin > 0
+        both_predicted_to_lose = home_margin < 0 and away_margin < 0
+
+        # predicted_margin is always positive as it's always associated
+        # with predicted_winner
+        if both_predicted_to_win or both_predicted_to_lose:
+            return abs(home_margin - away_margin)
+
+        return np.mean(np.abs([home_margin, away_margin]))
+
+    @classmethod
+    def _calculate_predicted_win_probability(
+        cls, home_win_probability, away_win_probability
+    ) -> float:
+        predicted_loser_oppo_win_proba = 1 - min(
+            [home_win_probability, away_win_probability]
+        )
+        predicted_winner_win_proba = max([home_win_probability, away_win_probability])
+        predicted_win_probability = np.mean(
+            [predicted_loser_oppo_win_proba, predicted_winner_win_proba]
+        )
+
+        return predicted_win_probability
+
+    @classmethod
+    def _calculate_predicted_winner(
+        cls, prediction_data, home_predicted_result, away_predicted_result
+    ) -> Team:
+        predicted_winner = (
+            "home_team"
+            if home_predicted_result > away_predicted_result
+            else "away_team"
+        )
+
+        team = Team.find_by(name=prediction_data[predicted_winner])
+
+        assert team is not None
+
+        return team
+
+    @classmethod
+    def _matching_relations_for_update(
+        cls, prediction_data: pd.Series, future_only
+    ) -> Tuple[Optional[Match], Optional[MLModel]]:
+        matches_by_team_names = lambda match: {
+            team_match.team and team_match.team.name
+            for team_match in match.team_matches
+        } == {
+            prediction_data["home_team"],
+            prediction_data["away_team"],
+        }
+
+        matches = list(
+            filter(
+                matches_by_team_names,
+                Match.filter_by_season(season=prediction_data["year"]).filter(
+                    round_number=prediction_data["round_number"]
+                ),
+            )
+        )
+
+        assert len(matches) == 1, (
+            "Prediction data should have yielded a unique match, but we got "
+            "the following instead:\n"
+            f"Matches: {[match.attributes for match in matches]}\n\n"
+            f"Prediction: {prediction_data}"
+        )
+
+        match = matches[0]
+
+        if future_only and match.start_date_time < datetime.now(tz=timezone.utc):
+            return None, None
+
+        ml_model = MLModel.find_by_name(name=prediction_data["ml_model"])
+
+        assert ml_model is not None
+
+        return match, ml_model
+
+    def _calculate_whether_correct(self) -> Optional[bool]:
+        """
+        Calculate whether a prediction is correct.
+
+        This is based on a combination of match results and conventional
+        footy-tipping rules (i.e. draws count as correct).
+        """
+        assert self.match
+
+        if not self.match.has_been_played:
+            return None
+
+        # In footy tipping competitions its typical to grant everyone a correct tip
+        # in the case of a draw
+        return self.match.is_draw or bool(
+            self.predicted_winner
+            and self.match.winner
+            and self.predicted_winner.id == self.match.winner.id
+        )

--- a/tipping/src/tipping/models/team.py
+++ b/tipping/src/tipping/models/team.py
@@ -22,7 +22,7 @@ class Team(BaseModel):
         self.id = None
 
     @classmethod
-    def find_by(cls, name: str):
+    def find_by(cls, name: str) -> Optional[Team]:
         """Fetch a team from the DB by its name.
 
         Params:

--- a/tipping/src/tipping/models/team.py
+++ b/tipping/src/tipping/models/team.py
@@ -9,7 +9,7 @@ from .base_model import BaseModel
 class Team(BaseModel):
     """Data model for AFL teams."""
 
-    def __init__(self, name: Optional[str] = None):  # pylint: disable=redefined-builtin
+    def __init__(self, name: Optional[str] = None):
         """
         Params:
         -------


### PR DESCRIPTION
This process is a bit more complicated than updating fixtures, requiring the creation of `MLModel` and `Prediction` classes as well as changes in the `Match` model. I ran pretty hard into the limitations of the FaunaDB GraphQL interface.

I had assumed that the `find` and `filter` queries would work like the typical ORM implementations (i.e. all kwargs are optional, with records needing to match all params that are present), but the reality is that they really only work with one param at a time, because whenever a find/filter query has multiple params and any are omitted, the missing params are treated as `null` values and try to match records accordingly. I worked around this with in-memory filtering of results, but this is not a good solution, especially as the DB queries used in this PR are simpler than those used in the GQL API responses.

I also ran into issues with the cyclical nature of model dependencies, as parent and children models often have to refer to each other. As with the limited queries, I found a work-around, but it made me long for a proper ORM.

I wanted to finish up this PR, because it has some useful changes for future migration work, but my long-term plan now is to look into SQLAlchemy as a possible solution. Unlike the Django ORM, SQLAlchemy is set up to allow for different DB dialects to be plugged into it and even lists some [3rd-party dialects](https://docs.sqlalchemy.org/en/14/dialects/) in its documentation. Translating SQL to Fauna's FQL will be a lot of work, but I think the end result will be much easier to work with than the half-baked FaunaDB ORM that I'm currently working toward.