### PR TITLE
Allow for partial weeks for last week of the year

### DIFF
--- a/backend/server/graphql/schema.py
+++ b/backend/server/graphql/schema.py
@@ -215,6 +215,9 @@ class Query(graphene.ObjectType):
             "available_seasons": (
                 sorted(
                     Prediction.objects.select_related("match")
+                    # If we don't have any match/prediction results yet, there won't be
+                    # any performance metrics to calculate
+                    .filter(is_correct__isnull=False)
                     .distinct("match__start_date_time__year")
                     .values_list("match__start_date_time__year", flat=True)
                 )

--- a/backend/server/graphql/types/season.py
+++ b/backend/server/graphql/types/season.py
@@ -427,6 +427,9 @@ class SeasonType(graphene.ObjectType):
             )
         )
 
+        if not any(metric_values):
+            return []
+
         return calculate_cumulative_metrics(metric_values, round_number).pipe(
             _collect_data_by_round
         )

--- a/backend/server/tests/fixtures/factories.py
+++ b/backend/server/tests/fixtures/factories.py
@@ -49,7 +49,7 @@ class TeamFactory(DjangoModelFactory):
 def _fake_datetime(match_factory, n, start_month_day=(MAR, FIRST)) -> datetime:
     round_week_delta = timedelta(days=ONE_WEEK)
 
-    # Since we create match records per year, we don't want want dates running
+    # Since we create match records per year, we don't want dates running
     # into the next year.
     max_datetime = timezone.make_aware(datetime(match_factory.year, DEC, THIRTY_FIRST))
     now_for_factory = timezone.make_aware(
@@ -60,14 +60,17 @@ def _fake_datetime(match_factory, n, start_month_day=(MAR, FIRST)) -> datetime:
     # whichever is less), because the sequence doesn't reset between tests
     # and eventually hits the end of the year for every test, resulting in duplicate
     # venue/date combinations that raise validation errors.
-    n_weeks_left_in_year = round((max_datetime - now_for_factory).days / ONE_WEEK)
+    n_days_left_in_year = (max_datetime - now_for_factory).days
+    n_weeks_left_in_year = math.floor(n_days_left_in_year / ONE_WEEK)
     n_weeks_left_in_season = min([n_weeks_left_in_year, SIX_MONTHS_IN_WEEKS])
-    start_round_week_delta = round_week_delta * (
-        math.ceil(n / TYPICAL_N_MATCHES_PER_ROUND) % n_weeks_left_in_season
+    start_round_week_delta = (
+        timedelta(days=0)
+        if n_weeks_left_in_season == 0
+        else round_week_delta
+        * (math.ceil(n / TYPICAL_N_MATCHES_PER_ROUND) % n_weeks_left_in_season)
     )
 
     try:
-        # The AFL season typically starts in March
         datetime_start = now_for_factory + start_round_week_delta
     except ValueError:
         # Trying to create a datetime for 29 Feb in a non-leap year raises an error,
@@ -80,7 +83,7 @@ def _fake_datetime(match_factory, n, start_month_day=(MAR, FIRST)) -> datetime:
         )
 
     try:
-        # Rounds last about a week, so that's how big we make our date range per round.
+        # Rounds last about a week, so that's how big we make our date range per round
         datetime_end = datetime_start + round_week_delta
     except ValueError:
         # Trying to create a datetime for 29 Feb in a non-leap year raises an error,

--- a/backend/server/tests/unit/test_schema.py
+++ b/backend/server/tests/unit/test_schema.py
@@ -453,7 +453,6 @@ class TestSchema(TestCase):
             """
 
         with self.subTest("for a 'Win Probability' model"):
-            print("win probability")
             executed = self.client.execute(
                 query, variables={"mlModelName": "accurate_af"}
             )

--- a/frontend/schema.json
+++ b/frontend/schema.json
@@ -99,7 +99,7 @@
                   "name": "Int",
                   "ofType": null
                 },
-                "defaultValue": "2020"
+                "defaultValue": "2021"
               }
             ],
             "type": {

--- a/tipping/src/tests/fixtures/factories.py
+++ b/tipping/src/tests/fixtures/factories.py
@@ -191,11 +191,6 @@ class MatchFactory(TippingFactory):
         size=2,
     )
 
-    @factory.post_generation
-    def calculate_winner(obj, _create, _extracted, **_kwargs):
-        "Assign correct winner to the given match."
-        obj.winner = obj._calculate_winner()
-
     @classmethod
     def _create(cls, model_class, *args, **kwargs):
         model_instance = model_class(**kwargs)

--- a/tipping/src/tests/integration/models/test_match.py
+++ b/tipping/src/tests/integration/models/test_match.py
@@ -14,7 +14,8 @@ REASONABLE_NUMBER_OF_RECORDS = 10
 def test_creating_valid_match(faunadb_client):
     match = MatchFactory.build()
     # Need to create winner first, so it will have a valid ID when we create match
-    match.winner.create()
+    if match.winner:
+        match.winner.create()
     saved_match = match.create()
 
     # It returns the saved match

--- a/tipping/src/tests/unit/models/test_match.py
+++ b/tipping/src/tests/unit/models/test_match.py
@@ -96,15 +96,13 @@ def test_collection_filter(match_collection, match_attributes):
 
 
 def test_from_db_response():
-    winner = TeamFactory.build(add_id=True)
-    match = MatchFactory.build(winner=winner, add_id=True)
+    match = MatchFactory.build(add_id=True)
     db_record = {
         "startDateTime": match.start_date_time.isoformat(),
         "season": match.season,
         "roundNumber": match.round_number,
         "venue": match.venue,
         "margin": match.margin,
-        "winner": {"name": match.winner.name, "_id": match.winner.id},
         "teamMatches": {
             "data": [
                 {
@@ -118,6 +116,9 @@ def test_from_db_response():
         },
         "_id": match.id,
     }
+
+    if match.winner:
+        db_record["winner"] = {"name": match.winner.name, "_id": match.winner.id}
 
     match_from_record = Match.from_db_response(db_record)
 


### PR DESCRIPTION
In the last week of the year, rounding the number of weeks left
results in a count of 0, which breaks the modulo math we use
later. This allows for a week count of 0, then we make the end
date just the end of the year. This will probably break on Dec 31
itself, but who cares.

Also fixed various other bugs that were lying dormant until we
got to the new year, like handling unplayed matches when
fetching data from the API.