### PR TITLE
Add skeleton for SQLAlchemy Dialect for Fauna

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -40,7 +40,7 @@ services:
       - backend
     env_file: .env
     environment:
-      PYTHONPATH: './src'
+      PYTHONPATH: "./src"
       PORT: 3333
       DATA_SCIENCE_SERVICE: http://host.docker.internal:8008
       TIPRESIAS_APP: http://backend:8000
@@ -68,11 +68,13 @@ services:
     image: postgres:11.6
     environment:
       - POSTGRES_DB=$DATABASE_NAME
+    ports:
+      - "5432:5432"
   faunadb:
     image: fauna/faunadb:latest
     ports:
-      - "8443:8443"
-      - "8084:8084"
+      - "8443:8443" # Base API
+      - "8084:8084" # GQL Api
   splash:
     image: scrapinghub/splash
     ports:

--- a/tipping/requirements.prod.txt
+++ b/tipping/requirements.prod.txt
@@ -10,6 +10,7 @@ gql==3.0.0a3
 cerberus
 sqlalchemy==1.3.22
 faunadb==4.0.1
+sqlparse==0.4.1
 
 # Browser automation
 MechanicalSoup

--- a/tipping/requirements.prod.txt
+++ b/tipping/requirements.prod.txt
@@ -8,6 +8,8 @@ simplejson
 rollbar
 gql==3.0.0a3
 cerberus
+sqlalchemy==1.3.22
+faunadb==4.0.1
 
 # Browser automation
 MechanicalSoup

--- a/tipping/src/tests/integration/conftest.py
+++ b/tipping/src/tests/integration/conftest.py
@@ -3,6 +3,7 @@
 import os
 from unittest.mock import patch
 import re
+from contextlib import contextmanager
 
 import pytest
 
@@ -19,23 +20,42 @@ def _setup_faunadb():
     )
 
 
-@pytest.fixture(scope="function")
-def faunadb_client():
-    """Set up and tear down test DB in local FaunaDB instance."""
+@contextmanager
+def _setup_teardown_test_db():
     os.system("npx fauna create-database test --endpoint localhost")
 
     create_key_output = os.popen(
         "npx fauna create-key test --endpoint=localhost"
     ).read()
-
-    faunadb_key = (
+    secret_key = (
         re.search("secret: (.+)", create_key_output).group(CAPTURED_MATCH).strip()
     )
 
-    client = FaunadbClient(faunadb_key=faunadb_key)
-    client.import_schema()
+    with patch("tipping.db.faunadb.settings.FAUNADB_KEY", secret_key):
+        try:
+            yield secret_key
+        finally:
+            os.system("npx fauna delete-database test --endpoint localhost")
 
-    with patch("tipping.db.faunadb.settings.FAUNADB_KEY", faunadb_key):
+
+@pytest.fixture(scope="function")
+def faunadb_client():
+    """Set up and tear down test DB in local FaunaDB instance.
+
+    Passes the created Faunadb client to the test function.
+    """
+    with _setup_teardown_test_db() as secret_key:
+        client = FaunadbClient(faunadb_key=secret_key)
+        client.import_schema()
+
         yield client
 
-    os.system("npx fauna delete-database test --endpoint localhost")
+
+@pytest.fixture(scope="function")
+def fauna_secret():
+    """Set up and tear down test DB in local Fauna instance.
+
+    Passes the generated key to the test function.
+    """
+    with _setup_teardown_test_db() as secret_key:
+        yield secret_key

--- a/tipping/src/tests/integration/db/test_sqlalchemy_fauna.py
+++ b/tipping/src/tests/integration/db/test_sqlalchemy_fauna.py
@@ -1,8 +1,12 @@
 # pylint: disable=missing-docstring
 
 from sqlalchemy.engine import create_engine
+from sqlalchemy.ext.declarative import declarative_base
 
 
 def test_db_connection(fauna_secret):
+    Base = declarative_base()
     engine = create_engine(f"fauna://faunadb:8443/?secret={fauna_secret}")
+    Base.metadata.reflect(engine)
+
     engine.connect()

--- a/tipping/src/tests/integration/db/test_sqlalchemy_fauna.py
+++ b/tipping/src/tests/integration/db/test_sqlalchemy_fauna.py
@@ -1,0 +1,8 @@
+# pylint: disable=missing-docstring
+
+from sqlalchemy.engine import create_engine
+
+
+def test_db_connection(fauna_secret):
+    engine = create_engine(f"fauna://faunadb:8443/?secret={fauna_secret}")
+    engine.connect()

--- a/tipping/src/tipping/db/__init__.py
+++ b/tipping/src/tipping/db/__init__.py
@@ -1,0 +1,5 @@
+"""Manages configuration for and connections to databases."""
+
+from sqlalchemy.dialects import registry
+
+registry.register("fauna", "tipping.db.sqlalchemy_fauna.dialect", "FaunaDialect")

--- a/tipping/src/tipping/db/sqlalchemy_fauna/__init__.py
+++ b/tipping/src/tipping/db/sqlalchemy_fauna/__init__.py
@@ -1,0 +1,6 @@
+"""Creates a Fauna Dialect for SQLAlchemy."""
+
+from tipping.db.sqlalchemy_fauna.dbapi import connect
+from tipping.db.sqlalchemy_fauna.exceptions import Error, NotSupportedError
+
+paramstyle = "pyformat"

--- a/tipping/src/tipping/db/sqlalchemy_fauna/dbapi.py
+++ b/tipping/src/tipping/db/sqlalchemy_fauna/dbapi.py
@@ -1,0 +1,187 @@
+"""DBAPI for use in the FaunaDialect."""
+
+from faunadb.client import FaunaClient
+
+from tipping.db.sqlalchemy_fauna import exceptions
+
+
+def connect(**connect_kwargs):
+    """Create a connection with Fauna."""
+    return FaunaConnection(**connect_kwargs)
+
+
+def check_closed(f):
+    """Decorator that checks if connection/cursor is closed.
+
+    Copied from other examples of 3rd-party Dialects.
+    """
+
+    def g(self, *args, **kwargs):
+        if self.closed:
+            raise exceptions.Error(
+                "{klass} already closed".format(klass=self.__class__.__name__)
+            )
+        return f(self, *args, **kwargs)
+
+    return g
+
+
+def check_result(f):
+    """Decorator that checks if the cursor has results from `execute`.
+
+    Copied from other examples of 3rd-party Dialects.
+    """
+
+    def g(self, *args, **kwargs):
+        if self._results is None:  # pylint: disable=protected-access
+            raise exceptions.Error("Called before `execute`")
+        return f(self, *args, **kwargs)
+
+    return g
+
+
+class FaunaConnection:
+    """Connection to a Fauna DB instance."""
+
+    def __init__(self, host="", port=None, secret="", scheme=""):
+        self.client = FaunaClient(scheme=scheme, domain=host, port=port, secret=secret)
+        self.closed = False
+        self.cursors = []
+
+    @check_closed
+    def close(self):
+        """Close the connection to the database."""
+        self.closed = True
+        for cursor in self.cursors:
+            try:
+                cursor.close()
+            except exceptions.Error:
+                pass  # already closed
+
+    @check_closed
+    def cursor(self):
+        """Return a new Cursor Object using the connection."""
+        cursor = FaunaCursor()
+        self.cursors.append(cursor)
+
+        return cursor
+
+    @check_closed
+    def execute(self, operation, parameters=None):
+        """Execute an SQL query."""
+        cursor = self.cursor()
+        return cursor.execute(operation, parameters)
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *exc):
+        self.close()
+
+
+def _execute_query(_operation, _parameters):
+    return [("empty",)], "To be implemented"
+
+
+class FaunaCursor:
+    """Fauna connection cursor."""
+
+    def __init__(self):
+        # This read/write attribute specifies the number of rows to fetch at a
+        # time with .fetchmany(). It defaults to 1 meaning to fetch a single
+        # row at a time.
+        self.arraysize = 1
+
+        self.closed = False
+
+        # this is updated only after a query
+        self.description = None
+
+        # this is set to a list of rows after a successful query
+        self._results = None
+
+    # Apparently mypy doesn't play nice with multiple decorators
+    @property  # type: ignore
+    @check_result
+    @check_closed
+    def rowcount(self):
+        """Number of rows in the query results."""
+        return len(self._results)
+
+    @check_closed
+    def close(self):
+        """Close the cursor."""
+        self.closed = True
+
+    @check_closed
+    def execute(self, operation, parameters=None):
+        """Execute the query."""
+        parameters = parameters or {}
+        self.description = None
+
+        self._results, self.description = _execute_query(operation, parameters)
+        return self
+
+    @check_closed
+    def executemany(self, operation, seq_of_parameters=None):
+        """Execute multiple queries."""
+        raise exceptions.NotSupportedError(
+            "`executemany` is not supported, use `execute` instead"
+        )
+
+    @check_result
+    @check_closed
+    def fetchone(self):
+        """Fetch the next row of a query result set.
+
+        Returns a single sequence, or `None` when no more data is available.
+        """
+        try:
+            return self._results.pop(0)
+        except IndexError:
+            return None
+
+    @check_result
+    @check_closed
+    def fetchmany(self, size=None):
+        """Fetch the next set of rows of a query result.
+
+        Returns rows as a sequence of sequences (e.g. a list of tuples).
+        An empty sequence is returned when no more rows are available.
+        """
+        size = size or self.arraysize
+        out = self._results[:size]
+        self._results = self._results[size:]
+        return out
+
+    @check_result
+    @check_closed
+    def fetchall(self):
+        """Fetch all (remaining) rows of a query result.
+
+        Returns rows as a sequence of sequences (e.g. a list of tuples).
+        Note that the cursor's arraysize attribute can affect the performance
+        of this operation.
+        """
+        out = self._results[:]
+        self._results = []
+        return out
+
+    @check_closed
+    def setinputsizes(self, sizes):
+        """Set output sizes.
+
+        Not supported.
+        """
+
+    @check_closed
+    def setoutputsizes(self, sizes):
+        """Set output sizes.
+
+        Not supported.
+        """
+
+    @check_closed
+    def __iter__(self):
+        """Iterate through results."""
+        return iter(self._results)

--- a/tipping/src/tipping/db/sqlalchemy_fauna/dialect.py
+++ b/tipping/src/tipping/db/sqlalchemy_fauna/dialect.py
@@ -1,0 +1,141 @@
+"""Module for defining the Fauna Dialect for use in SQLAlchemy."""
+
+from typing import List, Dict, Any
+
+from sqlalchemy.engine import default
+from sqlalchemy import types
+from mypy_extensions import TypedDict
+
+from tipping.settings import IS_PRODUCTION
+from tipping.db import sqlalchemy_fauna
+from tipping.db.sqlalchemy_fauna.dbapi import FaunaConnection
+
+ColumnName = TypedDict(
+    "ColumnName",
+    {
+        "name": str,
+        "type": Any,
+        "nullable": bool,
+        "default": Any,
+    },
+)
+
+
+type_map = {
+    "string": types.String,
+    "number": types.Numeric,
+    "boolean": types.Boolean,
+    "date": types.DATE,
+    "datetime": types.DATETIME,
+    "timeofday": types.TIME,
+}
+
+
+class FaunaDialect(default.DefaultDialect):  # pylint: disable=abstract-method
+    """SQLAlchemy Dialect for Fauna."""
+
+    name = "fauna"
+    scheme = "https" if IS_PRODUCTION else "http"
+    driver = "rest"
+
+    # Pylint says this method is hidden by sqlalchemy.engine.default,
+    # but all 3rd-party dialects I've looked at define 'dbapi' this way.
+    @classmethod
+    def dbapi(cls):  # pylint: disable=method-hidden
+        """Fauna DBAPI for use in SQLAlchemy."""
+        return sqlalchemy_fauna
+
+    def create_connect_args(self, url):
+        """Transform the database URL into connection kwargs."""
+        opts = url.translate_connect_args()
+        opts.update(url.query)
+        return [[], {**opts, "scheme": self.scheme}]
+
+    def get_schema_names(self, _connection, **_kwargs) -> List[str]:
+        """Return the database schema names.
+
+        This is just a blank string, because Fauna doesn't have schema names.
+        """
+        return [""]
+
+    def has_table(
+        self, connection: FaunaConnection, table_name: str, schema=None
+    ) -> bool:
+        """Check whether the database has the given table."""
+        return table_name in self.get_table_names(connection, schema)
+
+    def get_table_names(
+        self, connection: FaunaConnection, schema=None, **kwargs
+    ) -> List[str]:
+        """Get the names of all Fauna collections"""
+        raise Exception("TBI")
+
+    def get_view_names(self, connection, schema=None, **_kwargs) -> List[str]:
+        """Get the names of views."""
+        return []
+
+    def get_table_options(
+        self,
+        _connection,
+        _table_name,
+        schema=None,  # pylint: disable=unused-argument
+        **_kwargs
+    ) -> Dict[str, Any]:
+        """Get table options."""
+        return {}
+
+    def get_columns(
+        self, connection: FaunaConnection, table_name: str, schema=None, **_kwargs
+    ) -> List[ColumnName]:
+        """Get all column names in the given table."""
+        raise Exception("TBI")
+
+        query = "some query"  # pylint: disable=unreachable
+        result = connection.execute(query)
+        return [
+            {
+                "name": col[0],
+                "type": type_map[col],
+                "nullable": True,
+                "default": None,
+            }
+            for col in result[0]
+        ]
+
+    def get_pk_constraint(self, _connection, table_name, schema=None, **_kwargs):
+        """Get the pk constraint."""
+        return {"constrained_columns": [], "name": None}
+
+    def get_foreign_keys(self, connection, table_name, schema=None, **_kwargs):
+        """Get all foreign keys."""
+        return []
+
+    def get_check_constraints(self, connection, table_name, schema=None, **_kwargs):
+        """Get check constraints."""
+        return []
+
+    def get_table_comment(self, connection, table_name, schema=None, **_kwargs):
+        """Get the table comment."""
+        return {"text": ""}
+
+    def get_indexes(self, connection, table_name, schema=None, **_kwargs):
+        """Get all indexes from the given table."""
+        return []
+
+    def get_unique_constraints(self, connection, table_name, schema=None, **_kwargs):
+        """Get the unique constraints for the given table."""
+        return []
+
+    def get_view_definition(self, connection, view_name, schema=None, **kwargs):
+        """Get the view definition."""
+
+    def do_rollback(self, dbapi_connection):
+        """Rollback a transaction."""
+        # TODO: I think Fauna has transactions, because FQL has an 'Abort' function
+        # for terminating them
+
+    def _check_unicode_returns(self, connection, additional_tests=None):
+        return True
+
+    def _check_unicode_description(self, connection):
+        return True

--- a/tipping/src/tipping/db/sqlalchemy_fauna/dialect.py
+++ b/tipping/src/tipping/db/sqlalchemy_fauna/dialect.py
@@ -65,10 +65,15 @@ class FaunaDialect(default.DefaultDialect):  # pylint: disable=abstract-method
         return table_name in self.get_table_names(connection, schema)
 
     def get_table_names(
-        self, connection: FaunaConnection, schema=None, **kwargs
+        self, connection: FaunaConnection, schema=None, **_kwargs
     ) -> List[str]:
         """Get the names of all Fauna collections"""
-        raise Exception("TBI")
+        query = """
+            SELECT TABLE_NAME
+            FROM INFORMATION_SCHEMA.TABLES;
+        """
+        result = connection.execute(query)
+        return [row.name for row in result]
 
     def get_view_names(self, connection, schema=None, **_kwargs) -> List[str]:
         """Get the names of views."""
@@ -79,7 +84,7 @@ class FaunaDialect(default.DefaultDialect):  # pylint: disable=abstract-method
         _connection,
         _table_name,
         schema=None,  # pylint: disable=unused-argument
-        **_kwargs
+        **_kwargs,
     ) -> Dict[str, Any]:
         """Get table options."""
         return {}
@@ -87,10 +92,11 @@ class FaunaDialect(default.DefaultDialect):  # pylint: disable=abstract-method
     def get_columns(
         self, connection: FaunaConnection, table_name: str, schema=None, **_kwargs
     ) -> List[ColumnName]:
-        """Get all column names in the given table."""
-        raise Exception("TBI")
-
-        query = "some query"  # pylint: disable=unreachable
+        """Get all column names in the given collection."""
+        query = f"""
+            SELECT column_name FROM INFORMATION_SCHEMA.COLUMNS
+            WHERE TABLE_NAME = '{table_name}';
+        """
         result = connection.execute(query)
         return [
             {

--- a/tipping/src/tipping/db/sqlalchemy_fauna/exceptions.py
+++ b/tipping/src/tipping/db/sqlalchemy_fauna/exceptions.py
@@ -1,0 +1,43 @@
+# pylint: disable=missing-docstring
+
+"""Default error classes for SQLAlchemy Dialects."""
+
+
+class Error(Exception):
+    pass
+
+
+class Warning(Exception):  # pylint: disable=redefined-builtin
+    pass
+
+
+class InterfaceError(Error):
+    pass
+
+
+class DatabaseError(Error):
+    pass
+
+
+class InternalError(DatabaseError):
+    pass
+
+
+class OperationalError(DatabaseError):
+    pass
+
+
+class ProgrammingError(DatabaseError):
+    pass
+
+
+class IntegrityError(DatabaseError):
+    pass
+
+
+class DataError(DatabaseError):
+    pass
+
+
+class NotSupportedError(DatabaseError):
+    pass


### PR DESCRIPTION
This creates the basic classes and methods needed to use a Fauna
as an SQLAlchemy Dialect, which will allow us to offload a lot of
model and DB query logic to SQLAlchemy rather than creating some
half-baked, homebrewed ORM ourselves.

Most of the boilerplate is copy-pasted from other 3rd-party SQLA
Dialects, whose similarities suggest that a common template exists
somewhere, but I didn't find one. So far, we can just create a
connection to a Fauna instance, but cannot execute any queries.