### PR TITLE
Remove PYTHONPATH when deploying

### DIFF
--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -55,7 +55,6 @@ SERVICE_DOCKER_IMAGE=cfranklin11/${PROJECT_ID}_tipping:latest
 # Need lots of deploy-specific env vars, so we use docker instead of docker-compose
 docker run \
   -v ${HOME}/.aws:/app/.aws \
-  -e PYTHONPATH=./src \
   -e AWS_SHARED_CREDENTIALS_FILE=".aws/credentials" \
   -e TIPRESIAS_APP=${TIPRESIAS_APP} \
   -e TIPRESIAS_APP_TOKEN=${TIPRESIAS_APP_TOKEN} \

--- a/tipping/requirements.prod.txt
+++ b/tipping/requirements.prod.txt
@@ -6,6 +6,7 @@ pandas==1.2.0
 requests
 simplejson
 rollbar
+chardet<4.0 # required version for gql 3.0.0a3
 gql==3.0.0a3
 cerberus
 sqlalchemy==1.3.22

--- a/tipping/serverless.yml
+++ b/tipping/serverless.yml
@@ -40,7 +40,6 @@ provider:
     SPLASH_SERVICE: ${env:SPLASH_SERVICE}
     ROLLBAR_TOKEN: ${env:ROLLBAR_TOKEN}
 
-
 plugins:
   - serverless-offline
   - serverless-python-requirements
@@ -61,7 +60,7 @@ package:
     - handler.py
     - src/tipping/**
   exclude:
-    - '**'
+    - "**"
 
 functions:
   update_fixture_data:
@@ -96,18 +95,21 @@ functions:
           enabled: false
   fetch_match_predictions:
     handler: handler.fetch_match_predictions
+    timeout: 30
     events:
       - http:
           path: predictions
           method: get
   fetch_match_results:
     handler: handler.fetch_match_results
+    timeout: 30
     events:
       - http:
           path: matches
           method: get
   fetch_ml_models:
     handler: handler.fetch_ml_models
+    timeout: 30
     events:
       - http:
           path: ml_models


### PR DESCRIPTION
It's not needed, and apparently doing weird things with
PYTHONPATH can give you weird errors like:

ImportError: This package should not be accessible on Python 3.
Either you are trying to run from the python-future src folder or
your installation of python-future is corrupted.