### PR TITLE
Do image caching in GitHub actions correctly

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -15,17 +15,50 @@ jobs:
           curl -L https://codeclimate.com/downloads/test-reporter/test-reporter-0.6.3-linux-amd64 > ./cc-test-reporter
           chmod +x ./cc-test-reporter
           ./cc-test-reporter before-build
-      - name: Build images
-        run: |
-          docker pull cfranklin11/tipresias_backend:latest
-          docker pull cfranklin11/tipresias_frontend:latest
-          docker pull cfranklin11/tipresias_browser_test:latest
-          docker pull cfranklin11/tipresias_tipping:latest
-
-          docker build --cache-from cfranklin11/tipresias_backend:latest -t cfranklin11/tipresias_backend:latest ./backend
-          docker build --cache-from cfranklin11/tipresias_frontend:latest -t cfranklin11/tipresias_frontend:latest ./frontend
-          docker build --cache-from cfranklin11/tipresias_browser_test:latest -t cfranklin11/tipresias_browser_test:latest ./browser_test
-          docker build --cache-from cfranklin11/tipresias_tipping:latest -t cfranklin11/tipresias_tipping:latest ./tipping
+      - name: Set up Docker Buildx
+        id: buildx
+        uses: docker/setup-buildx-action@v1
+      - name: Cache Backend Docker layers
+        uses: actions/cache@v2
+        with:
+          path: |
+            /tmp/.buildx-cache-backend
+            /tmp/.buildx-cache-tipping
+          key: ${{ runner.os }}-buildx-${{ github.ref }}
+          restore-keys: |
+            ${{ runner.os }}-buildx-
+      - name: Build backend Docker image
+        uses: docker/build-push-action@v2
+        with:
+          context: ./backend
+          builder: ${{ steps.buildx.outputs.name }}
+          tags: cfranklin11/tipresias_backend:latest
+          load: true
+          cache-from: type=local,src=/tmp/.buildx-cache-backend
+          cache-to: type=local,dest=/tmp/.buildx-cache-backend
+      - name: Build tipping Docker image
+        uses: docker/build-push-action@v2
+        with:
+          context: ./tipping
+          builder: ${{ steps.buildx.outputs.name }}
+          tags: cfranklin11/tipresias_tipping:latest
+          load: true
+          cache-from: type=local,src=/tmp/.buildx-cache-tipping
+          cache-to: type=local,dest=/tmp/.buildx-cache-tipping
+      - name: Build frontend Docker image
+        uses: docker/build-push-action@v2
+        with:
+          context: ./frontend
+          builder: ${{ steps.buildx.outputs.name }}
+          tags: cfranklin11/tipresias_frontend:latest
+          load: true
+      - name: Build browser_test Docker image
+        uses: docker/build-push-action@v2
+        with:
+          context: ./browser_test
+          builder: ${{ steps.buildx.outputs.name }}
+          tags: cfranklin11/tipresias_browser_test:latest
+          load: true
       - name: Set up cloud credentials
         env:
           ENCRYPTION_PASSWORD: ${{ secrets.ENCRYPTION_PASSWORD }}


### PR DESCRIPTION
Turns out trying to leverage cached layers from a pulled Docker
image doesn't do anything, so I replaced that flow with a
combination of the Docker build actions and GitHub's native
caching action, which actually works. We're only caching the
Python apps, because those are the slowest to build, and I don't
want to run up against the memory limit for the cache.