### PR TITLE
Fix running integration tests in CI

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -78,24 +78,24 @@ jobs:
       - name: Lint
         if: ${{ always() }}
         run: |
-          docker run cfranklin11/tipresias_backend:latest pylint --disable=R server project scripts
-          docker run cfranklin11/tipresias_tipping:latest pylint --disable=R src handler.py
-          docker run cfranklin11/tipresias_frontend:latest yarn run eslint src
+          docker run --rm cfranklin11/tipresias_backend:latest pylint --disable=R server project scripts
+          docker run --rm cfranklin11/tipresias_tipping:latest pylint --disable=R src handler.py
+          docker run --rm cfranklin11/tipresias_frontend:latest yarn run eslint src
       - name: Check types
         if: ${{ always() }}
         run: |
-          docker run cfranklin11/tipresias_backend:latest mypy server project scripts
-          docker run cfranklin11/tipresias_tipping:latest mypy src handler.py
-          docker run cfranklin11/tipresias_frontend:latest yarn run flow
+          docker run --rm cfranklin11/tipresias_backend:latest mypy server project scripts
+          docker run --rm cfranklin11/tipresias_tipping:latest mypy src handler.py
+          docker run --rm cfranklin11/tipresias_frontend:latest yarn run flow
       - name: Check documentation
         if: ${{ always() }}
         run: |
-          docker run cfranklin11/tipresias_backend:latest pydocstyle server project scripts
-          docker run cfranklin11/tipresias_tipping:latest pydocstyle src handler.py
+          docker run --rm cfranklin11/tipresias_backend:latest pydocstyle server project scripts
+          docker run --rm cfranklin11/tipresias_tipping:latest pydocstyle src handler.py
       - name: Run unit tests
         if: ${{ always() }}
         run: |
-          docker run -e CI=true cfranklin11/tipresias_frontend:latest yarn run test:unit
+          docker run --rm -e CI=true cfranklin11/tipresias_frontend:latest yarn run test:unit
       - name: Run integration/system tests
         if: ${{ always() }}
         env:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -103,9 +103,16 @@ jobs:
           DATA_SCIENCE_SERVICE_TOKEN: ${{ secrets.DATA_SCIENCE_SERVICE_TOKEN }}
           DATABASE_NAME: ${{ secrets.DATABASE_NAME }}
         run: |
+          docker-compose -f docker-compose.ci.yml up --no-start
+
           ./scripts/update_frontend_gql_types.sh docker-compose.ci.yml
+          docker-compose -f docker-compose.ci.yml stop
+
           ./scripts/integration_tests.sh docker-compose.ci.yml
+          docker-compose -f docker-compose.ci.yml stop
+
           ./scripts/browser_tests.sh docker-compose.ci.yml
+          docker-compose -f docker-compose.ci.yml stop
       - name: Upload test coverage report
         # Only way I could get it to work was running format-coverage from each app's root.
         # Otherwise, it can't find files listed in coverage reports, because it uses $PWD,

--- a/docker-compose.ci.yml
+++ b/docker-compose.ci.yml
@@ -26,7 +26,7 @@ services:
     depends_on:
       - backend
     environment:
-      PYTHONPATH: './src'
+      PYTHONPATH: "./src"
       PORT: 3333
       TIPRESIAS_APP: http://backend:8000
       DATA_SCIENCE_SERVICE: $DATA_SCIENCE_SERVICE
@@ -60,7 +60,8 @@ services:
     image: fauna/faunadb:latest
     ports:
       - "8443:8443"
-      - "8084:8084"
+      # NOTE: GitHub Actions use port 8084
+      # - "8084:8084"
   browser_test:
     image: cfranklin11/tipresias_browser_test:latest
     depends_on:

--- a/scripts/integration_tests.sh
+++ b/scripts/integration_tests.sh
@@ -4,18 +4,17 @@ set -euo pipefail
 
 DOCKER_COMPOSE_FILE="${1:-docker-compose.yml}"
 
-docker-compose -f ${DOCKER_COMPOSE_FILE} stop
 docker-compose -f ${DOCKER_COMPOSE_FILE} up -d
 ./scripts/wait-for-it.sh localhost:3000 -t 30 -- echo "Server ready"
 
 # App backend tests
+echo "Running backend integration tests..."
 docker-compose -f ${DOCKER_COMPOSE_FILE} run --rm backend \
   coverage run manage.py test --no-input
 docker-compose -f ${DOCKER_COMPOSE_FILE} run --rm backend coverage xml
 
 # Tipping service tests
+echo "Running tipping service integration tests..."
 docker-compose -f ${DOCKER_COMPOSE_FILE} run --rm tipping \
   coverage run -m pytest src/tests
 docker-compose -f ${DOCKER_COMPOSE_FILE} run --rm tipping coverage xml
-
-docker-compose -f ${DOCKER_COMPOSE_FILE} stop

--- a/scripts/update_frontend_gql_types.sh
+++ b/scripts/update_frontend_gql_types.sh
@@ -5,6 +5,8 @@ set -euo pipefail
 CI=${CI:-"false"}
 DOCKER_COMPOSE_FILE="${1:-docker-compose.yml}"
 
+echo "Checking GraphQL type compatibility..."
+
 docker-compose -f ${DOCKER_COMPOSE_FILE} up -d
 
 ./scripts/wait-for-it.sh localhost:3000 -t 30 -- \


### PR DESCRIPTION
GitHub Actions recently started using port 8084 for something, which conflicts with the default port for Fauna's GQL API. We're not using that API and don't have any plans to use it, so it's safe to comment out.