### PR TITLE
Fix python version

### DIFF
--- a/tipping/Dockerfile
+++ b/tipping/Dockerfile
@@ -3,7 +3,7 @@
 # their own.
 # Using slim-buster instead of alpine based on this GH comment:
 # https://github.com/docker-library/python/issues/381#issuecomment-464258800
-FROM python:3.9.2-slim-buster@sha256:70b693f32768b122a6a5247b0c5d4394da69f5dc3baace93a34860bff00d8ecd
+FROM python:3.8.6-slim-buster@sha256:3a751ba465936180c83904df83436e835b9a919a6331062ae764deefbd3f3b47
 
 RUN apt-get --no-install-recommends update \
   # g++ is a dependency of gcc, so must come before

--- a/tipping/src/tests/unit/test_version.py
+++ b/tipping/src/tests/unit/test_version.py
@@ -1,0 +1,11 @@
+# pylint: disable=missing-docstring
+
+import os
+import sys
+
+
+def test_lambda_version_compatibility():
+    current_python_version = f"{sys.version_info.major}.{sys.version_info.minor}"
+    lambda_python_version = os.popen("npx serverless print | grep runtime:").read()
+
+    assert f"python{current_python_version}" in lambda_python_version


### PR DESCRIPTION
I carelessly upgraded the Python version for `tipping` without realising that it conflicted with the Lambda configuration version. This doesn't raise any errors until we try to deploy, so I added a test to check version compatibility to catch such errors earlier.