### PR TITLE
Break up fetching predictions by model

### DIFF
--- a/tipping/handler.py
+++ b/tipping/handler.py
@@ -61,13 +61,14 @@ def update_fixture_data(_event, _context, verbose=1):
 
 
 @rollbar.lambda_function
-def update_match_predictions(_event, _context, verbose=1):
+def update_match_predictions(event, _context, verbose=1):
     """
     Fetch predictions from ML models and send them to the main app.
 
     verbose: How much information to print. 1 prints all messages; 0 prints none.
     """
-    api.update_match_predictions(verbose=verbose)
+    ml_model_names = event.get("ml_model_names")
+    api.update_match_predictions(ml_model_names=ml_model_names, verbose=verbose)
 
     return _response("Success")
 

--- a/tipping/serverless.yml
+++ b/tipping/serverless.yml
@@ -77,6 +77,14 @@ functions:
           # Everyday, 12am UTC
           rate: cron(0 0 ? * 1-7 *)
           enabled: false
+          input:
+            ml_model_names: tipresias_margin_2021,tipresias_proba_2021
+      - schedule:
+          # Everyday, 1am UTC
+          rate: cron(0 1 ? * 1-7 *)
+          enabled: false
+          input:
+            ml_model_names: tipresias_margin_2021,tipresias_proba_2021
   update_matches:
     handler: handler.update_matches
     events:

--- a/tipping/src/tests/integration/test_tipping.py
+++ b/tipping/src/tests/integration/test_tipping.py
@@ -3,8 +3,9 @@
 from datetime import datetime
 from unittest import TestCase
 from unittest.mock import Mock, patch, MagicMock
-import pytz
+from copy import deepcopy
 
+import pytz
 from freezegun import freeze_time
 import pandas as pd
 from requests import Response
@@ -27,8 +28,7 @@ TIP_DATES = [
 
 
 class TestTipper(TestCase):
-    @patch("tipping.data_import")
-    def setUp(self, mock_data_import):  # pylint: disable=arguments-differ
+    def setUp(self):
         candy = CandyStore(seasons=MATCH_SEASON_RANGE)
         fixtures = data_factories.fake_fixture_data(fixtures=candy.fixtures(to_dict=None))
         predictions = data_factories.fake_prediction_data(
@@ -49,13 +49,14 @@ class TestTipper(TestCase):
         ]
         season_match_results = match_results.query('year == @TIP_SEASON_RANGE[0]')
 
-        mock_data_import.fetch_prediction_data = Mock(
+        self.mock_data_importer = Mock()
+        self.mock_data_importer.fetch_prediction_data = Mock(
             side_effect=season_predictions
         )
-        mock_data_import.fetch_fixture_data = Mock(
+        self.mock_data_importer.fetch_fixture_data = Mock(
             side_effect=season_fixtures
         )
-        mock_data_import.fetch_match_data = Mock(
+        self.mock_data_importer.fetch_match_data = Mock(
             return_value=season_match_results
         )
 
@@ -72,7 +73,7 @@ class TestTipper(TestCase):
         )
 
         self.tipping = Tipper(
-            data_importer=mock_data_import,
+            data_importer=self.mock_data_importer,
             tip_submitters=[self.mock_footy_tips_submitter, self.mock_monash_submitter],
             verbose=0,
         )
@@ -120,17 +121,22 @@ class TestTipper(TestCase):
                 mock_update_fixture_data.assert_not_called()
 
     @patch("tipping.tipping.data_export")
-    @patch("tipping.tipping.data_import")
-    def test_update_match_predictions(self, mock_data_import, mock_data_export):
+    def test_update_match_predictions(self, mock_data_export):
         mock_data_export.update_match_predictions = MagicMock()
 
         with self.subTest("with no future match records available"):
-            mock_data_import.fetch_fixture_data = MagicMock(return_value=pd.DataFrame())
+            mock_data_importer = deepcopy(self.mock_data_importer.fetch_fixture_data)
+            mock_data_importer.fetch_fixture_data = MagicMock(return_value=pd.DataFrame())
 
-            self.tipping.update_match_predictions()
+            tipping = Tipper(
+                data_importer=mock_data_importer,
+                tip_submitters=[self.mock_footy_tips_submitter, self.mock_monash_submitter],
+                verbose=0,
+            )
+            tipping.update_match_predictions()
 
             # It doesn't fetch predictions
-            self.tipping.data_importer.fetch_prediction_data.assert_not_called()
+            tipping.data_importer.fetch_prediction_data.assert_not_called()
             # It doesn't send predictions to server API
             mock_data_export.update_match_predictions.assert_not_called()
             # It doesn't try to submit any tips
@@ -138,14 +144,14 @@ class TestTipper(TestCase):
             self.mock_monash_submitter._submit_competition_tips.assert_not_called()  # pylint: disable=protected-access
 
         with self.subTest("with at least one future match record"):
-            mock_data_import.fetch_fixture_data = MagicMock(
+            mock_data_importer.fetch_fixture_data = MagicMock(
                 return_value=self.first_season_fixture
             )
 
-            self.tipping.update_match_predictions()
+            tipping.update_match_predictions()
 
             # It fetches predictions
-            self.tipping.data_importer.fetch_prediction_data.assert_called()
+            tipping.data_importer.fetch_prediction_data.assert_called()
             # It sends predictions to Tipresias app
             mock_data_export.update_match_predictions.assert_called()
             # It submits tips to all competitions

--- a/tipping/src/tests/unit/test_api.py
+++ b/tipping/src/tests/unit/test_api.py
@@ -209,7 +209,7 @@ class TestApi(TestCase):
         MockDataImporter.return_value = mock_data_import
 
         round_number = np.random.choice(fixtures["round_number"])
-        ml_models = list(set(np.random.choice(predictions["ml_model"], 2)))
+        ml_models = ",".join(set(np.random.choice(predictions["ml_model"], 2)))
         train_models = bool(np.random.randint(0, 2))
 
         prediction_response = self.api.fetch_match_predictions(
@@ -223,7 +223,7 @@ class TestApi(TestCase):
         mock_data_import.fetch_prediction_data.assert_called_with(
             CURRENT_YEAR_RANGE,
             round_number=round_number,
-            ml_models=ml_models,
+            ml_model_names=ml_models,
             train_models=train_models,
         )
         # It returns predictions organised by match

--- a/tipping/src/tests/unit/test_api.py
+++ b/tipping/src/tests/unit/test_api.py
@@ -5,6 +5,7 @@ from unittest.mock import patch, MagicMock
 from datetime import datetime, date
 import pytz
 
+import pandas as pd
 import numpy as np
 from freezegun import freeze_time
 from candystore import CandyStore
@@ -143,6 +144,18 @@ class TestApi(TestCase):
     @patch("tipping.api.data_import")
     def test_update_match_predictions(self, mock_data_import, mock_data_export):
         mock_data_export.update_match_predictions = MagicMock()
+
+        prediction_model_names = (
+            pd.concat(self.prediction_return_values)["ml_model"]
+            .drop_duplicates()
+            .to_numpy()
+        )
+        prediction_ml_models = data_factories.fake_ml_model_data(
+            len(prediction_model_names)
+        ).assign(name=prediction_model_names)
+        mock_data_import.fetch_ml_model_info = MagicMock(
+            return_value=prediction_ml_models
+        )
         mock_data_import.fetch_prediction_data = MagicMock(
             side_effect=self.prediction_return_values
         )

--- a/tipping/src/tests/unit/test_data_import.py
+++ b/tipping/src/tests/unit/test_data_import.py
@@ -7,6 +7,11 @@ import pytest
 from tipping import data_import
 
 
+@pytest.fixture()
+def data_importer():
+    return data_import.DataImporter()
+
+
 @pytest.mark.parametrize(
     "start_date,end_date",
     [
@@ -15,6 +20,6 @@ from tipping import data_import
         ("2020-05-24", str(datetime.now())),
     ],
 )
-def test_invalid_fetch_match_data_params(start_date, end_date):
+def test_invalid_fetch_match_data_params(start_date, end_date, data_importer):
     with pytest.raises(AssertionError, match="yyyy-mm-dd"):
-        data_import.fetch_match_data(start_date, end_date)
+        data_importer.fetch_match_data(start_date, end_date)

--- a/tipping/src/tipping/api.py
+++ b/tipping/src/tipping/api.py
@@ -67,7 +67,7 @@ def _fetch_current_round_fixture(verbose, after=True) -> Optional[pd.DataFrame]:
         preposition = "after" if after else "up to"
         print(f"Fetching fixture for matches {preposition} {beginning_of_today}...\n")
 
-    fixture_data_frame = data_import.fetch_fixture_data(
+    fixture_data_frame = data_import.DataImporter().fetch_fixture_data(
         start_date=beginning_of_this_year,
         end_date=end_of_this_year,
     )
@@ -126,7 +126,7 @@ def update_match_predictions(tips_submitters=None, verbose=1) -> None:
     current_round = matches_from_current_round["round_number"].min()
     current_season = matches_from_current_round["date"].min().year
 
-    ml_models = data_import.fetch_ml_model_info()
+    ml_models = data_import.DataImporter().fetch_ml_model_info()
 
     if verbose == 1:
         print("Fetching predictions for round " f"{current_round}, {current_season}...")
@@ -179,7 +179,7 @@ def update_matches(verbose=1) -> None:
     if verbose == 1:
         print(f"Fetching match data for season {right_now.year}")
 
-    match_data = data_import.fetch_match_data(
+    match_data = data_import.DataImporter().fetch_match_data(
         start_of_year, end_of_year, fetch_data=True
     )
 
@@ -208,7 +208,9 @@ def update_match_results(verbose=1) -> None:
     if verbose == 1:
         print(f"Fetching match results for round {current_round}")
 
-    match_results_data = data_import.fetch_match_results_data(current_round)
+    match_results_data = data_import.DataImporter().fetch_match_results_data(
+        current_round
+    )
 
     if verbose == 1:
         print("Match results data received!")
@@ -243,7 +245,7 @@ def fetch_match_predictions(
     --------
         List of prediction data dictionaries.
     """
-    prediction_data = data_import.fetch_prediction_data(
+    prediction_data = data_import.DataImporter().fetch_prediction_data(
         year_range,
         round_number=round_number,
         ml_models=ml_models,
@@ -272,7 +274,9 @@ def fetch_matches(
     --------
         List of match results data dicts.
     """
-    return data_import.fetch_match_data(start_date, end_date, fetch_data=fetch_data)
+    return data_import.DataImporter().fetch_match_data(
+        start_date, end_date, fetch_data=fetch_data
+    )
 
 
 def fetch_ml_models() -> pd.DataFrame:
@@ -283,4 +287,4 @@ def fetch_ml_models() -> pd.DataFrame:
     --------
     A list of objects with basic info about each ML model.
     """
-    return data_import.fetch_ml_model_info()
+    return data_import.DataImporter().fetch_ml_model_info()

--- a/tipping/src/tipping/data_import.py
+++ b/tipping/src/tipping/data_import.py
@@ -41,7 +41,7 @@ class DataImporter:
         self,
         year_range: str,
         round_number: Optional[int] = None,
-        ml_models: Optional[List[str]] = None,
+        ml_model_names: Optional[str] = None,
         train_models: Optional[bool] = False,
     ) -> pd.DataFrame:
         """
@@ -52,22 +52,21 @@ class DataImporter:
         year_range: Min (inclusive) and max (exclusive) years for which to fetch data.
             Format is 'yyyy-yyyy'.
         round_number: Specify a particular round for which to fetch data.
-        ml_models: List of ML model names to use for making predictions.
+        ml_model_names: Comma-separated string of ML model names to use
+            for making predictions.
         train_models: Whether to train models in between predictions (only applies
             when predicting across multiple seasons).
 
         Returns:
         --------
-        List of prediction data dictionaries.
+        Predictions data frame.
         """
-        ml_model_param = None if ml_models is None else ",".join(ml_models)
-
         prediction_data = self._fetch_data(
             "predictions",
             {
                 "year_range": year_range,
                 "round_number": round_number,
-                "ml_models": ml_model_param,
+                "ml_models": ml_model_names or None,
                 "train_models": train_models,
             },
         )

--- a/tipping/src/tipping/data_import.py
+++ b/tipping/src/tipping/data_import.py
@@ -25,192 +25,209 @@ PredictionData = TypedDict(
 DATE_STRING_REGEX = re.compile(r"^\d{4}\-\d{2}\-\d{2}$")
 
 
-def _validate_date_string(date_string: str):
-    assert (
-        DATE_STRING_REGEX.match(date_string) is not None
-    ), f"Date strings must have format yyyy-mm-dd. Received {date_string}"
+class DataImporter:
+    """Imports data from the data science service."""
 
+    def __init__(self, client=requests):
+        """Instantiate a DataImporter object.
 
-def _parse_dates(data_frame: pd.DataFrame) -> pd.Series:
-    # We have to use dateutil.parser instead of a pandas datetime parser,
-    # because the former doesn't maintain the timezone offset.
-    # We make sure all datetimes are converted to UTC, because that makes things
-    # easier due to Django converting all datetime fields to UTC when saving DB records.
-    return data_frame["date"].map(lambda dt: parser.parse(dt).replace(tzinfo=pytz.UTC))
+        Params:
+        -------
+        client: HTTP client for calling external APIs.
+        """
+        self.client = client
 
+    def fetch_prediction_data(
+        self,
+        year_range: str,
+        round_number: Optional[int] = None,
+        ml_models: Optional[List[str]] = None,
+        train_models: Optional[bool] = False,
+    ) -> pd.DataFrame:
+        """
+        Fetch prediction data from ML models in the data-science service.
 
-def _clean_datetime_param(param_value: ParamValue) -> Optional[str]:
-    if not isinstance(param_value, datetime):
-        return None
+        Params:
+        -------
+        year_range: Min (inclusive) and max (exclusive) years for which to fetch data.
+            Format is 'yyyy-yyyy'.
+        round_number: Specify a particular round for which to fetch data.
+        ml_models: List of ML model names to use for making predictions.
+        train_models: Whether to train models in between predictions (only applies
+            when predicting across multiple seasons).
 
-    # For the edge-case in which this gets run early enough in the morning
-    # such that UTC is still the previous day, and the start/end date filters are all
-    # one day off.
-    return str(param_value.astimezone(pytz.timezone("Australia/Melbourne")).date())
+        Returns:
+        --------
+        List of prediction data dictionaries.
+        """
+        ml_model_param = None if ml_models is None else ",".join(ml_models)
 
-
-def _clean_param_value(param_value: ParamValue) -> str:
-    return _clean_datetime_param(param_value) or str(param_value)
-
-
-def _fetch_data(
-    path: str, params: Optional[Dict[str, Any]] = None
-) -> Union[List[Dict[str, Any]], PredictionData]:
-    params = params or {}
-
-    service_host = settings.DATA_SCIENCE_SERVICE
-    headers = (
-        {"Authorization": f"Bearer {settings.DATA_SCIENCE_SERVICE_TOKEN}"}
-        if settings.IS_PRODUCTION
-        else {}
-    )
-
-    service_url = urljoin(service_host, path)
-    clean_params = {
-        key: _clean_param_value(value)
-        for key, value in params.items()
-        if value is not None
-    }
-
-    response = requests.get(service_url, params=clean_params, headers=headers)
-
-    if 200 <= response.status_code < 300:
-        return response.json().get("data")
-
-    raise Exception(
-        f"Bad response from application when requesting {service_url}:\n"
-        f"Status: {response.status_code}\n"
-        f"Headers: {response.headers}\n"
-        f"Body: {response.text}"
-    )
-
-
-def fetch_prediction_data(
-    year_range: str,
-    round_number: Optional[int] = None,
-    ml_models: Optional[List[str]] = None,
-    train_models: Optional[bool] = False,
-) -> pd.DataFrame:
-    """
-    Fetch prediction data from ML models in the data-science service.
-
-    Params:
-    -------
-    year_range: Min (inclusive) and max (exclusive) years for which to fetch data.
-        Format is 'yyyy-yyyy'.
-    round_number: Specify a particular round for which to fetch data.
-    ml_models: List of ML model names to use for making predictions.
-    train_models: Whether to train models in between predictions (only applies
-        when predicting across multiple seasons).
-
-    Returns:
-    --------
-    List of prediction data dictionaries.
-    """
-    ml_model_param = None if ml_models is None else ",".join(ml_models)
-
-    prediction_data = _fetch_data(
-        "predictions",
-        {
-            "year_range": year_range,
-            "round_number": round_number,
-            "ml_models": ml_model_param,
-            "train_models": train_models,
-        },
-    )
-
-    return pd.DataFrame(prediction_data)
-
-
-def fetch_fixture_data(start_date: datetime, end_date: datetime) -> pd.DataFrame:
-    """
-    Fetch fixture data (doesn't include match results) from machine_learning module.
-
-    Params:
-    -------
-    start_date: Timezone-aware date-time that determines the earliest date
-        for which to fetch data.
-    end_date: Timezone-aware date-time that determines the latest date
-        for which to fetch data.
-
-    Returns:
-    --------
-    pandas.DataFrame with fixture data.
-    """
-    fixtures = pd.DataFrame(
-        _fetch_data("fixtures", {"start_date": start_date, "end_date": end_date})
-    )
-
-    if fixtures.any().any():
-        return fixtures.assign(date=_parse_dates)
-
-    return fixtures
-
-
-def fetch_match_data(
-    start_date: str, end_date: str, fetch_data: bool = False
-) -> pd.DataFrame:
-    """
-    Fetch data for past matches from machine_learning module.
-
-    Params:
-    -------
-    start_date: Date string that determines the earliest date
-        for which to fetch data. Format is 'yyyy-mm-dd'.
-    end_date: Date string that determines the latest date
-        for which to fetch data. Format is 'yyyy-mm-dd'.
-    fetch_data: Whether to fetch fresh data. Non-fresh data goes up to end
-        of previous season.
-
-    Returns:
-    --------
-    pandas.DataFrame with match data.
-    """
-    _validate_date_string(start_date)
-    _validate_date_string(end_date)
-    matches = pd.DataFrame(
-        _fetch_data(
-            "matches",
-            {"start_date": start_date, "end_date": end_date, "fetch_data": fetch_data},
+        prediction_data = self._fetch_data(
+            "predictions",
+            {
+                "year_range": year_range,
+                "round_number": round_number,
+                "ml_models": ml_model_param,
+                "train_models": train_models,
+            },
         )
-    )
 
-    if any(matches):
-        return matches.assign(date=_parse_dates)
+        return pd.DataFrame(prediction_data)
 
-    return matches
+    def fetch_fixture_data(
+        self, start_date: datetime, end_date: datetime
+    ) -> pd.DataFrame:
+        """
+        Fetch fixture data (doesn't include match results) from machine_learning module.
 
+        Params:
+        -------
+        start_date: Timezone-aware date-time that determines the earliest date
+            for which to fetch data.
+        end_date: Timezone-aware date-time that determines the latest date
+            for which to fetch data.
 
-def fetch_match_results_data(round_number: int) -> pd.DataFrame:
-    """
-    Fetch minimal match results data.
+        Returns:
+        --------
+        pandas.DataFrame with fixture data.
+        """
+        fixtures = pd.DataFrame(
+            data=self._fetch_data(
+                "fixtures", {"start_date": start_date, "end_date": end_date}
+            )
+        )
 
-    Params:
-    -------
-    round_number: Fetch results for the given round.
+        if fixtures.any().any():
+            return fixtures.assign(date=self._parse_dates)
 
-    Returns:
-    --------
-    pandas.DataFrame with match data.
-    """
-    match_results = pd.DataFrame(
-        _fetch_data("match_results", {"round_number": round_number})
-    )
+        return fixtures
 
-    if any(match_results):
-        return match_results.assign(date=_parse_dates)
+    def fetch_match_data(
+        self, start_date: str, end_date: str, fetch_data: bool = False
+    ) -> pd.DataFrame:
+        """
+        Fetch data for past matches from machine_learning module.
 
-    return match_results
+        Params:
+        -------
+        start_date: Date string that determines the earliest date
+            for which to fetch data. Format is 'yyyy-mm-dd'.
+        end_date: Date string that determines the latest date
+            for which to fetch data. Format is 'yyyy-mm-dd'.
+        fetch_data: Whether to fetch fresh data. Non-fresh data goes up to end
+            of previous season.
 
+        Returns:
+        --------
+        pandas.DataFrame with match data.
+        """
+        self._validate_date_string(start_date)
+        self._validate_date_string(end_date)
+        matches = pd.DataFrame(
+            self._fetch_data(
+                "matches",
+                {
+                    "start_date": start_date,
+                    "end_date": end_date,
+                    "fetch_data": fetch_data,
+                },
+            )
+        )
 
-def fetch_ml_model_info() -> pd.DataFrame:
-    """
-    Fetch general info about all saved ML models.
+        if any(matches):
+            return matches.assign(date=self._parse_dates)
 
-    Returns:
-    --------
-    A list of objects with basic info about each ML model.
-    """
-    return pd.DataFrame(
-        [cast(MLModelInfo, ml_model) for ml_model in _fetch_data("ml_models")]
-    )
+        return matches
+
+    def fetch_match_results_data(self, round_number: int) -> pd.DataFrame:
+        """
+        Fetch minimal match results data.
+
+        Params:
+        -------
+        round_number: Fetch results for the given round.
+
+        Returns:
+        --------
+        pandas.DataFrame with match data.
+        """
+        match_results = pd.DataFrame(
+            self._fetch_data("match_results", {"round_number": round_number})
+        )
+
+        if any(match_results):
+            return match_results.assign(date=self._parse_dates)
+
+        return match_results
+
+    def fetch_ml_model_info(self) -> pd.DataFrame:
+        """
+        Fetch general info about all saved ML models.
+
+        Returns:
+        --------
+        A list of objects with basic info about each ML model.
+        """
+        return pd.DataFrame(
+            [cast(MLModelInfo, ml_model) for ml_model in self._fetch_data("ml_models")]
+        )
+
+    @staticmethod
+    def _validate_date_string(date_string: str):
+        assert (
+            DATE_STRING_REGEX.match(date_string) is not None
+        ), f"Date strings must have format yyyy-mm-dd. Received {date_string}"
+
+    @staticmethod
+    def _parse_dates(data_frame: pd.DataFrame) -> pd.Series:
+        # We have to use dateutil.parser instead of a pandas datetime parser,
+        # because the former doesn't maintain the timezone offset.
+        # We make sure all datetimes are converted to UTC, because that makes things
+        # easier due to Django converting all datetime fields to UTC when saving DB records.
+        return data_frame["date"].map(
+            lambda dt: parser.parse(dt).replace(tzinfo=pytz.UTC)
+        )
+
+    @staticmethod
+    def _clean_datetime_param(param_value: ParamValue) -> Optional[str]:
+        if not isinstance(param_value, datetime):
+            return None
+
+        # For the edge-case in which this gets run early enough in the morning
+        # such that UTC is still the previous day, and the start/end date filters are all
+        # one day off.
+        return str(param_value.astimezone(pytz.timezone("Australia/Melbourne")).date())
+
+    def _clean_param_value(self, param_value: ParamValue) -> str:
+        return self._clean_datetime_param(param_value) or str(param_value)
+
+    def _fetch_data(
+        self, path: str, params: Optional[Dict[str, Any]] = None
+    ) -> Union[List[Dict[str, Any]], PredictionData]:
+        params = params or {}
+
+        service_host = settings.DATA_SCIENCE_SERVICE
+        headers = (
+            {"Authorization": f"Bearer {settings.DATA_SCIENCE_SERVICE_TOKEN}"}
+            if settings.IS_PRODUCTION
+            else {}
+        )
+
+        service_url = urljoin(service_host, path)
+        clean_params = {
+            key: self._clean_param_value(value)
+            for key, value in params.items()
+            if value is not None
+        }
+
+        response = requests.get(service_url, params=clean_params, headers=headers)
+
+        if 200 <= response.status_code < 300:
+            return response.json().get("data")
+
+        raise Exception(
+            f"Bad response from application when requesting {service_url}:\n"
+            f"Status: {response.status_code}\n"
+            f"Headers: {response.headers}\n"
+            f"Body: {response.text}"
+        )

--- a/tipping/src/tipping/tipping.py
+++ b/tipping/src/tipping/tipping.py
@@ -37,7 +37,7 @@ class MonashSubmitter:
     """Submits tips to one or more of the Monash footy tipping competitions."""
 
     def __init__(
-        self, competitions: Optional[List[str]] = None, browser=None, verbose: int = 1,
+        self, competitions: Optional[List[str]] = None, browser=None, verbose: int = 1
     ):
         """
         Instantiate a MonashSubmitter object.
@@ -76,7 +76,7 @@ class MonashSubmitter:
     ) -> Dict[str, str]:
         PREDICTION_TYPE = {"normal": "margin", "info": "win_probability"}
         competition_prediction_type = cast(
-            PredictionType, f"predicted_{PREDICTION_TYPE[competition]}",
+            PredictionType, f"predicted_{PREDICTION_TYPE[competition]}"
         )
         predicted_winners = cast(List[MatchPrediction], convert_to_dict(predictions))
 
@@ -322,7 +322,7 @@ class Tipper:
         verbose: How much information to print. 1 prints all messages; 0 prints none.
         """
         self.fetch_data = fetch_data
-        self.data_importer: Any = data_importer or data_import
+        self.data_importer: Any = data_importer or data_import.DataImporter()
         self.ml_models = ml_models
         self.verbose = verbose
         self.tip_submitters = tip_submitters or [
@@ -353,7 +353,7 @@ class Tipper:
         """Request prediction data from Augury service for upcoming matches."""
         right_now = datetime.now(tz=pytz.UTC)
         end_of_year = datetime(right_now.year, DEC, THIRTY_FIRST, tzinfo=pytz.UTC)
-        upcoming_matches = data_import.fetch_fixture_data(right_now, end_of_year)
+        upcoming_matches = self.data_importer.fetch_fixture_data(right_now, end_of_year)
 
         if not upcoming_matches.any().any():
             if self.verbose == 1:


### PR DESCRIPTION
Trying to fetch predictions for all four models in one go was running up against the Lambda timeout. I tried making the requests asynchronous, but I had other timeout errors pop up. So, I went with the bandaid approach of just requesting predictions for two models at a time. This will at least buy me some time till I can set up an event-based architecture to rely less on overly-long HTTP requests to update data.