### PR TITLE
Allow cross-origin requests from separate frontend

### DIFF
--- a/backend/project/settings/common.py
+++ b/backend/project/settings/common.py
@@ -29,6 +29,8 @@ TIPPING_SERVICE = "http://tipping:3333"
 # See https://docs.djangoproject.com/en/2.1/howto/deployment/checklist/
 
 ALLOWED_HOSTS: List = []
+CORS_ORIGIN_ALLOW_ALL = False
+CORS_ORIGIN_WHITELIST = ("http://localhost:3000",)
 
 # Application definition
 
@@ -41,11 +43,13 @@ INSTALLED_APPS = [
     "django.contrib.sessions",
     "django.contrib.messages",
     "django.contrib.staticfiles",
+    "corsheaders",
 ]
 
 GRAPHENE = {"SCHEMA": "server.graphql.schema"}
 
 MIDDLEWARE = [
+    "corsheaders.middleware.CorsMiddleware",
     "django.middleware.security.SecurityMiddleware",
     "django.contrib.sessions.middleware.SessionMiddleware",
     "django.middleware.common.CommonMiddleware",

--- a/backend/project/settings/production.py
+++ b/backend/project/settings/production.py
@@ -21,6 +21,9 @@ ALLOWED_HOSTS = [
     os.environ.get("DATA_SCIENCE_SERVICE"),
 ]
 
+if os.environ["FRONTEND_SERVICE"]:
+    CORS_ORIGIN_WHITELIST = (os.environ["FRONTEND_SERVICE"],)
+
 INSTALLED_APPS.append("whitenoise.runserver_nostatic")
 
 # Must insert after SecurityMiddleware, which is first in settings/common.py

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -4,6 +4,7 @@ pandas==1.2.2
 
 # App packages
 django==3.1.7
+django-cors-headers
 whitenoise
 graphene==3.0.0b6
 graphene-django==3.0.0b7


### PR DESCRIPTION
Prerequisite for hosting the frontend app separate from the
backend.