### PR TITLE
Make sure the correct origins are allowed for all environments

### DIFF
--- a/backend/project/settings/common.py
+++ b/backend/project/settings/common.py
@@ -30,7 +30,7 @@ TIPPING_SERVICE = "http://tipping:3333"
 
 ALLOWED_HOSTS: List = []
 CORS_ORIGIN_ALLOW_ALL = False
-CORS_ORIGIN_WHITELIST = ["http://localhost:3000"]
+CORS_ALLOWED_ORIGINS = []
 
 # Application definition
 

--- a/backend/project/settings/common.py
+++ b/backend/project/settings/common.py
@@ -28,9 +28,9 @@ TIPPING_SERVICE = "http://tipping:3333"
 # Quick-start development settings - unsuitable for production
 # See https://docs.djangoproject.com/en/2.1/howto/deployment/checklist/
 
-ALLOWED_HOSTS: List = []
+ALLOWED_HOSTS: List[str] = []
 CORS_ORIGIN_ALLOW_ALL = False
-CORS_ALLOWED_ORIGINS = []
+CORS_ALLOWED_ORIGINS: List[str] = []
 
 # Application definition
 

--- a/backend/project/settings/development.py
+++ b/backend/project/settings/development.py
@@ -4,7 +4,11 @@
 from project.settings.common import *
 
 ALLOWED_HOSTS = ["backend", "localhost", "app", "host.docker.internal"]
-
+CORS_ALLOWED_ORIGINS = [
+    "http://frontend:3000",
+    "http://localhost:3000",
+    "http://host.docker.internal:3000",
+]
 # SECURITY WARNING: don't run with debug turned on in production!
 DEBUG = True
 

--- a/backend/project/settings/production.py
+++ b/backend/project/settings/production.py
@@ -21,10 +21,10 @@ ALLOWED_HOSTS = [
     os.environ.get("DATA_SCIENCE_SERVICE"),
 ]
 
-CORS_ORIGIN_WHITELIST = [os.getenv("PRODUCTION_HOST", "")]
-
-if os.getenv("FRONTEND_SERVICE") is not None:
-    CORS_ORIGIN_WHITELIST.append(os.environ["FRONTEND_SERVICE"])
+CORS_ALLOWED_ORIGINS = [
+    os.getenv("PRODUCTION_HOST", ""),
+    os.getenv("FRONTEND_SERVICE", ""),
+]
 
 INSTALLED_APPS.append("whitenoise.runserver_nostatic")
 

--- a/backend/project/settings/production.py
+++ b/backend/project/settings/production.py
@@ -17,8 +17,8 @@ TIPPING_SERVICE = "TBD"
 ALLOWED_HOSTS = [
     "tipresias.herokuapp.com",
     ".tipresias.net",
-    os.environ.get("PRODUCTION_HOST"),
-    os.environ.get("DATA_SCIENCE_SERVICE"),
+    os.environ.get("PRODUCTION_HOST", ""),
+    os.environ.get("DATA_SCIENCE_SERVICE", ""),
 ]
 
 CORS_ALLOWED_ORIGINS = [

--- a/backend/project/settings/test.py
+++ b/backend/project/settings/test.py
@@ -3,6 +3,11 @@
 from project.settings.common import *  # pylint: disable=wildcard-import, unused-wildcard-import
 
 ALLOWED_HOSTS = ["backend", "localhost", "app"]
+CORS_ALLOWED_ORIGINS = [
+    "http://frontend:3000",
+    "http://localhost:3000",
+    "http://host.docker.internal:3000",
+]
 
 # SECURITY WARNING: don't run with debug turned on in production!
 DEBUG = True

--- a/backend/project/settings/test.py
+++ b/backend/project/settings/test.py
@@ -1,18 +1,5 @@
 """Settings for the server app in the test environment."""
 
-from project.settings.common import *  # pylint: disable=wildcard-import, unused-wildcard-import
-
-ALLOWED_HOSTS = ["backend", "localhost", "app"]
-CORS_ALLOWED_ORIGINS = [
-    "http://frontend:3000",
-    "http://localhost:3000",
-    "http://host.docker.internal:3000",
-]
-
-# SECURITY WARNING: don't run with debug turned on in production!
-DEBUG = True
-
-# SECURITY WARNING: keep the secret key used in production secret!
-SECRET_KEY = "^6&#7de5dx#eqg6dm^l3#@wj6vjjn%2f=u(!&ia()h-l1ppan!"
+from project.settings.development import *  # pylint: disable=wildcard-import, unused-wildcard-import
 
 ENVIRONMENT = "test"


### PR DESCRIPTION
I had frontend integration tests failing, because the backend
wasn't permitting API calls from the given origin. I also updated
the config variable name to the latest version.