### PR TITLE
Reduce Rollbar noise

### DIFF
--- a/tipping/handler.py
+++ b/tipping/handler.py
@@ -24,6 +24,26 @@ rollbar_token = os.getenv("ROLLBAR_TOKEN", "missing_api_key")
 rollbar.init(rollbar_token, settings.ENVIRONMENT)
 
 
+def rollbar_ignore_handler(payload):
+    """Filter out certain errors rom Rollbar logs."""
+    error_class_name = (
+        payload.get("data", {})
+        .get("body", {})
+        .get("exception", {})
+        .get("class", {}, "")
+    )
+
+    # We ignore ServerErrorResponse, because that error will be recorded in Rollbar
+    # by the called service
+    if error_class_name == "ServerErrorResponse":
+        return False
+
+    return payload
+
+
+rollbar.events.add_payload_handler(rollbar_ignore_handler)
+
+
 class Response(TypedDict):
     """Response dict for AWS Lambda functions."""
 

--- a/tipping/requirements.txt
+++ b/tipping/requirements.txt
@@ -12,3 +12,4 @@ freezegun==1.1.0
 factory_boy
 coverage
 candystore==0.3.2
+responses

--- a/tipping/src/tests/unit/test_data_import.py
+++ b/tipping/src/tests/unit/test_data_import.py
@@ -3,13 +3,20 @@
 from datetime import datetime
 
 import pytest
+import responses
 
 from tipping import data_import
+from tipping import settings
 
 
-@pytest.fixture()
+@pytest.fixture
 def data_importer():
     return data_import.DataImporter()
+
+
+@pytest.fixture
+def response_data():
+    return {"data": [{"date": "2020-03-01"}]}
 
 
 @pytest.mark.parametrize(
@@ -23,3 +30,28 @@ def data_importer():
 def test_invalid_fetch_match_data_params(start_date, end_date, data_importer):
     with pytest.raises(AssertionError, match="yyyy-mm-dd"):
         data_importer.fetch_match_data(start_date, end_date)
+
+
+@responses.activate
+@pytest.mark.parametrize(
+    "status_code,expected_error",
+    [
+        (200, None),
+        (301, data_import.DataImportError),
+        (404, data_import.DataImportError),
+        (500, data_import.ServerErrorResponse),
+    ],
+)
+def test_responses(status_code, expected_error, data_importer, response_data):
+    responses.add(
+        responses.GET,
+        f"{settings.DATA_SCIENCE_SERVICE}/fixtures",
+        status=status_code,
+        json=response_data,
+    )
+
+    if expected_error is None:
+        data_importer.fetch_fixture_data(datetime.now(), datetime.now())
+    else:
+        with pytest.raises(expected_error, match=str(status_code)):
+            data_importer.fetch_fixture_data(datetime.now(), datetime.now())


### PR DESCRIPTION
Since we raise an error whenever a service receives an error response from another service, and we log all errors in Rollbar, we end up with a lot of duplicate items: both the initial error, and the manual `raise` from getting an unsuccessful response. So, we use a handler function to ignore those errors that we assume are being logged elsewhere.