### PR TITLE
Fix calculation of cumulative metrics by de-duplicating records

### DIFF
--- a/backend/server/graphql/schema.py
+++ b/backend/server/graphql/schema.py
@@ -279,7 +279,7 @@ class Query(graphene.ObjectType):
                 ml_model__used_in_competitions=True,
                 # We don't want to include matches without results, which would impact
                 # mean-based metrics like accuracy and MAE
-                match__teammatch__score__gt=0,
+                match__margin__isnull=False,
             )
             .select_related("ml_model", "match")
             .values(

--- a/backend/server/tests/unit/test_schema.py
+++ b/backend/server/tests/unit/test_schema.py
@@ -608,9 +608,14 @@ class TestSchema(TestCase):
         self.assertEqual(data["season"], YEAR)
         self.assertEqual(data["roundNumber"], ROUND_COUNT)
 
-        self.assertGreater(data["cumulativeCorrectCount"], 0)
+        # We force all predictions to be correct, so the correct count should just be
+        # the number of matches
+        self.assertEqual(data["cumulativeCorrectCount"], ROUND_COUNT * MATCH_COUNT)
         self.assertGreater(data["cumulativeMeanAbsoluteError"], 0)
-        self.assertGreater(data["cumulativeMarginDifference"], 0)
+        self.assertEqual(
+            round(data["cumulativeMarginDifference"]),
+            round(data["cumulativeMeanAbsoluteError"] * ROUND_COUNT * MATCH_COUNT),
+        )
         self.assertGreater(data["cumulativeAccuracy"], 0)
         # Bits can be positive or negative, so we just want to make sure it's not 0,
         # which would suggest a problem


### PR DESCRIPTION
By including 'teammatch' in the Prediction query, we got one
record per TeamMatch per Prediction, which resulted in double
the rows that we expected, which resulted in double the
cumulative correct count and cumulative margin error.