### PR TITLE
Add predictionSeason arg & field to allow display of relevant models

### DIFF
--- a/backend/server/graphql/types/models.py
+++ b/backend/server/graphql/types/models.py
@@ -91,3 +91,16 @@ class MLModelType(DjangoObjectType):
         ),
         required=True,
     )
+
+    prediction_seasons = graphene.List(
+        graphene.NonNull(graphene.Int),
+        description="Seasons for which the model has predicted match results.",
+        required=True,
+    )
+
+    @staticmethod
+    def resolve_prediction_seasons(root, _info):
+        """Fetch all seasons for which this model has predictions."""
+        return root.prediction_set.distinct("match__start_date_time__year").values_list(
+            "match__start_date_time__year", flat=True
+        )

--- a/backend/server/schema.graphql
+++ b/backend/server/schema.graphql
@@ -28,6 +28,11 @@ type Query {
     competition_only: Whether to filter ML models such that only the models whose predictions are submitted to competitions are returned. There are no more than one model per type of prediction (e.g. margin, win probability).
     """
     forCompetitionOnly: Boolean = false
+
+    """
+    Filter ML models such that only ones with predictions for the given season are returned.
+    """
+    predictionYear: Int = null
   ): [MLModelType!]!
 }
 

--- a/backend/server/schema.graphql
+++ b/backend/server/schema.graphql
@@ -105,6 +105,9 @@ type MLModelType {
   usedInCompetitions: Boolean!
   predictionType: ServerMLModelPredictionTypeChoices!
   predictionSet: [PredictionType!]!
+
+  """Seasons for which the model has predicted match results."""
+  predictionSeasons: [Int!]!
 }
 
 """An enumeration."""


### PR DESCRIPTION
With the proliferation of historical models, the UI is getting a
little busy, so we want to filter out models that don't have any
predictions in the displayed data.