### PR TITLE
Reinstall python dependencies plugin to fix running offline

### DIFF
--- a/tipping/handler.py
+++ b/tipping/handler.py
@@ -27,10 +27,7 @@ rollbar.init(rollbar_token, settings.ENVIRONMENT)
 def rollbar_ignore_handler(payload):
     """Filter out certain errors rom Rollbar logs."""
     error_class_name = (
-        payload.get("data", {})
-        .get("body", {})
-        .get("exception", {})
-        .get("class", {}, "")
+        payload.get("data").get("body", {}).get("exception", {}).get("class", "")
     )
 
     # We ignore ServerErrorResponse, because that error will be recorded in Rollbar

--- a/tipping/package-lock.json
+++ b/tipping/package-lock.json
@@ -14,15 +14,6 @@
                 "es5-ext": "^0.10.47"
             }
         },
-        "@babel/runtime-corejs3": {
-            "version": "7.10.4",
-            "resolved": "https://registry.npmjs.org/@babel/runtime-corejs3/-/runtime-corejs3-7.10.4.tgz",
-            "integrity": "sha512-BFlgP2SoLO9HJX9WBwN67gHWMBhDX/eDz64Jajd6mR/UAUzqrNMm99d4qHnVaKscAElZoFiPv+JpR/Siud5lXw==",
-            "requires": {
-                "core-js-pure": "^3.0.0",
-                "regenerator-runtime": "^0.13.4"
-            }
-        },
         "@hapi/accept": {
             "version": "3.2.4",
             "resolved": "https://registry.npmjs.org/@hapi/accept/-/accept-3.2.4.tgz",
@@ -402,7 +393,8 @@
         "@iarna/toml": {
             "version": "2.2.5",
             "resolved": "https://registry.npmjs.org/@iarna/toml/-/toml-2.2.5.tgz",
-            "integrity": "sha512-trnsAYxU3xnS1gPHPyU961coFyLkh4gAD/0zQ5mymY4yOZ+CYvsPqUbOFSw0aDM4y0tV7tiFxL/1XfXPNC6IPg=="
+            "integrity": "sha512-trnsAYxU3xnS1gPHPyU961coFyLkh4gAD/0zQ5mymY4yOZ+CYvsPqUbOFSw0aDM4y0tV7tiFxL/1XfXPNC6IPg==",
+            "dev": true
         },
         "@kwsites/file-exists": {
             "version": "1.1.1",
@@ -1386,11 +1378,6 @@
             "integrity": "sha512-6ckxMjBBD8URvjB6J3NcnuAn5Pkl7t3TizAg+xdlzzQGSPSmBcXf8KoIH0ua/i+tio+ZRUHEXp0HEmvaR4kt0w==",
             "dev": true
         },
-        "@types/color-name": {
-            "version": "1.1.1",
-            "resolved": "https://registry.npmjs.org/@types/color-name/-/color-name-1.1.1.tgz",
-            "integrity": "sha512-rr+OQyAjxze7GgWrSaJwydHStIhHq2lvY3BOC2Mj7KnzI7XK0Uw1TOOdI9lDoajEbSWLiYgoo4f1R51erQfhPQ=="
-        },
         "@types/http-cache-semantics": {
             "version": "4.0.0",
             "resolved": "https://registry.npmjs.org/@types/http-cache-semantics/-/http-cache-semantics-4.0.0.tgz",
@@ -1593,7 +1580,8 @@
         "appdirectory": {
             "version": "0.1.0",
             "resolved": "https://registry.npmjs.org/appdirectory/-/appdirectory-0.1.0.tgz",
-            "integrity": "sha1-62yBYyDnsqsW9e2ZfyjYIF31Y3U="
+            "integrity": "sha1-62yBYyDnsqsW9e2ZfyjYIF31Y3U=",
+            "dev": true
         },
         "aproba": {
             "version": "1.2.0",
@@ -1890,7 +1878,8 @@
         "balanced-match": {
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
-            "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c="
+            "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c=",
+            "dev": true
         },
         "base": {
             "version": "0.11.2",
@@ -2014,7 +2003,8 @@
         "bluebird": {
             "version": "3.7.2",
             "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.7.2.tgz",
-            "integrity": "sha512-XpNj6GDQzdfW+r2Wnn7xiSAd7TM3jzkxGXBGTtWKuSXv1xUV+azxAm8jdWZN06QTQk+2N2XB9jRDkvbmQmcRtg=="
+            "integrity": "sha512-XpNj6GDQzdfW+r2Wnn7xiSAd7TM3jzkxGXBGTtWKuSXv1xUV+azxAm8jdWZN06QTQk+2N2XB9jRDkvbmQmcRtg==",
+            "dev": true
         },
         "boxen": {
             "version": "5.0.0",
@@ -2094,6 +2084,7 @@
             "version": "1.1.11",
             "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
             "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
+            "dev": true,
             "requires": {
                 "balanced-match": "^1.0.0",
                 "concat-map": "0.0.1"
@@ -2581,6 +2572,7 @@
             "version": "6.0.0",
             "resolved": "https://registry.npmjs.org/cliui/-/cliui-6.0.0.tgz",
             "integrity": "sha512-t6wbgtoCXvAzst7QgXxJYqPt0usEfbgQdftEPbLL/cvv6HPE5VgvqCuAIDR0NgU52ds6rFwqrgakNLrHEjCbrQ==",
+            "dev": true,
             "requires": {
                 "string-width": "^4.2.0",
                 "strip-ansi": "^6.0.0",
@@ -2590,32 +2582,14 @@
                 "ansi-regex": {
                     "version": "5.0.0",
                     "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.0.tgz",
-                    "integrity": "sha512-bY6fj56OUQ0hU1KjFNDQuJFezqKdrAyFdIevADiqrWHwSlbmBNMHp5ak2f40Pm8JTFyM2mqxkG6ngkHO11f/lg=="
-                },
-                "emoji-regex": {
-                    "version": "8.0.0",
-                    "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
-                    "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A=="
-                },
-                "is-fullwidth-code-point": {
-                    "version": "3.0.0",
-                    "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
-                    "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg=="
-                },
-                "string-width": {
-                    "version": "4.2.0",
-                    "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.0.tgz",
-                    "integrity": "sha512-zUz5JD+tgqtuDjMhwIg5uFVV3dtqZ9yQJlZVfq4I01/K5Paj5UHj7VyrQOJvzawSVlKpObApbfD0Ed6yJc+1eg==",
-                    "requires": {
-                        "emoji-regex": "^8.0.0",
-                        "is-fullwidth-code-point": "^3.0.0",
-                        "strip-ansi": "^6.0.0"
-                    }
+                    "integrity": "sha512-bY6fj56OUQ0hU1KjFNDQuJFezqKdrAyFdIevADiqrWHwSlbmBNMHp5ak2f40Pm8JTFyM2mqxkG6ngkHO11f/lg==",
+                    "dev": true
                 },
                 "strip-ansi": {
                     "version": "6.0.0",
                     "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.0.tgz",
                     "integrity": "sha512-AuvKTrTfQNYNIctbR1K/YGTR1756GycPsg7b9bdV9Duqur4gv6aKqHXah67Z8ImS7WEz5QVcOtlfW2rZEugt6w==",
+                    "dev": true,
                     "requires": {
                         "ansi-regex": "^5.0.0"
                     }
@@ -2759,7 +2733,8 @@
         "concat-map": {
             "version": "0.0.1",
             "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
-            "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s="
+            "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
+            "dev": true
         },
         "configstore": {
             "version": "5.0.1",
@@ -2834,15 +2809,11 @@
             "integrity": "sha1-Z29us8OZl8LuGsOpJP1hJHSPV40=",
             "dev": true
         },
-        "core-js-pure": {
-            "version": "3.6.5",
-            "resolved": "https://registry.npmjs.org/core-js-pure/-/core-js-pure-3.6.5.tgz",
-            "integrity": "sha512-lacdXOimsiD0QyNf9BC/mxivNJ/ybBGJXQFKzRekp1WTHoVUWsUHEn+2T8GJAzzIhyOuXA+gOxCVN3l+5PLPUA=="
-        },
         "core-util-is": {
             "version": "1.0.2",
             "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
-            "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac="
+            "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac=",
+            "dev": true
         },
         "crc-32": {
             "version": "1.2.0",
@@ -2969,7 +2940,8 @@
         "decamelize": {
             "version": "1.2.0",
             "resolved": "https://registry.npmjs.org/decamelize/-/decamelize-1.2.0.tgz",
-            "integrity": "sha1-9lNNFRSCabIDUue+4m9QH5oZEpA="
+            "integrity": "sha1-9lNNFRSCabIDUue+4m9QH5oZEpA=",
+            "dev": true
         },
         "decode-uri-component": {
             "version": "0.2.0",
@@ -4198,6 +4170,7 @@
             "version": "4.1.0",
             "resolved": "https://registry.npmjs.org/find-up/-/find-up-4.1.0.tgz",
             "integrity": "sha512-PpOwAdQ/YlXQ2vj8a3h8IipDuYRi3wceVQQGYWxNINccq40Anw7BlsEXCMbt1Zt+OLA6Fq9suIpIWD0OsnISlw==",
+            "dev": true,
             "requires": {
                 "locate-path": "^5.0.0",
                 "path-exists": "^4.0.0"
@@ -4321,7 +4294,8 @@
         "fs.realpath": {
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
-            "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8="
+            "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8=",
+            "dev": true
         },
         "fs2": {
             "version": "0.3.9",
@@ -4412,7 +4386,8 @@
         "get-caller-file": {
             "version": "2.0.5",
             "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-2.0.5.tgz",
-            "integrity": "sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg=="
+            "integrity": "sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==",
+            "dev": true
         },
         "get-intrinsic": {
             "version": "1.1.1",
@@ -4466,6 +4441,7 @@
             "version": "7.1.6",
             "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.6.tgz",
             "integrity": "sha512-LwaxwyZ72Lk7vZINtNNrywX0ZuLyStrdDtabefZKAY5ZGJhVtgdznluResxNmPitE0SAO+O26sWTHeKSI2wMBA==",
+            "dev": true,
             "requires": {
                 "fs.realpath": "^1.0.0",
                 "inflight": "^1.0.4",
@@ -4479,6 +4455,7 @@
             "version": "3.2.1",
             "resolved": "https://registry.npmjs.org/glob-all/-/glob-all-3.2.1.tgz",
             "integrity": "sha512-x877rVkzB3ipid577QOp+eQCR6M5ZyiwrtaYgrX/z3EThaSPFtLDwBXFHc3sH1cG0R0vFYI5SRYeWMMSEyXkUw==",
+            "dev": true,
             "requires": {
                 "glob": "^7.1.2",
                 "yargs": "^15.3.1"
@@ -4745,7 +4722,8 @@
         "graceful-fs": {
             "version": "4.2.4",
             "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.4.tgz",
-            "integrity": "sha512-WjKPNJF79dtJAVniUlGGWHYGz2jWxT6VhN/4m1NdkbZ2nOsEF+cI1Edgql5zCRhs/VsQYRvrXctxktVXZUkixw=="
+            "integrity": "sha512-WjKPNJF79dtJAVniUlGGWHYGz2jWxT6VhN/4m1NdkbZ2nOsEF+cI1Edgql5zCRhs/VsQYRvrXctxktVXZUkixw==",
+            "dev": true
         },
         "graphlib": {
             "version": "2.1.8",
@@ -5175,7 +5153,8 @@
         "immediate": {
             "version": "3.0.6",
             "resolved": "https://registry.npmjs.org/immediate/-/immediate-3.0.6.tgz",
-            "integrity": "sha1-nbHb0Pr43m++D13V5Wu2BigN5ps="
+            "integrity": "sha1-nbHb0Pr43m++D13V5Wu2BigN5ps=",
+            "dev": true
         },
         "import-lazy": {
             "version": "2.1.0",
@@ -5205,6 +5184,7 @@
             "version": "1.0.6",
             "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
             "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
+            "dev": true,
             "requires": {
                 "once": "^1.3.0",
                 "wrappy": "1"
@@ -5213,7 +5193,8 @@
         "inherits": {
             "version": "2.0.4",
             "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
-            "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ=="
+            "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
+            "dev": true
         },
         "ini": {
             "version": "1.3.8",
@@ -5573,6 +5554,7 @@
             "version": "2.2.0",
             "resolved": "https://registry.npmjs.org/is-wsl/-/is-wsl-2.2.0.tgz",
             "integrity": "sha512-fKzAra0rGJUUBwGBgNkHZuToZcn+TtXHpeCgmkMJMMYx1sQDYaCSyjJBSCa2nH1DGm7s3n1oBnohoVTBaN7Lww==",
+            "dev": true,
             "requires": {
                 "is-docker": "^2.0.0"
             },
@@ -5580,7 +5562,8 @@
                 "is-docker": {
                     "version": "2.0.0",
                     "resolved": "https://registry.npmjs.org/is-docker/-/is-docker-2.0.0.tgz",
-                    "integrity": "sha512-pJEdRugimx4fBMra5z2/5iRdZ63OhYV0vr0Dwm5+xtW4D1FvRkB8hamMIhnWfyJeDdyr/aa7BDyNbtG38VxgoQ=="
+                    "integrity": "sha512-pJEdRugimx4fBMra5z2/5iRdZ63OhYV0vr0Dwm5+xtW4D1FvRkB8hamMIhnWfyJeDdyr/aa7BDyNbtG38VxgoQ==",
+                    "dev": true
                 }
             }
         },
@@ -5739,6 +5722,7 @@
             "version": "4.0.0",
             "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-4.0.0.tgz",
             "integrity": "sha1-h3Gq4HmbZAdrdmQPygWPnBDjPss=",
+            "dev": true,
             "requires": {
                 "graceful-fs": "^4.1.6"
             }
@@ -5803,6 +5787,7 @@
             "version": "3.5.0",
             "resolved": "https://registry.npmjs.org/jszip/-/jszip-3.5.0.tgz",
             "integrity": "sha512-WRtu7TPCmYePR1nazfrtuF216cIVon/3GWOvHS9QR5bIwSbnxtdpma6un3jyGGNhHsKCSzn5Ypk+EkDRvTGiFA==",
+            "dev": true,
             "requires": {
                 "lie": "~3.3.0",
                 "pako": "~1.0.2",
@@ -5813,12 +5798,14 @@
                 "isarray": {
                     "version": "1.0.0",
                     "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
-                    "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE="
+                    "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
+                    "dev": true
                 },
                 "readable-stream": {
                     "version": "2.3.7",
                     "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.7.tgz",
                     "integrity": "sha512-Ebho8K4jIbHAxnuxi7o42OrZgF/ZTNcsZj6nRKyUmkhLFq8CHItp/fy6hQZuZmP/n3yZ9VBUbp4zz/mX8hmYPw==",
+                    "dev": true,
                     "requires": {
                         "core-util-is": "~1.0.0",
                         "inherits": "~2.0.3",
@@ -5832,12 +5819,14 @@
                 "safe-buffer": {
                     "version": "5.1.2",
                     "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
-                    "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g=="
+                    "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
+                    "dev": true
                 },
                 "string_decoder": {
                     "version": "1.1.1",
                     "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
                     "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
+                    "dev": true,
                     "requires": {
                         "safe-buffer": "~5.1.0"
                     }
@@ -6028,6 +6017,7 @@
             "version": "3.3.0",
             "resolved": "https://registry.npmjs.org/lie/-/lie-3.3.0.tgz",
             "integrity": "sha512-UaiMJzeWRlEujzAuw5LokY1L5ecNQYZKfmyZ9L7wDHb/p5etKaxXhohBcrw0EYby+G/NA52vRSN4N39dxHAIwQ==",
+            "dev": true,
             "requires": {
                 "immediate": "~3.0.5"
             }
@@ -6036,6 +6026,7 @@
             "version": "5.0.0",
             "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-5.0.0.tgz",
             "integrity": "sha512-t7hw9pI+WvuwNJXwk5zVHpyhIqzg2qTlklJOf0mVxGSbe3Fp2VieZcduNYjaLDoy6p9uGpQEGWG87WpMKlNq8g==",
+            "dev": true,
             "requires": {
                 "p-locate": "^4.1.0"
             }
@@ -6073,7 +6064,8 @@
         "lodash.get": {
             "version": "4.4.2",
             "resolved": "https://registry.npmjs.org/lodash.get/-/lodash.get-4.4.2.tgz",
-            "integrity": "sha1-LRd/ZS+jHpObRDjVNBSZ36OCXpk="
+            "integrity": "sha1-LRd/ZS+jHpObRDjVNBSZ36OCXpk=",
+            "dev": true
         },
         "lodash.includes": {
             "version": "4.3.0",
@@ -6120,7 +6112,8 @@
         "lodash.set": {
             "version": "4.3.2",
             "resolved": "https://registry.npmjs.org/lodash.set/-/lodash.set-4.3.2.tgz",
-            "integrity": "sha1-2HV7HagH3eJIFrDWqEvqGnYjCyM="
+            "integrity": "sha1-2HV7HagH3eJIFrDWqEvqGnYjCyM=",
+            "dev": true
         },
         "lodash.template": {
             "version": "4.5.0",
@@ -6150,12 +6143,14 @@
         "lodash.uniqby": {
             "version": "4.7.0",
             "resolved": "https://registry.npmjs.org/lodash.uniqby/-/lodash.uniqby-4.7.0.tgz",
-            "integrity": "sha1-2ZwHpmnp5tJOE2Lf4mbGdhavEwI="
+            "integrity": "sha1-2ZwHpmnp5tJOE2Lf4mbGdhavEwI=",
+            "dev": true
         },
         "lodash.values": {
             "version": "4.3.0",
             "resolved": "https://registry.npmjs.org/lodash.values/-/lodash.values-4.3.0.tgz",
-            "integrity": "sha1-o6bCsOvsxcLLocF+bmIP6BtT00c="
+            "integrity": "sha1-o6bCsOvsxcLLocF+bmIP6BtT00c=",
+            "dev": true
         },
         "log": {
             "version": "6.0.0",
@@ -6382,6 +6377,7 @@
             "version": "3.0.4",
             "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
             "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
+            "dev": true,
             "requires": {
                 "brace-expansion": "^1.1.7"
             }
@@ -6796,6 +6792,7 @@
             "version": "1.4.0",
             "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
             "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
+            "dev": true,
             "requires": {
                 "wrappy": "1"
             }
@@ -6895,6 +6892,7 @@
             "version": "2.3.0",
             "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.3.0.tgz",
             "integrity": "sha512-//88mFWSJx8lxCzwdAABTJL2MyWB12+eIY7MDL2SqLmAkeKU9qxRvWuSyTjm3FUmpBEMuFfckAIqEaVGUDxb6w==",
+            "dev": true,
             "requires": {
                 "p-try": "^2.0.0"
             }
@@ -6903,6 +6901,7 @@
             "version": "4.1.0",
             "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-4.1.0.tgz",
             "integrity": "sha512-R79ZZ/0wAxKGu3oYMlz8jy/kbhsNrS7SKZ7PxEHBgJ5+F2mtFW2fK2cOtBh1cHYkQsbzFV7I+EoRKe6Yt0oK7A==",
+            "dev": true,
             "requires": {
                 "p-limit": "^2.2.0"
             }
@@ -6968,7 +6967,8 @@
         "p-try": {
             "version": "2.2.0",
             "resolved": "https://registry.npmjs.org/p-try/-/p-try-2.2.0.tgz",
-            "integrity": "sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ=="
+            "integrity": "sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ==",
+            "dev": true
         },
         "package-json": {
             "version": "6.5.0",
@@ -6985,7 +6985,8 @@
         "pako": {
             "version": "1.0.11",
             "resolved": "https://registry.npmjs.org/pako/-/pako-1.0.11.tgz",
-            "integrity": "sha512-4hLB8Py4zZce5s4yd9XzopqwVv/yGNhV1Bl8NTmCq1763HeK2+EwVTv+leGeL13Dnh2wfbqowVPXCIO0z4taYw=="
+            "integrity": "sha512-4hLB8Py4zZce5s4yd9XzopqwVv/yGNhV1Bl8NTmCq1763HeK2+EwVTv+leGeL13Dnh2wfbqowVPXCIO0z4taYw==",
+            "dev": true
         },
         "parseqs": {
             "version": "0.0.6",
@@ -7032,12 +7033,14 @@
         "path-exists": {
             "version": "4.0.0",
             "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
-            "integrity": "sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w=="
+            "integrity": "sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==",
+            "dev": true
         },
         "path-is-absolute": {
             "version": "1.0.1",
             "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
-            "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18="
+            "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18=",
+            "dev": true
         },
         "path-key": {
             "version": "2.0.1",
@@ -7213,7 +7216,8 @@
         "process-nextick-args": {
             "version": "2.0.1",
             "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.1.tgz",
-            "integrity": "sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag=="
+            "integrity": "sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag==",
+            "dev": true
         },
         "promise-queue": {
             "version": "2.2.5",
@@ -7384,11 +7388,6 @@
                 "esprima": "~4.0.0"
             }
         },
-        "regenerator-runtime": {
-            "version": "0.13.5",
-            "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.5.tgz",
-            "integrity": "sha512-ZS5w8CpKFinUzOwW3c83oPeVXoNsrLsaCoLtJvAClH135j/R77RuymhiSErhm2lKcwSCIpmvIWSbDkIfAqKQlA=="
-        },
         "regex-not": {
             "version": "1.0.2",
             "resolved": "https://registry.npmjs.org/regex-not/-/regex-not-1.0.2.tgz",
@@ -7517,12 +7516,14 @@
         "require-directory": {
             "version": "2.1.1",
             "resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
-            "integrity": "sha1-jGStX9MNqxyXbiNE/+f3kqam30I="
+            "integrity": "sha1-jGStX9MNqxyXbiNE/+f3kqam30I=",
+            "dev": true
         },
         "require-main-filename": {
             "version": "2.0.0",
             "resolved": "https://registry.npmjs.org/require-main-filename/-/require-main-filename-2.0.0.tgz",
-            "integrity": "sha512-NKN5kMDylKuldxYLSUfrbo5Tuzh4hd+2E8NPPX02mZtn1VuREQToYe/ZdlJy+J3uCpfaiGF05e7B8W0iXbQHmg=="
+            "integrity": "sha512-NKN5kMDylKuldxYLSUfrbo5Tuzh4hd+2E8NPPX02mZtn1VuREQToYe/ZdlJy+J3uCpfaiGF05e7B8W0iXbQHmg==",
+            "dev": true
         },
         "resolve-alpn": {
             "version": "1.0.0",
@@ -7577,6 +7578,7 @@
             "version": "3.0.2",
             "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-3.0.2.tgz",
             "integrity": "sha512-JZkJMZkAGFFPP2YqXZXPbMlMBgsxzE8ILs4lMIX/2o0L9UBw9O/Y3o6wFw/i9YLapcUJWwqbi3kdxIPdC62TIA==",
+            "dev": true,
             "requires": {
                 "glob": "^7.1.3"
             }
@@ -8155,47 +8157,101 @@
             }
         },
         "serverless-python-requirements": {
-            "version": "5.1.0",
-            "resolved": "https://registry.npmjs.org/serverless-python-requirements/-/serverless-python-requirements-5.1.0.tgz",
-            "integrity": "sha512-lJhikc6wJsOYFxYNGK763xtQITrtGPHD2KJvs8qaBkkOET4RVk8E0N3d8wAO22k+Tk7N6a6Jonnvsmo3W8vtCA==",
+            "version": "5.1.1",
+            "resolved": "https://registry.npmjs.org/serverless-python-requirements/-/serverless-python-requirements-5.1.1.tgz",
+            "integrity": "sha512-frqZhQcqf3kLMpkS1U8VUqiRnbDG4C81eQndlZ150gSFkAqCc521LemedtWEWGrBQQoWSTo4LivugLiQU7s/Sg==",
+            "dev": true,
             "requires": {
-                "@iarna/toml": "^2.2.3",
+                "@iarna/toml": "^2.2.5",
                 "appdirectory": "^0.1.0",
-                "bluebird": "^3.0.6",
-                "fs-extra": "^7.0.0",
-                "glob-all": "^3.1.0",
-                "is-wsl": "^2.0.0",
-                "jszip": "^3.1.0",
+                "bluebird": "^3.7.2",
+                "fs-extra": "^9.1.0",
+                "glob-all": "^3.2.1",
+                "is-wsl": "^2.2.0",
+                "jszip": "^3.6.0",
                 "lodash.get": "^4.4.2",
                 "lodash.set": "^4.3.2",
-                "lodash.uniqby": "^4.0.0",
+                "lodash.uniqby": "^4.7.0",
                 "lodash.values": "^4.3.0",
                 "rimraf": "^3.0.2",
                 "sha256-file": "1.0.0",
-                "shell-quote": "^1.6.1"
+                "shell-quote": "^1.7.2"
             },
             "dependencies": {
                 "fs-extra": {
-                    "version": "7.0.1",
-                    "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-7.0.1.tgz",
-                    "integrity": "sha512-YJDaCJZEnBmcbw13fvdAM9AwNOJwOzrE4pqMqBq5nFiEqXUqHwlK4B+3pUw6JNvfSPtX05xFHtYy/1ni01eGCw==",
+                    "version": "9.1.0",
+                    "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-9.1.0.tgz",
+                    "integrity": "sha512-hcg3ZmepS30/7BSFqRvoo3DOMQu7IjqxO5nCDt+zM9XWjb33Wg7ziNT+Qvqbuc3+gWpzO02JubVyk2G4Zvo1OQ==",
+                    "dev": true,
                     "requires": {
-                        "graceful-fs": "^4.1.2",
-                        "jsonfile": "^4.0.0",
-                        "universalify": "^0.1.0"
+                        "at-least-node": "^1.0.0",
+                        "graceful-fs": "^4.2.0",
+                        "jsonfile": "^6.0.1",
+                        "universalify": "^2.0.0"
                     }
+                },
+                "jsonfile": {
+                    "version": "6.1.0",
+                    "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-6.1.0.tgz",
+                    "integrity": "sha512-5dgndWOriYSm5cnYaJNhalLNDKOqFwyDB/rr1E9ZsGciGvKPs8R2xYGCacuf3z6K1YKDz182fd+fY3cn3pMqXQ==",
+                    "dev": true,
+                    "requires": {
+                        "graceful-fs": "^4.1.6",
+                        "universalify": "^2.0.0"
+                    }
+                },
+                "jszip": {
+                    "version": "3.6.0",
+                    "resolved": "https://registry.npmjs.org/jszip/-/jszip-3.6.0.tgz",
+                    "integrity": "sha512-jgnQoG9LKnWO3mnVNBnfhkh0QknICd1FGSrXcgrl67zioyJ4wgx25o9ZqwNtrROSflGBCGYnJfjrIyRIby1OoQ==",
+                    "dev": true,
+                    "requires": {
+                        "lie": "~3.3.0",
+                        "pako": "~1.0.2",
+                        "readable-stream": "~2.3.6",
+                        "set-immediate-shim": "~1.0.1"
+                    }
+                },
+                "readable-stream": {
+                    "version": "2.3.7",
+                    "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.7.tgz",
+                    "integrity": "sha512-Ebho8K4jIbHAxnuxi7o42OrZgF/ZTNcsZj6nRKyUmkhLFq8CHItp/fy6hQZuZmP/n3yZ9VBUbp4zz/mX8hmYPw==",
+                    "dev": true,
+                    "requires": {
+                        "core-util-is": "~1.0.0",
+                        "inherits": "~2.0.3",
+                        "isarray": "~1.0.0",
+                        "process-nextick-args": "~2.0.0",
+                        "safe-buffer": "~5.1.1",
+                        "string_decoder": "~1.1.1",
+                        "util-deprecate": "~1.0.1"
+                    }
+                },
+                "safe-buffer": {
+                    "version": "5.1.2",
+                    "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+                    "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
+                    "dev": true
+                },
+                "universalify": {
+                    "version": "2.0.0",
+                    "resolved": "https://registry.npmjs.org/universalify/-/universalify-2.0.0.tgz",
+                    "integrity": "sha512-hAZsKq7Yy11Zu1DE0OzWjw7nnLZmJZYTDZZyEFHZdUhV8FkH5MCfoU1XMaxXovpyW5nq5scPqq0ZDP9Zyl04oQ==",
+                    "dev": true
                 }
             }
         },
         "set-blocking": {
             "version": "2.0.0",
             "resolved": "https://registry.npmjs.org/set-blocking/-/set-blocking-2.0.0.tgz",
-            "integrity": "sha1-BF+XgtARrppoA93TgrJDkrPYkPc="
+            "integrity": "sha1-BF+XgtARrppoA93TgrJDkrPYkPc=",
+            "dev": true
         },
         "set-immediate-shim": {
             "version": "1.0.1",
             "resolved": "https://registry.npmjs.org/set-immediate-shim/-/set-immediate-shim-1.0.1.tgz",
-            "integrity": "sha1-SysbJ+uAip+NzEgaWOXlb1mfP2E="
+            "integrity": "sha1-SysbJ+uAip+NzEgaWOXlb1mfP2E=",
+            "dev": true
         },
         "set-value": {
             "version": "2.0.1",
@@ -8223,7 +8279,8 @@
         "sha256-file": {
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/sha256-file/-/sha256-file-1.0.0.tgz",
-            "integrity": "sha512-nqf+g0veqgQAkDx0U2y2Tn2KWyADuuludZTw9A7J3D+61rKlIIl9V5TS4mfnwKuXZOH9B7fQyjYJ9pKRHIsAyg=="
+            "integrity": "sha512-nqf+g0veqgQAkDx0U2y2Tn2KWyADuuludZTw9A7J3D+61rKlIIl9V5TS4mfnwKuXZOH9B7fQyjYJ9pKRHIsAyg==",
+            "dev": true
         },
         "shebang-command": {
             "version": "1.2.0",
@@ -8243,7 +8300,8 @@
         "shell-quote": {
             "version": "1.7.2",
             "resolved": "https://registry.npmjs.org/shell-quote/-/shell-quote-1.7.2.tgz",
-            "integrity": "sha512-mRz/m/JVscCrkMyPqHc/bczi3OQHkLTqXHEFu0zDhK/qfv3UcOA4SVmRCLmos4bhjr9ekVQubj/R7waKapmiQg=="
+            "integrity": "sha512-mRz/m/JVscCrkMyPqHc/bczi3OQHkLTqXHEFu0zDhK/qfv3UcOA4SVmRCLmos4bhjr9ekVQubj/R7waKapmiQg==",
+            "dev": true
         },
         "shortid": {
             "version": "2.2.16",
@@ -8522,7 +8580,8 @@
             "version": "0.6.1",
             "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
             "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
-            "dev": true
+            "dev": true,
+            "optional": true
         },
         "source-map-resolve": {
             "version": "0.5.3",
@@ -9351,7 +9410,8 @@
         "universalify": {
             "version": "0.1.2",
             "resolved": "https://registry.npmjs.org/universalify/-/universalify-0.1.2.tgz",
-            "integrity": "sha512-rBJeI5CXAlmy1pV+617WB9J63U6XcazHHF2f2dbJix4XzpUF0RS3Zbj0FGIOCAva5P/d/GBOYaACQ1w+0azUkg=="
+            "integrity": "sha512-rBJeI5CXAlmy1pV+617WB9J63U6XcazHHF2f2dbJix4XzpUF0RS3Zbj0FGIOCAva5P/d/GBOYaACQ1w+0azUkg==",
+            "dev": true
         },
         "unset-value": {
             "version": "1.0.0",
@@ -9498,7 +9558,8 @@
         "util-deprecate": {
             "version": "1.0.2",
             "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
-            "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8="
+            "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8=",
+            "dev": true
         },
         "uuid": {
             "version": "8.3.2",
@@ -9548,7 +9609,8 @@
         "which-module": {
             "version": "2.0.0",
             "resolved": "https://registry.npmjs.org/which-module/-/which-module-2.0.0.tgz",
-            "integrity": "sha1-2e8H3Od7mQK4o6j6SzHD4/fm6Ho="
+            "integrity": "sha1-2e8H3Od7mQK4o6j6SzHD4/fm6Ho=",
+            "dev": true
         },
         "which-pm-runs": {
             "version": "1.0.0",
@@ -9666,6 +9728,7 @@
             "version": "6.2.0",
             "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-6.2.0.tgz",
             "integrity": "sha512-r6lPcBGxZXlIcymEu7InxDMhdW0KDxpLgoFLcguasxCaJ/SOIZwINatK9KY/tf+ZrlywOKU0UDj3ATXUBfxJXA==",
+            "dev": true,
             "requires": {
                 "ansi-styles": "^4.0.0",
                 "string-width": "^4.1.0",
@@ -9675,14 +9738,15 @@
                 "ansi-regex": {
                     "version": "5.0.0",
                     "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.0.tgz",
-                    "integrity": "sha512-bY6fj56OUQ0hU1KjFNDQuJFezqKdrAyFdIevADiqrWHwSlbmBNMHp5ak2f40Pm8JTFyM2mqxkG6ngkHO11f/lg=="
+                    "integrity": "sha512-bY6fj56OUQ0hU1KjFNDQuJFezqKdrAyFdIevADiqrWHwSlbmBNMHp5ak2f40Pm8JTFyM2mqxkG6ngkHO11f/lg==",
+                    "dev": true
                 },
                 "ansi-styles": {
-                    "version": "4.2.1",
-                    "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.2.1.tgz",
-                    "integrity": "sha512-9VGjrMsG1vePxcSweQsN20KY/c4zN0h9fLjqAbwbPfahM3t+NL+M9HC8xeXG2I8pX5NoamTGNuomEUFI7fcUjA==",
+                    "version": "4.3.0",
+                    "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+                    "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+                    "dev": true,
                     "requires": {
-                        "@types/color-name": "^1.1.1",
                         "color-convert": "^2.0.1"
                     }
                 },
@@ -9690,6 +9754,7 @@
                     "version": "2.0.1",
                     "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
                     "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+                    "dev": true,
                     "requires": {
                         "color-name": "~1.1.4"
                     }
@@ -9697,32 +9762,14 @@
                 "color-name": {
                     "version": "1.1.4",
                     "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
-                    "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA=="
-                },
-                "emoji-regex": {
-                    "version": "8.0.0",
-                    "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
-                    "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A=="
-                },
-                "is-fullwidth-code-point": {
-                    "version": "3.0.0",
-                    "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
-                    "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg=="
-                },
-                "string-width": {
-                    "version": "4.2.0",
-                    "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.0.tgz",
-                    "integrity": "sha512-zUz5JD+tgqtuDjMhwIg5uFVV3dtqZ9yQJlZVfq4I01/K5Paj5UHj7VyrQOJvzawSVlKpObApbfD0Ed6yJc+1eg==",
-                    "requires": {
-                        "emoji-regex": "^8.0.0",
-                        "is-fullwidth-code-point": "^3.0.0",
-                        "strip-ansi": "^6.0.0"
-                    }
+                    "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+                    "dev": true
                 },
                 "strip-ansi": {
                     "version": "6.0.0",
                     "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.0.tgz",
                     "integrity": "sha512-AuvKTrTfQNYNIctbR1K/YGTR1756GycPsg7b9bdV9Duqur4gv6aKqHXah67Z8ImS7WEz5QVcOtlfW2rZEugt6w==",
+                    "dev": true,
                     "requires": {
                         "ansi-regex": "^5.0.0"
                     }
@@ -9732,7 +9779,8 @@
         "wrappy": {
             "version": "1.0.2",
             "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
-            "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8="
+            "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
+            "dev": true
         },
         "write-file-atomic": {
             "version": "2.4.3",
@@ -9779,14 +9827,6 @@
             "integrity": "sha1-wodrBhaKrcQOV9l+gRkayPQ5iz4=",
             "dev": true
         },
-        "xregexp": {
-            "version": "4.3.0",
-            "resolved": "https://registry.npmjs.org/xregexp/-/xregexp-4.3.0.tgz",
-            "integrity": "sha512-7jXDIFXh5yJ/orPn4SXjuVrWWoi4Cr8jfV1eHv9CixKSbU+jY4mxfrBwAuDvupPNKpMUY+FeIqsVw/JLT9+B8g==",
-            "requires": {
-                "@babel/runtime-corejs3": "^7.8.3"
-            }
-        },
         "xtend": {
             "version": "4.0.2",
             "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.2.tgz",
@@ -9796,7 +9836,8 @@
         "y18n": {
             "version": "4.0.1",
             "resolved": "https://registry.npmjs.org/y18n/-/y18n-4.0.1.tgz",
-            "integrity": "sha512-wNcy4NvjMYL8gogWWYAO7ZFWFfHcbdbE57tZO8e4cbpj8tfUcwrwqSl3ad8HxpYWCdXcJUCeKKZS62Av1affwQ=="
+            "integrity": "sha512-wNcy4NvjMYL8gogWWYAO7ZFWFfHcbdbE57tZO8e4cbpj8tfUcwrwqSl3ad8HxpYWCdXcJUCeKKZS62Av1affwQ==",
+            "dev": true
         },
         "yallist": {
             "version": "4.0.0",
@@ -9821,12 +9862,13 @@
             }
         },
         "yargs": {
-            "version": "15.4.0",
-            "resolved": "https://registry.npmjs.org/yargs/-/yargs-15.4.0.tgz",
-            "integrity": "sha512-D3fRFnZwLWp8jVAAhPZBsmeIHY8tTsb8ItV9KaAaopmC6wde2u6Yw29JBIZHXw14kgkRnYmDgmQU4FVMDlIsWw==",
+            "version": "15.4.1",
+            "resolved": "https://registry.npmjs.org/yargs/-/yargs-15.4.1.tgz",
+            "integrity": "sha512-aePbxDmcYW++PaqBsJ+HYUFwCdv4LVvdnhBy78E57PIor8/OVvhMrADFFEDh8DHDFRv/O9i3lPhsENjO7QX0+A==",
+            "dev": true,
             "requires": {
                 "cliui": "^6.0.0",
-                "decamelize": "^3.2.0",
+                "decamelize": "^1.2.0",
                 "find-up": "^4.1.0",
                 "get-caller-file": "^2.0.1",
                 "require-directory": "^2.1.1",
@@ -9836,55 +9878,13 @@
                 "which-module": "^2.0.0",
                 "y18n": "^4.0.0",
                 "yargs-parser": "^18.1.2"
-            },
-            "dependencies": {
-                "ansi-regex": {
-                    "version": "5.0.0",
-                    "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.0.tgz",
-                    "integrity": "sha512-bY6fj56OUQ0hU1KjFNDQuJFezqKdrAyFdIevADiqrWHwSlbmBNMHp5ak2f40Pm8JTFyM2mqxkG6ngkHO11f/lg=="
-                },
-                "decamelize": {
-                    "version": "3.2.0",
-                    "resolved": "https://registry.npmjs.org/decamelize/-/decamelize-3.2.0.tgz",
-                    "integrity": "sha512-4TgkVUsmmu7oCSyGBm5FvfMoACuoh9EOidm7V5/J2X2djAwwt57qb3F2KMP2ITqODTCSwb+YRV+0Zqrv18k/hw==",
-                    "requires": {
-                        "xregexp": "^4.2.4"
-                    }
-                },
-                "emoji-regex": {
-                    "version": "8.0.0",
-                    "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
-                    "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A=="
-                },
-                "is-fullwidth-code-point": {
-                    "version": "3.0.0",
-                    "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
-                    "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg=="
-                },
-                "string-width": {
-                    "version": "4.2.0",
-                    "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.0.tgz",
-                    "integrity": "sha512-zUz5JD+tgqtuDjMhwIg5uFVV3dtqZ9yQJlZVfq4I01/K5Paj5UHj7VyrQOJvzawSVlKpObApbfD0Ed6yJc+1eg==",
-                    "requires": {
-                        "emoji-regex": "^8.0.0",
-                        "is-fullwidth-code-point": "^3.0.0",
-                        "strip-ansi": "^6.0.0"
-                    }
-                },
-                "strip-ansi": {
-                    "version": "6.0.0",
-                    "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.0.tgz",
-                    "integrity": "sha512-AuvKTrTfQNYNIctbR1K/YGTR1756GycPsg7b9bdV9Duqur4gv6aKqHXah67Z8ImS7WEz5QVcOtlfW2rZEugt6w==",
-                    "requires": {
-                        "ansi-regex": "^5.0.0"
-                    }
-                }
             }
         },
         "yargs-parser": {
             "version": "18.1.3",
             "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-18.1.3.tgz",
             "integrity": "sha512-o50j0JeToy/4K6OZcaQmW6lyXXKhq7csREXcDwk2omFPJEwUNOVtJKvmDr9EI1fAJZUyZcRF7kxGBWmRXudrCQ==",
+            "dev": true,
             "requires": {
                 "camelcase": "^5.0.0",
                 "decamelize": "^1.2.0"
@@ -9893,7 +9893,8 @@
                 "camelcase": {
                     "version": "5.3.1",
                     "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-5.3.1.tgz",
-                    "integrity": "sha512-L28STB170nwWS63UjtlEOE3dldQApaJXZkOI1uMFfzf3rRuPegHaHesyee+YxQ+W6SvRDQV6UrdOdRiR153wJg=="
+                    "integrity": "sha512-L28STB170nwWS63UjtlEOE3dldQApaJXZkOI1uMFfzf3rRuPegHaHesyee+YxQ+W6SvRDQV6UrdOdRiR153wJg==",
+                    "dev": true
                 }
             }
         },

--- a/tipping/package.json
+++ b/tipping/package.json
@@ -16,13 +16,12 @@
     "url": "https://github.com/tipresias/tipresias/issues"
   },
   "homepage": "https://github.com/tipresias/tipresias#readme",
-  "dependencies": {
-    "serverless-python-requirements": "^5.1.0"
-  },
+  "dependencies": {},
   "devDependencies": {
     "fauna-shell": "^0.12.3",
     "serverless": "^2.31.0",
     "serverless-offline": "^6.9.0",
-    "serverless-prune-plugin": "^1.4.4"
+    "serverless-prune-plugin": "^1.4.4",
+    "serverless-python-requirements": "^5.1.1"
   }
 }

--- a/tipping/serverless.yml
+++ b/tipping/serverless.yml
@@ -44,7 +44,6 @@ plugins:
   - serverless-offline
   - serverless-python-requirements
   - serverless-prune-plugin
-
 custom:
   pythonRequirements:
     dockerizePip: false # We run sls inside Docker already


### PR DESCRIPTION
I generally don't need to run serverless functions locally,
so I hadn't fixed this till now, but if you follow the official
instructions for installing this plugin, the tool includes it
with devDependencies instead of dependencies, and now sls offline
works.