### PR TITLE
Silence duplicate Rollbar items

### DIFF
--- a/tipping/src/tests/unit/test_data_export.py
+++ b/tipping/src/tests/unit/test_data_export.py
@@ -1,11 +1,9 @@
 # pylint: disable=missing-docstring
 
-from unittest import TestCase
-from unittest.mock import patch, MagicMock
-import json
-
 import numpy as np
 import pandas as pd
+import responses
+import pytest
 
 from tests.fixtures import data_factories
 from tipping import data_export, settings
@@ -14,133 +12,124 @@ from tipping import data_export, settings
 N_MATCHES = 5
 
 
-class TestDataExport(TestCase):
-    def setUp(self):
-        self.data_export = data_export
+@responses.activate
+@pytest.mark.parametrize(
+    "status_code,expected_error",
+    [
+        (200, None),
+        (301, data_export.DataExportError),
+        (404, data_export.DataExportError),
+        (500, data_export.ServerErrorResponse),
+    ],
+)
+def test_update_fixture_data(status_code, expected_error):
+    responses.add(
+        responses.POST,
+        f"{settings.TIPRESIAS_APP}/fixtures",
+        status=status_code,
+        json="Stuff happened",
+    )
 
-    @patch("tipping.data_export.requests")
-    def test_update_fixture_data(self, mock_requests):
-        mock_response = MagicMock()
-        mock_response.status_code = 200
-        mock_response.headers = {}
-        mock_response.text = "Stuff happened"
+    fake_fixture = data_factories.fake_fixture_data()
+    upcoming_round = np.random.randint(1, 24)
 
-        mock_requests.post = MagicMock(return_value=mock_response)
+    if expected_error is None:
+        data_export.update_fixture_data(fake_fixture, upcoming_round)
+    else:
+        with pytest.raises(expected_error, match=str(status_code)):
+            data_export.update_fixture_data(fake_fixture, upcoming_round)
 
-        url = settings.TIPRESIAS_APP + "/fixtures"
-        fake_fixture = data_factories.fake_fixture_data()
-        upcoming_round = np.random.randint(1, 24)
-        self.data_export.update_fixture_data(fake_fixture, upcoming_round)
 
-        # It posts the data
-        fixture_response = fake_fixture.astype({"date": str}).to_dict("records")
-        mock_requests.post.assert_called_with(
-            url,
-            json={"upcoming_round": upcoming_round, "data": fixture_response},
-            headers={},
-        )
+@responses.activate
+@pytest.mark.parametrize(
+    "status_code,expected_error",
+    [
+        (200, None),
+        (301, data_export.DataExportError),
+        (404, data_export.DataExportError),
+        (500, data_export.ServerErrorResponse),
+    ],
+)
+def test_update_match_predictions(status_code, expected_error):
+    response_data = [
+        {
+            "predicted_winner__name": "Some Team",
+            # Can't use 'None' for either prediction value, because it messes
+            # with pandas equality checks
+            "predicted_margin": 5.23,
+            "predicted_win_probability": 0.876,
+        }
+    ]
+    responses.add(
+        responses.POST,
+        f"{settings.TIPRESIAS_APP}/predictions",
+        status=status_code,
+        json=response_data,
+    )
 
-        with self.subTest("when the status code isn't 2xx"):
-            mock_response.status_code = 500
+    fake_predictions = pd.concat(
+        [data_factories.fake_prediction_data() for _ in range(N_MATCHES)]
+    )
 
-            with self.assertRaisesRegex(
-                data_export.ServerErrorResponse, "Bad response"
-            ):
-                self.data_export.update_fixture_data(fake_fixture, upcoming_round)
-
-    @patch("tipping.data_export.requests")
-    def test_update_match_predictions(self, mock_requests):
-        mock_response = MagicMock()
-        mock_response.status_code = 200
-        mock_response.headers = {}
-        response_data = [
-            {
-                "predicted_winner__name": "Some Team",
-                # Can't use 'None' for either prediction value, because it messes
-                # with pandas equality checks
-                "predicted_margin": 5.23,
-                "predicted_win_probability": 0.876,
-            }
-        ]
-        mock_response.text = json.dumps(response_data)
-
-        mock_requests.post = MagicMock(return_value=mock_response)
-
-        url = settings.TIPRESIAS_APP + "/predictions"
-        fake_predictions = pd.concat(
-            [data_factories.fake_prediction_data() for _ in range(N_MATCHES)]
-        )
-        prediction_records = self.data_export.update_match_predictions(fake_predictions)
-
-        # It posts the data
-        prediction_data = fake_predictions.to_dict("records")
-        mock_requests.post.assert_called_with(
-            url, json={"data": prediction_data}, headers={}
-        )
+    if expected_error is None:
+        prediction_records = data_export.update_match_predictions(fake_predictions)
 
         # It returns the created/updated predictions records
-        self.assertTrue((prediction_records == pd.DataFrame(response_data)).all().all())
+        assert (prediction_records == pd.DataFrame(response_data)).all().all()
+    else:
+        with pytest.raises(expected_error, match=str(status_code)):
+            data_export.update_match_predictions(fake_predictions)
 
-        with self.subTest("when the status code isn't 2xx"):
-            mock_response.status_code = 500
 
-            with self.assertRaisesRegex(
-                data_export.ServerErrorResponse, "Bad response"
-            ):
-                self.data_export.update_match_predictions(fake_predictions)
+@responses.activate
+@pytest.mark.parametrize(
+    "status_code,expected_error",
+    [
+        (200, None),
+        (301, data_export.DataExportError),
+        (404, data_export.DataExportError),
+        (500, data_export.ServerErrorResponse),
+    ],
+)
+def test_update_matches(status_code, expected_error):
+    responses.add(
+        responses.POST,
+        f"{settings.TIPRESIAS_APP}/matches",
+        status=status_code,
+        json="Stuff happened",
+    )
 
-    @patch("tipping.data_export.requests")
-    def test_update_matches(self, mock_requests):
-        mock_response = MagicMock()
-        mock_response.status_code = 200
-        mock_response.headers = {}
-        mock_response.text = "Stuff happened"
+    fake_matches = data_factories.fake_match_data()
 
-        mock_requests.post = MagicMock(return_value=mock_response)
+    if expected_error is None:
+        data_export.update_matches(fake_matches)
+    else:
+        with pytest.raises(expected_error, match=str(status_code)):
+            data_export.update_matches(fake_matches)
 
-        url = settings.TIPRESIAS_APP + "/matches"
-        fake_matches = data_factories.fake_match_data()
-        self.data_export.update_matches(fake_matches)
 
-        # It posts the data
-        matches_response = fake_matches.astype({"date": str}).to_dict("records")
-        mock_requests.post.assert_called_with(
-            url, json={"data": matches_response}, headers={}
-        )
+@responses.activate
+@pytest.mark.parametrize(
+    "status_code,expected_error",
+    [
+        (200, None),
+        (301, data_export.DataExportError),
+        (404, data_export.DataExportError),
+        (500, data_export.ServerErrorResponse),
+    ],
+)
+def test_update_match_results(status_code, expected_error):
+    responses.add(
+        responses.POST,
+        f"{settings.TIPRESIAS_APP}/matches",
+        status=status_code,
+        json="Stuff happened",
+    )
 
-        with self.subTest("when the status code isn't 2xx"):
-            mock_response.status_code = 500
+    fake_match_results = data_factories.fake_match_results_data()
 
-            with self.assertRaisesRegex(
-                data_export.ServerErrorResponse, "Bad response"
-            ):
-                self.data_export.update_matches(fake_matches)
-
-    @patch("tipping.data_export.requests")
-    def test_update_match_results(self, mock_requests):
-        mock_response = MagicMock()
-        mock_response.status_code = 200
-        mock_response.headers = {}
-        mock_response.text = "Stuff happened"
-
-        mock_requests.post = MagicMock(return_value=mock_response)
-
-        url = settings.TIPRESIAS_APP + "/matches"
-        fake_match_results = data_factories.fake_match_results_data()
-        self.data_export.update_match_results(fake_match_results)
-
-        # It posts the data
-        match_results_response = fake_match_results.astype({"date": str}).to_dict(
-            "records"
-        )
-        mock_requests.post.assert_called_with(
-            url, json={"data": match_results_response}, headers={}
-        )
-
-        with self.subTest("when the status code isn't 2xx"):
-            mock_response.status_code = 500
-
-            with self.assertRaisesRegex(
-                data_export.ServerErrorResponse, "Bad response"
-            ):
-                self.data_export.update_match_results(fake_match_results)
+    if expected_error is None:
+        data_export.update_match_results(fake_match_results)
+    else:
+        with pytest.raises(expected_error, match=str(status_code)):
+            data_export.update_match_results(fake_match_results)

--- a/tipping/src/tests/unit/test_data_export.py
+++ b/tipping/src/tests/unit/test_data_export.py
@@ -41,9 +41,11 @@ class TestDataExport(TestCase):
         )
 
         with self.subTest("when the status code isn't 2xx"):
-            mock_response.status_code = 400
+            mock_response.status_code = 500
 
-            with self.assertRaisesRegex(Exception, "Bad response"):
+            with self.assertRaisesRegex(
+                data_export.ServerErrorResponse, "Bad response"
+            ):
                 self.data_export.update_fixture_data(fake_fixture, upcoming_round)
 
     @patch("tipping.data_export.requests")
@@ -80,9 +82,11 @@ class TestDataExport(TestCase):
         self.assertTrue((prediction_records == pd.DataFrame(response_data)).all().all())
 
         with self.subTest("when the status code isn't 2xx"):
-            mock_response.status_code = 400
+            mock_response.status_code = 500
 
-            with self.assertRaisesRegex(Exception, "Bad response"):
+            with self.assertRaisesRegex(
+                data_export.ServerErrorResponse, "Bad response"
+            ):
                 self.data_export.update_match_predictions(fake_predictions)
 
     @patch("tipping.data_export.requests")
@@ -105,9 +109,11 @@ class TestDataExport(TestCase):
         )
 
         with self.subTest("when the status code isn't 2xx"):
-            mock_response.status_code = 400
+            mock_response.status_code = 500
 
-            with self.assertRaisesRegex(Exception, "Bad response"):
+            with self.assertRaisesRegex(
+                data_export.ServerErrorResponse, "Bad response"
+            ):
                 self.data_export.update_matches(fake_matches)
 
     @patch("tipping.data_export.requests")
@@ -132,7 +138,9 @@ class TestDataExport(TestCase):
         )
 
         with self.subTest("when the status code isn't 2xx"):
-            mock_response.status_code = 400
+            mock_response.status_code = 500
 
-            with self.assertRaisesRegex(Exception, "Bad response"):
+            with self.assertRaisesRegex(
+                data_export.ServerErrorResponse, "Bad response"
+            ):
                 self.data_export.update_match_results(fake_match_results)


### PR DESCRIPTION
When `data_export` sends an HTTP call to another service, and the receiver raises an error, we end up with two items in Rollbar, because `data_export` raises an error on an unsuccessful response. I fixed this not too long ago in `data_import`, but neglected to fix it as well in `data_export`.