### PR TITLE
Fix exception filter to avoid duplicate Rollbar items

### DIFF
--- a/tipping/handler.py
+++ b/tipping/handler.py
@@ -27,7 +27,11 @@ rollbar.init(rollbar_token, settings.ENVIRONMENT)
 def rollbar_ignore_handler(payload):
     """Filter out certain errors rom Rollbar logs."""
     error_class_name = (
-        payload.get("data").get("body", {}).get("exception", {}).get("class", "")
+        payload["data"]
+        .get("body", {})
+        .get("trace", {})
+        .get("exception", {})
+        .get("class", "")
     )
 
     # We ignore ServerErrorResponse, because that error will be recorded in Rollbar


### PR DESCRIPTION
They must have changed the structure of the payload, because the
"exception" key is now inside a "trace" key.