### PR TITLE
Set default score to null

### DIFF
--- a/tipping/alembic/versions/78f15e41337c_made_score_nullable.py
+++ b/tipping/alembic/versions/78f15e41337c_made_score_nullable.py
@@ -1,0 +1,23 @@
+"""made_score_nullable
+
+Revision ID: 78f15e41337c
+Revises: 6430c0506353
+Create Date: 2021-06-22 22:48:20.828345
+
+"""
+from alembic import op
+
+
+# revision identifiers, used by Alembic.
+revision = "78f15e41337c"
+down_revision = "6430c0506353"
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    op.alter_column("team_matches", "score", server_default=None)
+
+
+def downgrade():
+    op.alter_column("team_matches", "score", server_default=0)

--- a/tipping/sqlalchemy-fauna/README.md
+++ b/tipping/sqlalchemy-fauna/README.md
@@ -1,8 +1,21 @@
-## Known Issues & Limitations
+# sqlalchemy-fauna
 
-- There are a whole bunch of limitations with regards to what sorts of queries are supported (e.g. can only handle column value conditions for `WHERE` clauses), but I'll more as I go, so it's not really worth listing them all here
+A Fauna dialect for SQLAlchemy
+
+## Known Issues & Limitations
 
 - Primary keys of models have to use the `Integer` type in order to leverage the `autoincrement` param (`True` by default) to allow for auto-generated `id`s. However, Fauna returns `id` values as numeric strings. Coercing them to integers breaks `alembic`, which actually expects its numeric strings to remain strings, so I left it as is.
   - Possible solution: the PostGres dialect has a `UUID` data type for string primary keys. I couldn't use it directly, but I might be able to copy it for use with Fauna.
 
 - Alembic's `autogenerate` option for creating migrations doesn't work very well, because it includes a whole bunch of changes that already exist in the schema. I think this has to do with bugs in how the dialect responds to `INFORMATION_SCHEMA` queries. However, the auto-generated migrations include all the desired changes: you just have to delete the undesired ones.
+  - Possible solution: investigate what alembic does with the `INFORMATION_SCHEMA` data and maybe fix those responses to match what the equivalent SQL queries return.
+
+- Many valid SQL queries are not supported due to a combination of their being really difficult to make work in Fauna and their use cases not having come up in my own projects. These, in theory, could be supported eventually, and I've tried to mark as many of them as possible with `NotSupported` errors and unit tests.
+
+## TODO
+
+For keeping track of next steps for extending SQL support. Not meant to be comprehensive.
+
+- Support `JOIN` for cross-table filtering & results
+- Support `ON DELETE` strategies for foreign keys (currently is just `SET NULL` I suppose since the ref no longer exists)
+- Support `GROUP BY`

--- a/tipping/sqlalchemy-fauna/sqlalchemy_fauna/fauna/translation/alter.py
+++ b/tipping/sqlalchemy-fauna/sqlalchemy_fauna/fauna/translation/alter.py
@@ -1,0 +1,74 @@
+"""Translate a ALTER SQL query into an equivalent FQL query."""
+
+import typing
+
+from sqlparse import sql as token_groups
+from sqlparse import tokens as token_types
+from faunadb import query as q
+from faunadb.objects import _Expr as QueryExpression
+
+from sqlalchemy_fauna import exceptions
+
+
+def _translate_drop_default(table_name: str, column_name: str) -> QueryExpression:
+    drop_default = q.update(
+        q.collection(table_name),
+        {"data": {"metadata": {"fields": {column_name: {"default": None}}}}},
+    )
+    select_ref = lambda res: q.select("ref", res)
+
+    return q.let(
+        {"collection": select_ref(drop_default)},
+        {"data": [{"id": q.var("collection")}]},
+    )
+
+
+def _translate_alter_column(
+    statement: token_groups.Statement,
+    table_name: str,
+    starting_idx: int,
+) -> QueryExpression:
+    idx, column_identifier = statement.token_next_by(
+        i=token_groups.Identifier, idx=starting_idx
+    )
+    column_name = column_identifier.value
+
+    _, drop = statement.token_next_by(m=(token_types.DDL, "DROP"), idx=idx)
+    _, default = statement.token_next_by(m=(token_types.Keyword, "DEFAULT"))
+
+    if drop and default:
+        return _translate_drop_default(table_name, column_name)
+
+    raise exceptions.NotSupportedError(
+        "For statements with ALTER COLUMN, only DROP DEFAULT is currently supported."
+    )
+
+
+def translate_alter(statement: token_groups.Statement) -> typing.List[QueryExpression]:
+    """Translate an ALTER SQL query into an equivalent FQL query.
+
+    Params:
+    -------
+    statement: An SQL statement returned by sqlparse.
+
+    Returns:
+    --------
+    An FQL query expression.
+    """
+    idx, table_keyword = statement.token_next_by(m=(token_types.Keyword, "TABLE"))
+    assert table_keyword is not None
+
+    idx, table_identifier = statement.token_next_by(i=token_groups.Identifier, idx=idx)
+    table_name = table_identifier.value
+
+    _, second_alter = statement.token_next_by(m=(token_types.DDL, "ALTER"), idx=idx)
+    _, column_keyword = statement.token_next_by(
+        m=(token_types.Keyword, "COLUMN"), idx=idx
+    )
+
+    if second_alter and column_keyword:
+        return [_translate_alter_column(statement, table_name, idx)]
+
+    raise exceptions.NotSupportedError(
+        "For ALTER TABLE queries, only ALTER COLUMN is currently supported."
+    )

--- a/tipping/sqlalchemy-fauna/sqlalchemy_fauna/fauna/translation/base.py
+++ b/tipping/sqlalchemy-fauna/sqlalchemy_fauna/fauna/translation/base.py
@@ -13,6 +13,7 @@ from .drop import translate_drop
 from .insert import translate_insert
 from .delete import translate_delete
 from .update import translate_update
+from .alter import translate_alter
 
 
 def format_sql_query(sql_query: str) -> str:
@@ -58,5 +59,8 @@ def translate_sql_to_fql(
 
     if sql_statement.token_first().match(token_types.DML, "UPDATE"):
         return translate_update(sql_statement)
+
+    if sql_statement.token_first().match(token_types.DDL, "ALTER"):
+        return translate_alter(sql_statement)
 
     raise exceptions.NotSupportedError()

--- a/tipping/sqlalchemy-fauna/sqlalchemy_fauna/fauna/translation/insert.py
+++ b/tipping/sqlalchemy-fauna/sqlalchemy_fauna/fauna/translation/insert.py
@@ -72,7 +72,7 @@ def translate_insert(statement: token_groups.Statement) -> typing.List[QueryExpr
     }
 
     collection = q.get(q.collection(table_name))
-    field_metadata = q.select(["data", "metadata", "fields"], collection, default=[])
+    field_metadata = q.select(["data", "metadata", "fields"], collection, default={})
 
     get_field_value = lambda doc: q.select(
         q.var("field_name"),

--- a/tipping/sqlalchemy-fauna/sqlalchemy_fauna/fauna/translation/select.py
+++ b/tipping/sqlalchemy-fauna/sqlalchemy_fauna/fauna/translation/select.py
@@ -282,7 +282,10 @@ def _translate_select_from_info_schema_constraints(
         q.get(q.collection(condition_value)),
     )
     collection_field_names = q.map_(
-        q.lambda_(["field_name", "field_metadata"], q.var("field_name")),
+        q.lambda_(
+            ["field_name", "field_metadata"],
+            q.if_(q.equals(q.var("field_name"), "ref"), "id", q.var("field_name")),
+        ),
         q.to_array(collection_fields),
     )
 
@@ -292,7 +295,7 @@ def _translate_select_from_info_schema_constraints(
     term_field = (
         q.let(
             {"field": q.select("field", q.var("term"))},
-            last_field_name,
+            q.if_(q.equals("ref", last_field_name), "id", last_field_name),
         ),
     )
     index_term_fields = q.union(

--- a/tipping/sqlalchemy-fauna/sqlalchemy_fauna/fauna/translation/select.py
+++ b/tipping/sqlalchemy-fauna/sqlalchemy_fauna/fauna/translation/select.py
@@ -86,7 +86,7 @@ def _parse_functions(
 
 
 def _translate_select_with_functions(
-    records_to_select: QueryExpression,
+    documents_to_select: QueryExpression,
     field_alias_map: FieldAliasMap,
     field_functions: FunctionMap,
 ):
@@ -133,7 +133,7 @@ def _translate_select_with_functions(
     # for GROUP BY
     first_document = q.select_with_default(0, paginated_documents, default={})
     query_response = q.let(
-        {"documents": records_to_select},
+        {"documents": documents_to_select},
         q.map_(
             q.lambda_("document", aliased_document),
             [first_document],
@@ -147,10 +147,11 @@ def _translate_select_with_functions(
 
 
 def _translate_select_without_functions(
-    records_to_select: QueryExpression, field_alias_map: FieldAliasMap
+    documents_to_select: QueryExpression,
+    field_alias_map: FieldAliasMap,
+    distinct=False,
 ):
-    document_items = q.to_array(q.get(q.var("document")))
-    flattened_items = q.union(
+    flatten = lambda items: q.union(
         q.map_(
             q.lambda_(
                 ["key", "value"],
@@ -162,32 +163,45 @@ def _translate_select_without_functions(
                     [[q.var("key"), q.var("value")]],
                 ),
             ),
-            document_items,
+            items,
         )
     )
 
-    selected_fields = list(field_alias_map.keys())
-    field_alias = q.select_with_default(
-        q.var("field"),
-        field_alias_map,
-        default=q.var("field"),
+    translate_fields_to_aliases = lambda document_fields: q.lambda_(
+        "field",
+        [
+            q.select_with_default(
+                q.var("field"), field_alias_map, default=q.var("field")
+            ),
+            q.select_with_default(q.var("field"), document_fields, default=None),
+        ],
     )
 
-    field_value = q.select_with_default(
-        q.var("field"), q.to_object(flattened_items), default=None
-    )
-    translate_to_alias = q.lambda_("field", [field_alias, field_value])
     # We map over selected_fields to build document object to maintain the order
     # of fields as queried. Otherwise, SQLAlchemy gets confused and assigns values
     # to the incorrect keys.
-    aliased_document = q.to_object(q.map_(translate_to_alias, selected_fields))
+    selected_fields = list(field_alias_map.keys())
+    select_document_fields = q.lambda_(
+        "document",
+        q.to_object(
+            q.map_(
+                translate_fields_to_aliases(
+                    q.to_object(flatten(q.to_array(q.get(q.var("document")))))
+                ),
+                selected_fields,
+            )
+        ),
+    )
+    translate_documents = lambda documents: q.map_(
+        select_document_fields,
+        q.paginate(documents),
+    )
 
     return q.let(
-        {"documents": records_to_select},
-        q.map_(
-            q.lambda_("document", aliased_document),
-            q.paginate(q.var("documents")),
-        ),
+        {"documents": documents_to_select},
+        q.distinct(translate_documents(q.var("documents")))
+        if distinct
+        else translate_documents(q.var("documents")),
     )
 
 
@@ -196,6 +210,8 @@ def _translate_select_from_table(statement: token_groups.Statement) -> QueryExpr
 
     if wildcard is not None:
         raise exceptions.NotSupportedError("Wildcards ('*') are not yet supported")
+
+    _, distinct = statement.token_next_by(m=(token_types.Keyword, "DISTINCT"))
 
     idx, identifiers = statement.token_next_by(
         i=(token_groups.Identifier, token_groups.IdentifierList, token_groups.Function)
@@ -215,17 +231,19 @@ def _translate_select_from_table(statement: token_groups.Statement) -> QueryExpr
         )
 
     _, where_group = statement.token_next_by(i=token_groups.Where, idx=idx)
-    records_to_select = parse_where(where_group, table_name)
+    documents_to_select = parse_where(where_group, table_name)
 
     table_functions = _parse_functions(q.var("documents"), identifiers, table_name)
     field_functions = table_functions[table_name]
 
     return (
         _translate_select_with_functions(
-            records_to_select, field_alias_map, field_functions
+            documents_to_select, field_alias_map, field_functions
         )
         if len(field_functions)
-        else _translate_select_without_functions(records_to_select, field_alias_map)
+        else _translate_select_without_functions(
+            documents_to_select, field_alias_map, distinct=distinct
+        )
     )
 
 

--- a/tipping/sqlalchemy-fauna/tests/integration/test_dialect.py
+++ b/tipping/sqlalchemy-fauna/tests/integration/test_dialect.py
@@ -1,5 +1,7 @@
 # pylint: disable=missing-docstring,redefined-outer-name
 
+from functools import reduce
+
 import pytest
 from sqlalchemy.ext.declarative import declarative_base
 from sqlalchemy import Column, Integer, String, DateTime, Boolean, Float
@@ -81,3 +83,8 @@ def test_get_indexes(user_model, fauna_engine):
         ] + ["all_users", "users_by_ref_terms", "users_by_name_terms"]
 
         assert index_names == set(expected_index_names)
+
+        index_columns = reduce(
+            lambda acc, curr: set(curr["column_names"]) | acc, queried_indexes, set([])
+        )
+        assert index_columns == set(users_columns)

--- a/tipping/sqlalchemy-fauna/tests/integration/test_sqlalchemy_fauna.py
+++ b/tipping/sqlalchemy-fauna/tests/integration/test_sqlalchemy_fauna.py
@@ -421,3 +421,21 @@ def test_select_distinct(fauna_session, user_model):
 
     assert len(distinct_ages) == 2
     assert set(distinct_ages) == set([40, 12])
+
+
+def test_select_is_null(fauna_session, user_model):
+    User, Base = user_model
+    fauna_engine = fauna_session.get_bind()
+    Base.metadata.create_all(fauna_engine)
+
+    user_attributes = [("Bob", "Cook"), ("Linda", "Waitress"), ("Louise", None)]
+
+    for name, job in user_attributes:
+        fauna_session.add(User(name=name, job=job))
+
+    queried_users = (
+        fauna_session.execute(select(User).where(User.job == None)).scalars().all()
+    )
+
+    assert len(queried_users) == 1
+    assert queried_users[0].job == None

--- a/tipping/sqlalchemy-fauna/tests/integration/test_sqlalchemy_fauna.py
+++ b/tipping/sqlalchemy-fauna/tests/integration/test_sqlalchemy_fauna.py
@@ -405,3 +405,19 @@ def test_count(fauna_session, user_model):
     fauna_session.commit()
 
     assert fauna_session.execute(select(func.count(User.id))).scalar() == len(names)
+
+
+def test_select_distinct(fauna_session, user_model):
+    User, Base = user_model
+    fauna_engine = fauna_session.get_bind()
+    Base.metadata.create_all(fauna_engine)
+
+    user_attributes = [("Bob", 40), ("Linda", 40), ("Louise", 12)]
+
+    for name, age in user_attributes:
+        fauna_session.add(User(name=name, age=age))
+
+    distinct_ages = fauna_session.execute(select(User.age).distinct()).scalars().all()
+
+    assert len(distinct_ages) == 2
+    assert set(distinct_ages) == set([40, 12])

--- a/tipping/sqlalchemy-fauna/tests/unit/translation/test_alter.py
+++ b/tipping/sqlalchemy-fauna/tests/unit/translation/test_alter.py
@@ -1,0 +1,45 @@
+# pylint: disable=missing-docstring,redefined-outer-name
+
+import pytest
+import sqlparse
+from faunadb.objects import _Expr as QueryExpression
+
+from sqlalchemy_fauna import exceptions
+from sqlalchemy_fauna.fauna.translation import alter
+
+
+alter_table = "ALTER TABLE users"
+alter_column = f"{alter_table} ALTER COLUMN age"
+drop_default = f"{alter_column} DROP DEFAULT"
+
+
+@pytest.mark.parametrize("sql_query", [drop_default])
+def test_translate_alter(sql_query):
+    fql_queries = alter.translate_alter(sqlparse.parse(sql_query)[0])
+
+    for fql_query in fql_queries:
+        assert isinstance(fql_query, QueryExpression)
+
+
+rename_table = f"{alter_table} RENAME TO people"
+rename_column = f"{alter_table} RENAME COLUMN age TO years_on_earth"
+add_column = f"{alter_table} ADD COLUMN height INT"
+drop_column = f"{alter_table} DROP COLUMN height"
+set_default = f"{alter_column} SET DEFAULT 10"
+change_data_type = f"{alter_column} TYPE FLOAT"
+
+
+@pytest.mark.parametrize(
+    ["sql_query", "error_message"],
+    [
+        (rename_table, "only ALTER COLUMN is currently supported"),
+        (rename_column, "only ALTER COLUMN is currently supported"),
+        (add_column, "only ALTER COLUMN is currently supported"),
+        (drop_column, "only ALTER COLUMN is currently supported"),
+        (set_default, "only DROP DEFAULT is currently supported"),
+        (change_data_type, "only DROP DEFAULT is currently supported"),
+    ],
+)
+def test_translating_unsupported_alter(sql_query, error_message):
+    with pytest.raises(exceptions.NotSupportedError, match=error_message):
+        alter.translate_alter(sqlparse.parse(sql_query)[0])

--- a/tipping/sqlalchemy-fauna/tests/unit/translation/test_common.py
+++ b/tipping/sqlalchemy-fauna/tests/unit/translation/test_common.py
@@ -146,6 +146,7 @@ where_greater = select_values + f" WHERE users.age > {FAKE.pyint()}"
 where_greater_equal = select_values + f" WHERE users.age >= {FAKE.pyint()}"
 where_less = select_values + f" WHERE users.age < {FAKE.pyint()}"
 where_less_equal = select_values + f" WHERE users.age <= {FAKE.pyint()}"
+where_is_null = select_values + f" WHERE users.job IS NULL"
 
 
 @pytest.mark.parametrize(
@@ -159,9 +160,10 @@ where_less_equal = select_values + f" WHERE users.age <= {FAKE.pyint()}"
         where_greater_equal,
         where_less,
         where_less_equal,
+        where_is_null,
     ],
 )
-def test_translate_select(sql_query):
+def test_parsing_where(sql_query):
     statement = sqlparse.parse(sql_query)[0]
     _, where_group = statement.token_next_by(i=(token_groups.Where))
 

--- a/tipping/sqlalchemy-fauna/tests/unit/translation/test_select.py
+++ b/tipping/sqlalchemy-fauna/tests/unit/translation/test_select.py
@@ -78,7 +78,7 @@ select_aliases = (
     "FROM users"
 )
 select_where_equals = select_values + " WHERE users.name = 'Bob'"
-select_count = "SELECT count(users.id) AS count_1 from users"
+select_count = "SELECT count(users.id) AS count_1 FROM users"
 
 
 @pytest.mark.parametrize(

--- a/tipping/src/tipping/models/team_match.py
+++ b/tipping/src/tipping/models/team_match.py
@@ -26,7 +26,7 @@ class TeamMatch(Base):
     match_id = Column(Integer, ForeignKey("matches.id"), nullable=False)
     match = relationship("Match", back_populates="team_matches")
     at_home = Column(Boolean, nullable=False)
-    score = Column(Integer, default=0)
+    score = Column(Integer)
 
     @classmethod
     def from_fixture(


### PR DESCRIPTION
I've gone back and forth as to whether it's better to have
consistent data types or use null default values. In this case,
I think it's better to allow for nulls, since I want a clear
distinction between matches that haven't been played yet and those
that have. Also, conceptually, it makes more sense for a match's
scores to be null before it starts, and 0 once it's begun but
before anyone has scored.

Includes necessary extension of `sqlalchemy_fauna` to support
this change, as well as an update of its README.