### PR TITLE
Save foreign key fields as refs instead of IDs

### DIFF
--- a/tipping/sqlalchemy-fauna/sqlalchemy_fauna/fauna/translation/common.py
+++ b/tipping/sqlalchemy-fauna/sqlalchemy_fauna/fauna/translation/common.py
@@ -108,6 +108,39 @@ def extract_value(
     return string_value
 
 
+def get_foreign_key_ref(
+    foreign_value: QueryExpression,
+    references: QueryExpression,
+) -> QueryExpression:
+    """Get the Ref to a document associated with a foreign key value.
+
+    Params:
+    -------
+    foreign_value: The value to look up, usually an ID.
+    references: Field metadata dict that defines the collection (key) and field name (value)
+        that the foreign key refers to.
+
+    Returns:
+    --------
+    Fauna query expression that returns an array of Refs for the associated document(s).
+    """
+    return q.let(
+        {
+            # Assumes that there is only one reference per foreign key
+            # and that it refers to the associated collection's ID field
+            # (e.g. {'associated_table': 'id'}).
+            # This is enforced via NotSupported errors when creating collections.
+            "reference": q.union(q.to_array(references)),
+            "foreign_collection": q.collection(q.select(0, q.var("reference"))),
+        },
+        q.if_(
+            q.equals(foreign_value, None),
+            None,
+            q.ref(q.var("foreign_collection"), foreign_value),
+        ),
+    )
+
+
 def _parse_identifier(
     table_field_map: TableFieldMap,
     identifier: typing.Union[token_groups.Identifier, TokenType],
@@ -258,6 +291,10 @@ def _parse_comparison(
         ),
     )
 
+    get_collection_fields = lambda name: q.select(
+        ["data", "metadata", "fields"], q.get(q.collection(name))
+    )
+
     equality_range = q.range(
         q.match(q.index(f"{collection_name}_by_{field_name}")),
         [comparison_value],
@@ -269,13 +306,30 @@ def _parse_comparison(
             assert isinstance(comparison_value, str)
             return q.singleton(q.ref(q.collection(collection_name), comparison_value))
 
-        return q.if_(
-            q.exists(q.index(f"{collection_name}_by_{field_name}_terms")),
-            q.match(
-                q.index(f"{collection_name}_by_{field_name}_terms"),
-                comparison_value,
+        return q.let(
+            {
+                "ref_index": q.index(f"{collection_name}_by_{field_name}_refs"),
+                "term_index": q.index(f"{collection_name}_by_{field_name}_terms"),
+                "references": q.select(
+                    [field_name, "references"], get_collection_fields(collection_name)
+                ),
+                "comparison_value": comparison_value,
+            },
+            q.if_(
+                q.exists(q.var("ref_index")),
+                q.match(
+                    q.var("ref_index"),
+                    get_foreign_key_ref(q.var("comparison_value"), q.var("references")),
+                ),
+                q.if_(
+                    q.exists(q.var("term_index")),
+                    q.match(
+                        q.var("term_index"),
+                        comparison_value,
+                    ),
+                    convert_to_ref_set(equality_range),
+                ),
             ),
-            convert_to_ref_set(equality_range),
         )
 
     if comparison.value in [">=", ">"]:

--- a/tipping/sqlalchemy-fauna/tests/integration/test_sqlalchemy_fauna.py
+++ b/tipping/sqlalchemy-fauna/tests/integration/test_sqlalchemy_fauna.py
@@ -163,6 +163,21 @@ def test_insert_record(fauna_session, user_model):
     assert isinstance(int(created_user.id), int)
 
 
+def test_insert_with_null_foreign_key(fauna_session, parent_child):
+    Base = parent_child["base"]
+    Child = parent_child["child"]
+
+    fauna_engine = fauna_session.get_bind()
+    Base.metadata.create_all(fauna_engine)
+
+    child = Child(name="Gene")
+    fauna_session.add(child)
+    fauna_session.commit()
+
+    assert child.id is not None
+    assert child.parent_id is None
+
+
 def test_select_empty_table(fauna_session, user_model):
     User, Base = user_model
     fauna_engine = fauna_session.get_bind()

--- a/tipping/sqlalchemy-fauna/tests/unit/translation/test_common.py
+++ b/tipping/sqlalchemy-fauna/tests/unit/translation/test_common.py
@@ -8,6 +8,7 @@ from sqlparse import tokens as token_types
 from faker import Faker
 import sqlparse
 from faunadb.objects import _Expr as QueryExpression
+from faunadb import query as q
 
 from sqlalchemy_fauna import exceptions
 from sqlalchemy_fauna.fauna.translation import common
@@ -168,4 +169,13 @@ def test_parsing_where(sql_query):
     _, where_group = statement.token_next_by(i=(token_groups.Where))
 
     fql_query = common.parse_where(where_group, "users")
+    assert isinstance(fql_query, QueryExpression)
+
+
+def test_get_foreign_key_ref():
+    fql_query = q.let(
+        {"references": {}, "foreign_key": FAKE.credit_card_number()},
+        common.get_foreign_key_ref(q.var("foreign_key"), q.var("references")),
+    )
+
     assert isinstance(fql_query, QueryExpression)

--- a/tipping/sqlalchemy-fauna/tests/unit/translation/test_create.py
+++ b/tipping/sqlalchemy-fauna/tests/unit/translation/test_create.py
@@ -24,10 +24,24 @@ def test_translate_create(sql_query):
 
 
 create_check = "CREATE TABLE users (id INTEGER NOT NULL, age INTEGER CHECK (age > 40))"
+multiple_references = (
+    "CREATE TABLE users (id INTEGER NOT NULL, account_id INTEGER NOT NULL, "
+    "PRIMARY KEY (id), FOREIGN KEY(account_id) REFERENCES bank_accounts (id), "
+    "FOREIGN KEY(account_id) REFERENCES social_accounts (id))"
+)
+non_id_reference = (
+    "CREATE TABLE users (id INTEGER NOT NULL, account_name VARCHAR NOT NULL, "
+    "PRIMARY KEY (id), FOREIGN KEY(account_name) REFERENCES accounts (name))"
+)
 
 
 @pytest.mark.parametrize(
-    ["sql_query", "error_message"], [(create_check, "CHECK keyword is not supported")]
+    ["sql_query", "error_message"],
+    [
+        (create_check, "CHECK keyword is not supported"),
+        (multiple_references, "Foreign keys with multiple references"),
+        (non_id_reference, "Foreign keys referring to fields other than ID"),
+    ],
 )
 def test_translating_unsupported_create(sql_query, error_message):
     with pytest.raises(exceptions.NotSupportedError, match=error_message):


### PR DESCRIPTION
This will make implementing JOIN queries much easier, as we'll
be able to use FQL's Join function to match parent refs with their
children's foreign-key refs rather than having to convert refs
to IDs then back again.