### PR TITLE
Refactor query translation into SQL objects

### DIFF
--- a/tipping/sqlalchemy-fauna/sqlalchemy_fauna/fauna/client.py
+++ b/tipping/sqlalchemy-fauna/sqlalchemy_fauna/fauna/client.py
@@ -54,14 +54,18 @@ class FaunaClient:
             for fql_query in fql_queries:
                 result = self._execute_with_retries(fql_query)
         except fauna_errors.BadRequest as err:
-            if "document is not unique" not in str(err):
-                raise err
+            # The response from Fauna contains more information about where to find
+            # the bug in the FQL, but it gets lost in the default error message.
+            fauna_response = err.request_result.response_content
 
-            # TODO: this isn't a terribly helpful error message, but executing the queries
-            # to make a better one is a little tricky, so leaving it as-is for now.
-            raise exceptions.ProgrammingError(
-                "Tried to create a document with duplicate value for a unique field."
-            )
+            if "document is not unique" in str(err):
+                # TODO: this isn't a terribly helpful error message, but executing the queries
+                # to make a better one is a little tricky, so leaving it as-is for now.
+                raise exceptions.ProgrammingError(
+                    "Tried to create a document with duplicate value for a unique field."
+                ) from err
+
+            raise exceptions.InternalError(fauna_response) from err
 
         return [self._fauna_data_to_sqlalchemy_result(data) for data in result["data"]]
 

--- a/tipping/sqlalchemy-fauna/sqlalchemy_fauna/fauna/client.py
+++ b/tipping/sqlalchemy-fauna/sqlalchemy_fauna/fauna/client.py
@@ -80,7 +80,7 @@ class FaunaClient:
             if "document data is not valid" not in str(err) or retries >= 10:
                 raise err
 
-            sleep(retries * 2)
+            sleep(retries)
             return self._execute_with_retries(query, retries=(retries + 1))
 
     def _fauna_data_to_sqlalchemy_result(

--- a/tipping/sqlalchemy-fauna/sqlalchemy_fauna/fauna/translation/__init__.py
+++ b/tipping/sqlalchemy-fauna/sqlalchemy_fauna/fauna/translation/__init__.py
@@ -1,4 +1,4 @@
 """Translate an SQL query into an equivalent FQL query"""
 
 from .base import format_sql_query, translate_sql_to_fql
-from .common import parse_identifiers
+from . import models

--- a/tipping/sqlalchemy-fauna/sqlalchemy_fauna/fauna/translation/alter.py
+++ b/tipping/sqlalchemy-fauna/sqlalchemy_fauna/fauna/translation/alter.py
@@ -8,6 +8,7 @@ from faunadb import query as q
 from faunadb.objects import _Expr as QueryExpression
 
 from sqlalchemy_fauna import exceptions
+from .models import Table
 
 
 def _translate_drop_default(table_name: str, column_name: str) -> QueryExpression:
@@ -59,7 +60,7 @@ def translate_alter(statement: token_groups.Statement) -> typing.List[QueryExpre
     assert table_keyword is not None
 
     idx, table_identifier = statement.token_next_by(i=token_groups.Identifier, idx=idx)
-    table_name = table_identifier.value
+    table = Table(table_identifier)
 
     _, second_alter = statement.token_next_by(m=(token_types.DDL, "ALTER"), idx=idx)
     _, column_keyword = statement.token_next_by(
@@ -67,7 +68,7 @@ def translate_alter(statement: token_groups.Statement) -> typing.List[QueryExpre
     )
 
     if second_alter and column_keyword:
-        return [_translate_alter_column(statement, table_name, idx)]
+        return [_translate_alter_column(statement, table.name, idx)]
 
     raise exceptions.NotSupportedError(
         "For ALTER TABLE queries, only ALTER COLUMN is currently supported."

--- a/tipping/sqlalchemy-fauna/sqlalchemy_fauna/fauna/translation/common.py
+++ b/tipping/sqlalchemy-fauna/sqlalchemy_fauna/fauna/translation/common.py
@@ -4,17 +4,16 @@ import typing
 import re
 from datetime import datetime, timezone
 from warnings import warn
-from functools import reduce
 from dateutil import parser
 
 from sqlparse import sql as token_groups
 from sqlparse import tokens as token_types
-from sqlparse.tokens import _TokenType as TokenType
 from mypy_extensions import TypedDict
 from faunadb.objects import _Expr as QueryExpression
 from faunadb import query as q
 
 from sqlalchemy_fauna import exceptions
+from . import models
 
 TableNames = typing.Sequence[typing.Optional[str]]
 ColumnNames = typing.Sequence[str]
@@ -149,94 +148,19 @@ def get_foreign_key_ref(
     )
 
 
-def _parse_identifier(
-    table_field_map: TableFieldMap,
-    identifier: typing.Union[token_groups.Identifier, TokenType],
-) -> TableFieldMap:
-    if not isinstance(identifier, token_groups.Identifier):
-        return table_field_map
-
-    idx, identifier_name = identifier.token_next_by(
-        t=token_types.Name, i=token_groups.Function
-    )
-
-    tok_idx, next_token = identifier.token_next(idx, skip_ws=True)
-    if next_token and next_token.match(token_types.Punctuation, "."):
-        idx = tok_idx
-        table_name = identifier_name.value
-        idx, column_identifier = identifier.token_next_by(t=token_types.Name, idx=idx)
-        column_name = column_identifier.value
-    else:
-        table_name = None
-        column_name = identifier_name.value
-
-    idx, as_keyword = identifier.token_next_by(m=(token_types.Keyword, "AS"), idx=idx)
-
-    if as_keyword is not None:
-        _, alias_identifier = identifier.token_next_by(
-            i=token_groups.Identifier, idx=idx
-        )
-        alias_name = alias_identifier.value
-    else:
-        alias_name = column_name
-
-    if table_name is None:
-        assert len(table_field_map.keys()) == 1
-        return {
-            key: {**value, column_name: alias_name}
-            for key, value in table_field_map.items()
-        }
-
-    # Fauna doesn't have an 'id' field, so we extract the ID value from the 'ref' included
-    # in query responses, but we still want to map the field name to aliases as with other
-    # fields for consistency when passing results to SQLAlchemy
-    field_map_key = "ref" if column_name == "id" else column_name
-    return {
-        **table_field_map,
-        table_name: {**table_field_map.get(table_name, {}), field_map_key: alias_name},
-    }
-
-
-def parse_identifiers(
-    identifiers: typing.Union[
-        token_groups.Identifier, token_groups.IdentifierList, token_groups.Function
-    ],
-    table_name: typing.Optional[str] = None,
-) -> TableFieldMap:
-    """Extract raw table name, column name, and alias from SQL identifiers.
-
-    Params:
-    -------
-    identifiers: Either a single identifier or identifier list.
-
-    Returns:
-    --------
-    typing.Tuple of table_names, column names, and column aliases.
-    """
-    if isinstance(identifiers, token_groups.Function):
-        return _parse_identifier(
-            {table_name: {}}, token_groups.Identifier([identifiers])
-        )
-
-    if isinstance(identifiers, token_groups.Identifier):
-        return _parse_identifier({table_name: {}}, identifiers)
-
-    return reduce(_parse_identifier, identifiers, {table_name: {}})
-
-
 def _parse_is_null(
     where_group: token_groups.Where,
-    collection_name: str,
+    table: models.Table,
     starting_idx: typing.Optional[int],
 ) -> QueryExpression:
     idx = starting_idx or 0
     idx, comparison_identifier = where_group.token_next_by(
         i=token_groups.Identifier, idx=idx
     )
-    table_field_map = _parse_identifier({collection_name: {}}, comparison_identifier)
-    field_names = list(table_field_map[collection_name].keys())
-    assert len(field_names) == 1
-    field_name = field_names[0]
+    columns = models.Column.from_identifier_group(comparison_identifier)
+    assert len(columns) == 1
+    table.add_column(columns[0])
+    field_name = columns[0].name
 
     idx, is_keyword = where_group.token_next(idx, skip_ws=True, skip_cm=True)
     idx, null_keyword = where_group.token_next(idx, skip_ws=True, skip_cm=True)
@@ -252,20 +176,20 @@ def _parse_is_null(
         index_match,
         q.lambda_(
             ["value", "ref"],
-            q.match(q.index(f"{collection_name}_by_ref_terms"), q.var("ref")),
+            q.match(q.index(f"{table.name}_by_ref_terms"), q.var("ref")),
         ),
     )
     comparison_value = None
     equality_range = q.range(
-        q.match(q.index(f"{collection_name}_by_{field_name}")),
+        q.match(q.index(f"{table.name}_by_{field_name}")),
         [comparison_value],
         [comparison_value],
     )
 
     return q.if_(
-        q.exists(q.index(f"{collection_name}_by_{field_name}_terms")),
+        q.exists(q.index(f"{table.name}_by_{field_name}_terms")),
         q.match(
-            q.index(f"{collection_name}_by_{field_name}_terms"),
+            q.index(f"{table.name}_by_{field_name}_terms"),
             comparison_value,
         ),
         convert_to_ref_set(equality_range),
@@ -273,13 +197,13 @@ def _parse_is_null(
 
 
 def _parse_comparison(
-    comparison_group: token_groups.Comparison, collection_name: str
+    comparison_group: token_groups.Comparison, table: models.Table
 ) -> QueryExpression:
     _, comparison_identifier = comparison_group.token_next_by(i=token_groups.Identifier)
-    table_field_map = _parse_identifier({collection_name: {}}, comparison_identifier)
-    field_names = list(table_field_map[collection_name].keys())
-    assert len(field_names) == 1
-    field_name = field_names[0]
+    columns = models.Column.from_identifier_group(comparison_identifier)
+    assert len(columns) == 1
+    table.add_column(columns[0])
+    field_name = columns[0].name
 
     comp_idx, comparison = comparison_group.token_next_by(t=token_types.Comparison)
     value_idx, comparison_check = comparison_group.token_next_by(t=token_types.Literal)
@@ -295,7 +219,7 @@ def _parse_comparison(
         index_match,
         q.lambda_(
             ["value", "ref"],
-            q.match(q.index(f"{collection_name}_by_ref_terms"), q.var("ref")),
+            q.match(q.index(f"{table.name}_by_ref_terms"), q.var("ref")),
         ),
     )
 
@@ -304,7 +228,7 @@ def _parse_comparison(
     )
 
     equality_range = q.range(
-        q.match(q.index(f"{collection_name}_by_{field_name}")),
+        q.match(q.index(f"{table.name}_by_{field_name}")),
         [comparison_value],
         [comparison_value],
     )
@@ -312,15 +236,15 @@ def _parse_comparison(
     if comparison.value == "=":
         if field_name == "ref":
             assert isinstance(comparison_value, str)
-            return q.singleton(q.ref(q.collection(collection_name), comparison_value))
+            return q.singleton(q.ref(q.collection(table.name), comparison_value))
 
         return q.let(
             {
-                "ref_index": q.index(f"{collection_name}_by_{field_name}_refs"),
-                "term_index": q.index(f"{collection_name}_by_{field_name}_terms"),
+                "ref_index": q.index(f"{table.name}_by_{field_name}_refs"),
+                "term_index": q.index(f"{table.name}_by_{field_name}_terms"),
                 "references": q.select(
                     [field_name, "references"],
-                    get_collection_fields(collection_name),
+                    get_collection_fields(table.name),
                     default={},
                 ),
                 "comparison_value": comparison_value,
@@ -347,13 +271,13 @@ def _parse_comparison(
 
         if field_value_greater_than_literal:
             inclusive_comparison_range = q.range(
-                q.match(q.index(f"{collection_name}_by_{field_name}")),
+                q.match(q.index(f"{table.name}_by_{field_name}")),
                 [comparison_value],
                 [],
             )
         else:
             inclusive_comparison_range = q.range(
-                q.match(q.index(f"{collection_name}_by_{field_name}")),
+                q.match(q.index(f"{table.name}_by_{field_name}")),
                 [],
                 [comparison_value],
             )
@@ -370,13 +294,13 @@ def _parse_comparison(
 
         if field_value_less_than_literal:
             inclusive_comparison_range = q.range(
-                q.match(q.index(f"{collection_name}_by_{field_name}")),
+                q.match(q.index(f"{table.name}_by_{field_name}")),
                 [],
                 [comparison_value],
             )
         else:
             inclusive_comparison_range = q.range(
-                q.match(q.index(f"{collection_name}_by_{field_name}")),
+                q.match(q.index(f"{table.name}_by_{field_name}")),
                 [comparison_value],
                 [],
             )
@@ -395,7 +319,7 @@ def _parse_comparison(
 
 
 def parse_where(
-    where_group: token_groups.Where, collection_name: str
+    where_group: token_groups.Where, table: models.Table
 ) -> QueryExpression:
     """Convert an SQL WHERE clause into an FQL match query.
 
@@ -408,7 +332,7 @@ def parse_where(
     FQL query expression that matches on the same conditions as the WHERE clause.
     """
     if where_group is None:
-        return q.intersection(q.match(q.index(f"all_{collection_name}")))
+        return q.intersection(q.match(q.index(f"all_{table.name}")))
 
     _, or_keyword = where_group.token_next_by(m=(token_types.Keyword, "OR"))
     if or_keyword is not None:
@@ -440,9 +364,9 @@ def parse_where(
         )
 
         comparison_query = (
-            _parse_is_null(where_group, collection_name, and_idx)
+            _parse_is_null(where_group, table, and_idx)
             if comparison.value == "IS"
-            else _parse_comparison(comparison, collection_name)
+            else _parse_comparison(comparison, table)
         )
         comparisons.append(comparison_query)
 

--- a/tipping/sqlalchemy-fauna/sqlalchemy_fauna/fauna/translation/common.py
+++ b/tipping/sqlalchemy-fauna/sqlalchemy_fauna/fauna/translation/common.py
@@ -35,6 +35,7 @@ TableFieldMap = typing.Dict[typing.Optional[str], FieldAliasMap]
 
 
 NULL = "NULL"
+DATA = "data"
 
 
 class _NumericString(Exception):
@@ -299,7 +300,7 @@ def _parse_comparison(
     )
 
     get_collection_fields = lambda name: q.select(
-        ["data", "metadata", "fields"], q.get(q.collection(name))
+        [DATA, "metadata", "fields"], q.get(q.collection(name))
     )
 
     equality_range = q.range(

--- a/tipping/sqlalchemy-fauna/sqlalchemy_fauna/fauna/translation/delete.py
+++ b/tipping/sqlalchemy-fauna/sqlalchemy_fauna/fauna/translation/delete.py
@@ -7,6 +7,7 @@ from faunadb import query as q
 from faunadb.objects import _Expr as QueryExpression
 
 from .common import parse_where
+from . import models
 
 
 def translate_delete(statement: token_groups.Statement) -> typing.List[QueryExpression]:
@@ -20,10 +21,11 @@ def translate_delete(statement: token_groups.Statement) -> typing.List[QueryExpr
     --------
     An FQL query expression.
     """
-    idx, table = statement.token_next_by(i=token_groups.Identifier)
+    idx, table_identifier = statement.token_next_by(i=token_groups.Identifier)
+    table = models.Table(table_identifier)
     _, where_group = statement.token_next_by(i=(token_groups.Where), idx=idx)
 
-    records_to_delete = parse_where(where_group, table.value)
+    records_to_delete = parse_where(where_group, table)
     delete_records = q.delete(q.select("ref", q.get(records_to_delete)))
 
     return [

--- a/tipping/sqlalchemy-fauna/sqlalchemy_fauna/fauna/translation/models.py
+++ b/tipping/sqlalchemy-fauna/sqlalchemy_fauna/fauna/translation/models.py
@@ -1,0 +1,15 @@
+"""Collection of objects representing RDB structures in SQL queries"""
+
+from sqlparse import sql as token_groups
+
+
+class Table:
+    """Representation of a table object in SQL.
+
+    Params:
+    -------
+    table_identifier: Parsed SQL Identifier for a table name.
+    """
+
+    def __init__(self, table_identifier: token_groups.Identifier):
+        self.name = table_identifier.value

--- a/tipping/sqlalchemy-fauna/sqlalchemy_fauna/fauna/translation/models.py
+++ b/tipping/sqlalchemy-fauna/sqlalchemy_fauna/fauna/translation/models.py
@@ -3,9 +3,16 @@
 from __future__ import annotations
 
 import typing
+from functools import reduce
 
 from sqlparse import sql as token_groups
 from sqlparse import tokens as token_types
+
+from sqlalchemy_fauna import exceptions
+
+
+# Probably not a complete list, but covers the basics
+FUNCTION_NAMES = {"min", "max", "count", "avg", "sum"}
 
 
 class Column:
@@ -16,10 +23,64 @@ class Column:
     """
 
     def __init__(self, identifier: token_groups.Identifier):
+        self.name = ""
+        self.alias = ""
         self._table: typing.Optional[Table] = None
         self._table_name: typing.Optional[str] = None
+
         idx = self._assign_names(identifier)
         self._assign_alias(identifier, idx)
+        # Fauna doesn't have an 'id' field, so we extract the ID value from the 'ref' included
+        # in query responses, but we still want to map the field name to aliases as with other
+        # fields for consistency when passing results to SQLAlchemy
+        if self.name == "id":
+            self.name = "ref"
+
+    @classmethod
+    def from_identifier_group(
+        cls,
+        identifiers: typing.Union[
+            token_groups.Identifier, token_groups.IdentifierList, token_groups.Function
+        ],
+    ) -> typing.List[Column]:
+        """Create column objects from any of the possible SQL identifier objects.
+
+        Params:
+        -------
+        identifiers: A parsed SQL token group that contains column names and/or aliases.
+
+        Returns:
+        --------
+        A list of column objects.
+        """
+        if isinstance(identifiers, token_groups.IdentifierList):
+            return [
+                Column(id)
+                for id in identifiers
+                if isinstance(id, token_groups.Identifier)
+            ]
+
+        if isinstance(identifiers, token_groups.Function):
+            _, identifier = identifiers.token_next_by(i=token_groups.Identifier)
+            _, name = identifier.token_next_by(t=token_types.Name)
+
+            if name.value.lower() in FUNCTION_NAMES:
+                return [Column(token_groups.Identifier([identifiers]))]
+
+            _, parenthesis = identifiers.token_next_by(i=token_groups.Parenthesis)
+            _, column_id_list = parenthesis.token_next_by(i=token_groups.IdentifierList)
+            columns = cls.from_identifier_group(column_id_list)
+            for column in columns:
+                column._table_name = name.value
+
+            return columns
+
+        if isinstance(identifiers, token_groups.Identifier):
+            return [Column(identifiers)]
+
+        raise exceptions.InternalError(
+            f"Tried to create a column from unsupported SQL token type {type(identifiers)}"
+        )
 
     @property
     def table(self) -> typing.Optional[Table]:
@@ -38,38 +99,49 @@ class Column:
         """Name of the associated table in the SQL query."""
         return self._table_name
 
+    @property
+    def alias_map(self) -> typing.Dict[str, str]:
+        """Dictionary that maps the column name to its alias in the SQL query."""
+        return {self.name: self.alias}
+
     def _assign_names(self, identifier: token_groups.Identifier) -> int:
         idx, identifier_name = identifier.token_next_by(
             t=token_types.Name, i=token_groups.Function
         )
 
-        maybe_idx, next_token = identifier.token_next(idx, skip_ws=True)
+        tok_idx, next_token = identifier.token_next(idx, skip_ws=True)
         if next_token and next_token.match(token_types.Punctuation, "."):
-            idx = maybe_idx
-            self._table_name = identifier_name.value
-
+            idx = tok_idx
+            table_name = identifier_name.value
             idx, column_identifier = identifier.token_next_by(
                 t=token_types.Name, idx=idx
             )
-            self.name = column_identifier.value
+            column_name = column_identifier.value
         else:
-            self._table_name = None
-            self.name = identifier_name.value
+            table_name = None
+            column_name = identifier_name.value
+
+        self.name = column_name
+        self._table_name = table_name
 
         return idx
 
     def _assign_alias(self, identifier: token_groups.Identifier, idx: int):
+        assert self.name is not None
         idx, as_keyword = identifier.token_next_by(
             m=(token_types.Keyword, "AS"), idx=idx
         )
 
         if as_keyword is None:
-            self.alias = None
+            self.alias = "id" if self.name == "ref" else self.name
         else:
             _, alias_identifier = identifier.token_next_by(
                 i=token_groups.Identifier, idx=idx
             )
             self.alias = alias_identifier.value
+
+    def __str__(self) -> str:
+        return self.name
 
 
 class Table:
@@ -102,5 +174,18 @@ class Table:
         """Add an associated column object to this table."""
         assert self.name is not None
 
-        column.table = self
-        self._columns.append(column)
+        matching_column = (col for col in self.columns if column.name == col.name)
+        try:
+            next(matching_column)
+        except StopIteration:
+            column.table = self
+            self._columns.append(column)
+
+    @property
+    def column_alias_map(self) -> typing.Dict[str, str]:
+        """Dictionary that maps column names to their aliases in the SQL query."""
+        collect_alias_maps = lambda acc, col: {**acc, **col.alias_map}
+        return reduce(collect_alias_maps, self.columns, {})
+
+    def __str__(self) -> str:
+        return self.name

--- a/tipping/sqlalchemy-fauna/sqlalchemy_fauna/fauna/translation/models.py
+++ b/tipping/sqlalchemy-fauna/sqlalchemy_fauna/fauna/translation/models.py
@@ -1,6 +1,75 @@
 """Collection of objects representing RDB structures in SQL queries"""
 
+from __future__ import annotations
+
+import typing
+
 from sqlparse import sql as token_groups
+from sqlparse import tokens as token_types
+
+
+class Column:
+    """Representation of a column object in SQL.
+
+    Params:
+    identifier: Parsed SQL Identifier for a column name and/or alias.
+    """
+
+    def __init__(self, identifier: token_groups.Identifier):
+        self._table: typing.Optional[Table] = None
+        self._table_name: typing.Optional[str] = None
+        idx = self._assign_names(identifier)
+        self._assign_alias(identifier, idx)
+
+    @property
+    def table(self) -> typing.Optional[Table]:
+        """Table object associated with this column."""
+        return self._table
+
+    @table.setter
+    def table(self, table: Table):
+        assert self._table_name is None or self._table_name == table.name
+
+        self._table = table
+        self._table_name = table.name
+
+    @property
+    def table_name(self) -> typing.Optional[str]:
+        """Name of the associated table in the SQL query."""
+        return self._table_name
+
+    def _assign_names(self, identifier: token_groups.Identifier) -> int:
+        idx, identifier_name = identifier.token_next_by(
+            t=token_types.Name, i=token_groups.Function
+        )
+
+        maybe_idx, next_token = identifier.token_next(idx, skip_ws=True)
+        if next_token and next_token.match(token_types.Punctuation, "."):
+            idx = maybe_idx
+            self._table_name = identifier_name.value
+
+            idx, column_identifier = identifier.token_next_by(
+                t=token_types.Name, idx=idx
+            )
+            self.name = column_identifier.value
+        else:
+            self._table_name = None
+            self.name = identifier_name.value
+
+        return idx
+
+    def _assign_alias(self, identifier: token_groups.Identifier, idx: int):
+        idx, as_keyword = identifier.token_next_by(
+            m=(token_types.Keyword, "AS"), idx=idx
+        )
+
+        if as_keyword is None:
+            self.alias = None
+        else:
+            _, alias_identifier = identifier.token_next_by(
+                i=token_groups.Identifier, idx=idx
+            )
+            self.alias = alias_identifier.value
 
 
 class Table:
@@ -8,8 +77,30 @@ class Table:
 
     Params:
     -------
-    table_identifier: Parsed SQL Identifier for a table name.
+    identifier: Parsed SQL Identifier for a table name.
+    columns: Column objects that belong to the given table.
     """
 
-    def __init__(self, table_identifier: token_groups.Identifier):
-        self.name = table_identifier.value
+    def __init__(
+        self,
+        identifier: token_groups.Identifier,
+        columns: typing.Optional[typing.List[Column]] = None,
+    ):
+        self.name = identifier.value
+        self._columns: typing.List[Column] = []
+
+        columns = columns or []
+        for column in columns:
+            self.add_column(column)
+
+    @property
+    def columns(self) -> typing.List[Column]:
+        """List of column objects associated with this table."""
+        return self._columns
+
+    def add_column(self, column: Column):
+        """Add an associated column object to this table."""
+        assert self.name is not None
+
+        column.table = self
+        self._columns.append(column)

--- a/tipping/sqlalchemy-fauna/sqlalchemy_fauna/fauna/translation/update.py
+++ b/tipping/sqlalchemy-fauna/sqlalchemy_fauna/fauna/translation/update.py
@@ -48,7 +48,7 @@ def translate_update(statement: token_groups.Statement) -> typing.List[QueryExpr
     update_value_value = extract_value(update_value)
 
     _, where_group = statement.token_next_by(i=token_groups.Where)
-    records_to_update = parse_where(where_group, table.name)
+    records_to_update = parse_where(where_group, table)
 
     updated_count = q.do(
         q.update(

--- a/tipping/sqlalchemy-fauna/tests/integration/test_sqlalchemy_fauna.py
+++ b/tipping/sqlalchemy-fauna/tests/integration/test_sqlalchemy_fauna.py
@@ -427,6 +427,27 @@ def test_count(fauna_session, user_model):
     assert fauna_session.execute(select(func.count(User.id))).scalar() == len(names)
 
 
+def test_count_with_empty_results(fauna_session, user_model):
+    User, Base = user_model
+    fauna_engine = fauna_session.get_bind()
+    Base.metadata.create_all(fauna_engine)
+
+    assert fauna_session.execute(select(func.count(User.id))).scalar() == 0
+
+    names = ["Bob", "Linda", "Louise"]
+
+    for name in names:
+        fauna_session.add(User(name=name))
+
+    fauna_session.commit()
+
+    user_count = fauna_session.execute(
+        select(func.count(User.id)).where(User.name == "No one")
+    ).scalar()
+
+    assert user_count == 0
+
+
 def test_select_distinct(fauna_session, user_model):
     User, Base = user_model
     fauna_engine = fauna_session.get_bind()

--- a/tipping/sqlalchemy-fauna/tests/unit/translation/test_models.py
+++ b/tipping/sqlalchemy-fauna/tests/unit/translation/test_models.py
@@ -6,12 +6,15 @@ import pytest
 from sqlalchemy_fauna.fauna.translation import models
 
 
+column_name = "name"
+
+
 @pytest.mark.parametrize(
     ["column_sql", "expected_table_name", "expected_alias"],
     [
-        ("users.name", "users", None),
-        ("name", None, None),
-        ("users.name AS user_name", "users", "user_name"),
+        (f"users.{column_name}", "users", column_name),
+        (column_name, None, column_name),
+        (f"users.{column_name} AS user_name", "users", "user_name"),
     ],
 )
 def test_column(column_sql, expected_table_name, expected_alias):
@@ -22,13 +25,53 @@ def test_column(column_sql, expected_table_name, expected_alias):
 
     column = models.Column(column_identifier)
 
-    assert column.name == "name"
+    assert column.name == column_name
+    assert str(column) == column_name
     assert column.table_name == expected_table_name
     assert column.alias == expected_alias
+    assert column.alias_map == {column.name: column.alias}
 
     table = models.Table(table_identifier, columns=[column])
     column.table = table
     assert column.table_name == table.name
+
+
+table_name = "users"
+select_single_column = f"SELECT {table_name}.id FROM {table_name}"
+select_columns = f"SELECT {table_name}.id, {table_name}.name FROM {table_name}"
+select_aliases = (
+    f"SELECT {table_name}.id AS user_id, {table_name}.name AS user_name "
+    "FROM {table_name}"
+)
+select_function = f"SELECT count({table_name}.id) FROM {table_name}"
+select_function_alias = (
+    f"SELECT count({table_name}.id) AS count_{table_name} FROM {table_name}"
+)
+insert = "INSERT INTO users (name, age, finger_count) VALUES ('Bob', 30, 10)"
+
+
+@pytest.mark.parametrize(
+    ["sql_query", "expected_columns", "expected_aliases"],
+    [
+        (select_single_column, ["ref"], ["id"]),
+        (select_columns, ["ref", "name"], ["id", "name"]),
+        (select_aliases, ["ref", "name"], ["user_id", "user_name"]),
+        (select_function, [f"count({table_name}.id)"], [f"count({table_name}.id)"]),
+        (select_function_alias, [f"count({table_name}.id)"], [f"count_{table_name}"]),
+        (insert, ["name", "age", "finger_count"], ["name", "age", "finger_count"]),
+    ],
+)
+def test_from_identifier_group(sql_query, expected_columns, expected_aliases):
+    statement = sqlparse.parse(sql_query)[0]
+    _, identifiers = statement.token_next_by(
+        i=(token_groups.Identifier, token_groups.IdentifierList, token_groups.Function)
+    )
+
+    columns = models.Column.from_identifier_group(identifiers)
+
+    for column in columns:
+        assert column.name in expected_columns
+        assert column.alias in expected_aliases
 
 
 def test_table():
@@ -41,8 +84,11 @@ def test_table():
     column = models.Column(column_identifier)
     table = models.Table(table_identifier, columns=[column])
     assert table.name == table_name
+    assert str(table) == table_name
+
     assert len(table.columns) == 1
     assert table.columns[0].name == column.name
+    assert table.column_alias_map == {column.name: column.alias}
 
 
 def test_add_column():

--- a/tipping/sqlalchemy-fauna/tests/unit/translation/test_models.py
+++ b/tipping/sqlalchemy-fauna/tests/unit/translation/test_models.py
@@ -2,16 +2,59 @@
 
 import sqlparse
 from sqlparse import sql as token_groups
-
+import pytest
 from sqlalchemy_fauna.fauna.translation import models
 
 
-def test_table_name():
+@pytest.mark.parametrize(
+    ["column_sql", "expected_table_name", "expected_alias"],
+    [
+        ("users.name", "users", None),
+        ("name", None, None),
+        ("users.name AS user_name", "users", "user_name"),
+    ],
+)
+def test_column(column_sql, expected_table_name, expected_alias):
+    sql_query = f"SELECT {column_sql} FROM users"
+    statement = sqlparse.parse(sql_query)[0]
+    idx, column_identifier = statement.token_next_by(i=(token_groups.Identifier))
+    _, table_identifier = statement.token_next_by(i=(token_groups.Identifier), idx=idx)
+
+    column = models.Column(column_identifier)
+
+    assert column.name == "name"
+    assert column.table_name == expected_table_name
+    assert column.alias == expected_alias
+
+    table = models.Table(table_identifier, columns=[column])
+    column.table = table
+    assert column.table_name == table.name
+
+
+def test_table():
     table_name = "users"
     sql_query = f"SELECT users.name FROM {table_name}"
     statement = sqlparse.parse(sql_query)[0]
-    idx, _column_identifiers = statement.token_next_by(i=(token_groups.Identifier))
+    idx, column_identifier = statement.token_next_by(i=(token_groups.Identifier))
     _, table_identifier = statement.token_next_by(i=(token_groups.Identifier), idx=idx)
 
-    table = models.Table(table_identifier)
+    column = models.Column(column_identifier)
+    table = models.Table(table_identifier, columns=[column])
     assert table.name == table_name
+    assert len(table.columns) == 1
+    assert table.columns[0].name == column.name
+
+
+def test_add_column():
+    table_name = "users"
+    sql_query = f"SELECT users.name FROM {table_name}"
+    statement = sqlparse.parse(sql_query)[0]
+    idx, column_identifier = statement.token_next_by(i=(token_groups.Identifier))
+    _, table_identifier = statement.token_next_by(i=(token_groups.Identifier), idx=idx)
+
+    column = models.Column(column_identifier)
+    table = models.Table(table_identifier)
+
+    table.add_column(column)
+
+    assert table.columns == [column]

--- a/tipping/sqlalchemy-fauna/tests/unit/translation/test_models.py
+++ b/tipping/sqlalchemy-fauna/tests/unit/translation/test_models.py
@@ -1,0 +1,17 @@
+# pylint: disable=missing-docstring,redefined-outer-name
+
+import sqlparse
+from sqlparse import sql as token_groups
+
+from sqlalchemy_fauna.fauna.translation import models
+
+
+def test_table_name():
+    table_name = "users"
+    sql_query = f"SELECT users.name FROM {table_name}"
+    statement = sqlparse.parse(sql_query)[0]
+    idx, _column_identifiers = statement.token_next_by(i=(token_groups.Identifier))
+    _, table_identifier = statement.token_next_by(i=(token_groups.Identifier), idx=idx)
+
+    table = models.Table(table_identifier)
+    assert table.name == table_name


### PR DESCRIPTION
This was inspired by getting `JOIN`s to work being way too damn hard. I found myself wanting access to information, like table names and their relative positions to each other, in awkward parts of the code. Abstracting from the low-level SQL parsing and working with query objects to RDB structures within the query will hopefully take me a fair way toward simplifying some of the trickier query clauses.