### PR TITLE
Make sure that upcoming match is on different day from previous

### DIFF
--- a/tipping/src/tests/integration/models/test_match.py
+++ b/tipping/src/tests/integration/models/test_match.py
@@ -63,10 +63,29 @@ def test_from_future_fixtures(fauna_session):
         assert total_match_count == created_match_count
 
 
+def _get_matches_from_different_days(fixture_matches):
+    first_match = fixture_matches.iloc[0, :]
+    next_match_idx = np.random.randint(1, len(fixture_matches))
+    next_match = fixture_matches.iloc[next_match_idx, :]
+
+    while True:
+        if next_match["date"].to_pydatetime() > first_match[
+            "date"
+        ].to_pydatetime() + timedelta(days=1):
+            break
+
+        next_match_idx = next_match_idx + 1
+        assert next_match_idx < len(fixture_matches)
+
+        next_match = fixture_matches.iloc[next_match_idx, :]
+
+    return first_match, next_match
+
+
 def test_from_future_fixtures_with_skipped_round(fauna_session):
     fixture_matches = data_factories.fake_fixture_data()
-    first_match = fixture_matches.iloc[0, :]
-    next_match = fixture_matches.iloc[np.random.randint(1, len(fixture_matches)), :]
+    first_match, next_match = _get_matches_from_different_days(fixture_matches)
+
     patched_date = next_match["date"].to_pydatetime() - timedelta(days=1)
     upcoming_round_number = int(next_match["round_number"]) + 1
 


### PR DESCRIPTION
This test periodically doesn't raise the expected error, and I
think it's due to the next match being on the same day as the
first match, which would make the patched date the day before the
first match, which wouldn't raise, because the first match would
in fact be the next match. Since it's the first match of the fake
season, it would be saved in the DB without error.