### PR TITLE
Implement SQLQuery class for managing query tables

### DIFF
--- a/tipping/sqlalchemy-fauna/sqlalchemy_fauna/dbapi.py
+++ b/tipping/sqlalchemy-fauna/sqlalchemy_fauna/dbapi.py
@@ -128,7 +128,7 @@ class FaunaQuery:
             i=(token_groups.Identifier), idx=idx
         )
 
-        table = models.Table(table_identifier)
+        table = models.Table.from_identifier(table_identifier)
 
         _, column_identifiers = sql_statement.token_next_by(
             i=(

--- a/tipping/sqlalchemy-fauna/sqlalchemy_fauna/fauna/translation/alter.py
+++ b/tipping/sqlalchemy-fauna/sqlalchemy_fauna/fauna/translation/alter.py
@@ -61,7 +61,7 @@ def translate_alter(statement: token_groups.Statement) -> typing.List[QueryExpre
     assert table_keyword is not None
 
     idx, table_identifier = statement.token_next_by(i=token_groups.Identifier, idx=idx)
-    table = Table(table_identifier)
+    table = Table.from_identifier(table_identifier)
 
     _, second_alter = statement.token_next_by(m=(token_types.DDL, "ALTER"), idx=idx)
     _, column_keyword = statement.token_next_by(

--- a/tipping/sqlalchemy-fauna/sqlalchemy_fauna/fauna/translation/alter.py
+++ b/tipping/sqlalchemy-fauna/sqlalchemy_fauna/fauna/translation/alter.py
@@ -32,7 +32,7 @@ def _translate_alter_column(
     idx, column_identifier = statement.token_next_by(
         i=token_groups.Identifier, idx=starting_idx
     )
-    column = Column(column_identifier)
+    column = Column.from_identifier(column_identifier)
     table.add_column(column)
 
     _, drop = statement.token_next_by(m=(token_types.DDL, "DROP"), idx=idx)

--- a/tipping/sqlalchemy-fauna/sqlalchemy_fauna/fauna/translation/delete.py
+++ b/tipping/sqlalchemy-fauna/sqlalchemy_fauna/fauna/translation/delete.py
@@ -22,7 +22,7 @@ def translate_delete(statement: token_groups.Statement) -> typing.List[QueryExpr
     An FQL query expression.
     """
     idx, table_identifier = statement.token_next_by(i=token_groups.Identifier)
-    table = models.Table(table_identifier)
+    table = models.Table.from_identifier(table_identifier)
     _, where_group = statement.token_next_by(i=(token_groups.Where), idx=idx)
 
     records_to_delete = parse_where(where_group, table)

--- a/tipping/sqlalchemy-fauna/sqlalchemy_fauna/fauna/translation/delete.py
+++ b/tipping/sqlalchemy-fauna/sqlalchemy_fauna/fauna/translation/delete.py
@@ -21,10 +21,10 @@ def translate_delete(statement: token_groups.Statement) -> typing.List[QueryExpr
     --------
     An FQL query expression.
     """
-    idx, table_identifier = statement.token_next_by(i=token_groups.Identifier)
-    table = models.Table.from_identifier(table_identifier)
-    _, where_group = statement.token_next_by(i=(token_groups.Where), idx=idx)
+    sql_query = models.SQLQuery.from_statement(statement)
+    table = sql_query.tables[0]
 
+    _, where_group = statement.token_next_by(i=(token_groups.Where))
     records_to_delete = parse_where(where_group, table)
     delete_records = q.delete(q.select("ref", q.get(records_to_delete)))
 

--- a/tipping/sqlalchemy-fauna/sqlalchemy_fauna/fauna/translation/insert.py
+++ b/tipping/sqlalchemy-fauna/sqlalchemy_fauna/fauna/translation/insert.py
@@ -60,7 +60,7 @@ def translate_insert(statement: token_groups.Statement) -> typing.List[QueryExpr
         )
 
     func_idx, table_identifier = function_group.token_next_by(i=token_groups.Identifier)
-    table = models.Table(table_identifier)
+    table = models.Table.from_identifier(table_identifier)
 
     _, column_group = function_group.token_next_by(
         i=token_groups.Parenthesis, idx=func_idx

--- a/tipping/sqlalchemy-fauna/sqlalchemy_fauna/fauna/translation/insert.py
+++ b/tipping/sqlalchemy-fauna/sqlalchemy_fauna/fauna/translation/insert.py
@@ -52,28 +52,10 @@ def translate_insert(statement: token_groups.Statement) -> typing.List[QueryExpr
     --------
     An FQL query expression.
     """
-    idx, function_group = statement.token_next_by(i=token_groups.Function)
+    sql_query = models.SQLQuery.from_statement(statement)
+    table = sql_query.tables[0]
 
-    if function_group is None:
-        raise exceptions.NotSupportedError(
-            "INSERT INTO statements without column names are not currently supported."
-        )
-
-    func_idx, table_identifier = function_group.token_next_by(i=token_groups.Identifier)
-    table = models.Table.from_identifier(table_identifier)
-
-    _, column_group = function_group.token_next_by(
-        i=token_groups.Parenthesis, idx=func_idx
-    )
-    _, column_identifiers = column_group.token_next_by(
-        i=(token_groups.IdentifierList, token_groups.Identifier)
-    )
-
-    for column in models.Column.from_identifier_group(column_identifiers):
-        table.add_column(column)
-
-    idx, value_group = statement.token_next_by(i=token_groups.Values, idx=idx)
-
+    _, value_group = statement.token_next_by(i=token_groups.Values)
     document_to_insert = _build_document(table, value_group)
 
     # Fauna's Select doesn't play nice with null values, so we have to wrap it in an

--- a/tipping/sqlalchemy-fauna/sqlalchemy_fauna/fauna/translation/models.py
+++ b/tipping/sqlalchemy-fauna/sqlalchemy_fauna/fauna/translation/models.py
@@ -246,6 +246,9 @@ class SQLQuery:
         if first_token.match(token_types.DML, "INSERT"):
             return cls._build_insert_query(statement)
 
+        if first_token.match(token_types.DML, "DELETE"):
+            return cls._build_delete_query(statement)
+
         raise exceptions.NotSupportedError(f"Unsupported query type {first_token}")
 
     @classmethod
@@ -327,6 +330,13 @@ class SQLQuery:
 
         for column in Column.from_identifier_group(column_identifiers):
             table.add_column(column)
+
+        return cls(tables=[table])
+
+    @classmethod
+    def _build_delete_query(cls, statement: token_groups.Statement) -> SQLQuery:
+        _, table_identifier = statement.token_next_by(i=token_groups.Identifier)
+        table = Table.from_identifier(table_identifier)
 
         return cls(tables=[table])
 

--- a/tipping/sqlalchemy-fauna/sqlalchemy_fauna/fauna/translation/models.py
+++ b/tipping/sqlalchemy-fauna/sqlalchemy_fauna/fauna/translation/models.py
@@ -5,8 +5,7 @@ from __future__ import annotations
 import typing
 from functools import reduce
 
-from sqlparse import sql as token_groups
-from sqlparse import tokens as token_types
+from sqlparse import sql as token_groups, tokens as token_types
 
 from sqlalchemy_fauna import exceptions
 
@@ -149,21 +148,32 @@ class Table:
 
     Params:
     -------
-    identifier: Parsed SQL Identifier for a table name.
+    name: Name of the table.
     columns: Column objects that belong to the given table.
     """
 
-    def __init__(
-        self,
-        identifier: token_groups.Identifier,
-        columns: typing.Optional[typing.List[Column]] = None,
-    ):
-        self.name = identifier.value
+    def __init__(self, name: str, columns: typing.Optional[typing.List[Column]] = None):
+        self.name = name
         self._columns: typing.List[Column] = []
 
         columns = columns or []
         for column in columns:
             self.add_column(column)
+
+    @classmethod
+    def from_identifier(cls, identifier: token_groups.Identifier) -> Table:
+        """Extract table name from an SQL identifier.
+
+        Params:
+        -------
+        identifier: SQL token that contains the table's name.
+
+        Returns:
+        --------
+        A new Table object.
+        """
+        name = identifier.value
+        return cls(name=name)
 
     @property
     def columns(self) -> typing.List[Column]:

--- a/tipping/sqlalchemy-fauna/sqlalchemy_fauna/fauna/translation/select.py
+++ b/tipping/sqlalchemy-fauna/sqlalchemy_fauna/fauna/translation/select.py
@@ -491,7 +491,7 @@ def translate_select(statement: token_groups.Statement) -> typing.List[QueryExpr
             "Only one table per query is currently supported"
         )
 
-    table = Table(table_identifier)
+    table = Table.from_identifier(table_identifier)
 
     # TODO: As I've looked into INFORMATION_SCHEMA queries more, I realise
     # that these aren't returning valid responses for the given SQL queries,

--- a/tipping/sqlalchemy-fauna/sqlalchemy_fauna/fauna/translation/update.py
+++ b/tipping/sqlalchemy-fauna/sqlalchemy_fauna/fauna/translation/update.py
@@ -36,7 +36,7 @@ def translate_update(statement: token_groups.Statement) -> typing.List[QueryExpr
     idx, comparison_group = statement.token_next_by(i=token_groups.Comparison, idx=idx)
 
     _, update_column = comparison_group.token_next_by(i=token_groups.Identifier)
-    column = Column(update_column)
+    column = Column.from_identifier(update_column)
     table.add_column(column)
 
     idx, comparison = comparison_group.token_next_by(m=(token_types.Comparison, "="))

--- a/tipping/sqlalchemy-fauna/sqlalchemy_fauna/fauna/translation/update.py
+++ b/tipping/sqlalchemy-fauna/sqlalchemy_fauna/fauna/translation/update.py
@@ -9,7 +9,7 @@ from faunadb.objects import _Expr as QueryExpression
 
 from sqlalchemy_fauna import exceptions
 from .common import extract_value, parse_where
-from .models import Column, Table
+from .models import SQLQuery
 
 
 def translate_update(statement: token_groups.Statement) -> typing.List[QueryExpression]:
@@ -23,22 +23,10 @@ def translate_update(statement: token_groups.Statement) -> typing.List[QueryExpr
     --------
     An FQL query expression.
     """
-    idx, table_identifier = statement.token_next_by(i=token_groups.Identifier)
+    sql_query = SQLQuery.from_statement(statement)
+    table = sql_query.tables[0]
 
-    if table_identifier is None:
-        raise exceptions.NotSupportedError(
-            "Only one table per query is currently supported"
-        )
-
-    table = Table.from_identifier(table_identifier)
-
-    idx, _ = statement.token_next_by(m=(token_types.Keyword, "SET"), idx=idx)
-    idx, comparison_group = statement.token_next_by(i=token_groups.Comparison, idx=idx)
-
-    _, update_column = comparison_group.token_next_by(i=token_groups.Identifier)
-    column = Column.from_identifier(update_column)
-    table.add_column(column)
-
+    idx, comparison_group = statement.token_next_by(i=token_groups.Comparison)
     idx, comparison = comparison_group.token_next_by(m=(token_types.Comparison, "="))
 
     if comparison is None:

--- a/tipping/sqlalchemy-fauna/sqlalchemy_fauna/fauna/translation/update.py
+++ b/tipping/sqlalchemy-fauna/sqlalchemy_fauna/fauna/translation/update.py
@@ -30,7 +30,7 @@ def translate_update(statement: token_groups.Statement) -> typing.List[QueryExpr
             "Only one table per query is currently supported"
         )
 
-    table = Table(table_identifier)
+    table = Table.from_identifier(table_identifier)
 
     idx, _ = statement.token_next_by(m=(token_types.Keyword, "SET"), idx=idx)
     idx, comparison_group = statement.token_next_by(i=token_groups.Comparison, idx=idx)

--- a/tipping/sqlalchemy-fauna/tests/unit/translation/test_common.py
+++ b/tipping/sqlalchemy-fauna/tests/unit/translation/test_common.py
@@ -92,7 +92,7 @@ def test_parsing_unsupported_where(sql_query, error_message):
     statement = sqlparse.parse(sql_query)[0]
     idx, _ = statement.token_next_by(m=(token_types.Keyword, "FROM"))
     _, table_identifier = statement.token_next_by(i=(token_groups.Identifier), idx=idx)
-    table = models.Table(table_identifier)
+    table = models.Table.from_identifier(table_identifier)
     _, where_group = statement.token_next_by(i=(token_groups.Where))
 
     with pytest.raises(exceptions.NotSupportedError, match=error_message):
@@ -130,7 +130,7 @@ def test_parsing_where(sql_query):
     statement = sqlparse.parse(sql_query)[0]
     idx, _ = statement.token_next_by(m=(token_types.Keyword, "FROM"))
     _, table_identifier = statement.token_next_by(i=(token_groups.Identifier), idx=idx)
-    table = models.Table(table_identifier)
+    table = models.Table.from_identifier(table_identifier)
     _, where_group = statement.token_next_by(i=(token_groups.Where))
 
     fql_query = common.parse_where(where_group, table)

--- a/tipping/sqlalchemy-fauna/tests/unit/translation/test_select.py
+++ b/tipping/sqlalchemy-fauna/tests/unit/translation/test_select.py
@@ -16,8 +16,6 @@ partial_select_info_schema_columns = "SELECT * FROM INFORMATION_SCHEMA.COLUMNS"
 partial_select_info_schema_constraints = (
     "SELECT * FROM INFORMATION_SCHEMA.CONSTRAINT_TABLE_USAGE"
 )
-select_multiple_tables = "SELECT * FROM users, accounts"
-select_all = "SELECT * FROM users"
 select_sum = "SELECT sum(users.id) AS sum_1 from users"
 select_avg = "SELECT avg(users.id) AS avg_1 from users"
 
@@ -53,8 +51,6 @@ select_avg = "SELECT avg(users.id) AS avg_1 from users"
             partial_select_info_schema_constraints + " WHERE TABLE_NAME LIKE 'users'",
             "Only column-value-based conditions",
         ),
-        (select_multiple_tables, "Only one table per query is currently supported"),
-        (select_all, "Wildcards"),
         (select_sum, "SUM"),
         (select_avg, "AVG"),
     ],


### PR DESCRIPTION
In trying to implement translation of multi-table SQL queries with `JOIN` clauses, I ran into trouble trying to keep track of the positioning of tables within the joins and the keys on which to join them. Since this is information that doesn't fit cleanly within a `Table` object, I'm creating a higher-level object to keep track of these connections.