### PR TITLE
Add support for multi-table queries via JOIN clauses

### DIFF
--- a/tipping/sqlalchemy-fauna/README.md
+++ b/tipping/sqlalchemy-fauna/README.md
@@ -16,7 +16,5 @@ A Fauna dialect for SQLAlchemy
 
 For keeping track of next steps for extending SQL support. Not meant to be comprehensive.
 
-- Support `JOIN` for cross-table filtering & results
-  - Nest merged documents to avoid ones with the same field names  from different collections overwriting each other
 - Support `ON DELETE` strategies for foreign keys (currently is just `SET NULL` I suppose since the ref no longer exists)
 - Support `GROUP BY`

--- a/tipping/sqlalchemy-fauna/README.md
+++ b/tipping/sqlalchemy-fauna/README.md
@@ -17,5 +17,6 @@ A Fauna dialect for SQLAlchemy
 For keeping track of next steps for extending SQL support. Not meant to be comprehensive.
 
 - Support `JOIN` for cross-table filtering & results
+  - Nest merged documents to avoid ones with the same field names  from different collections overwriting each other
 - Support `ON DELETE` strategies for foreign keys (currently is just `SET NULL` I suppose since the ref no longer exists)
 - Support `GROUP BY`

--- a/tipping/sqlalchemy-fauna/sqlalchemy_fauna/fauna/translation/common.py
+++ b/tipping/sqlalchemy-fauna/sqlalchemy_fauna/fauna/translation/common.py
@@ -174,10 +174,7 @@ def index_name(
     ) or (column_name is None and index_type in [IndexType.ALL, IndexType.REF])
     assert is_valid_column_name
 
-    is_valid_foreign_key_name = (
-        foreign_key_name is None
-        and (index_type != IndexType.REF or column_name is None)
-    ) or (
+    is_valid_foreign_key_name = foreign_key_name is None or (
         foreign_key_name is not None
         and column_name is not None
         and index_type == IndexType.REF

--- a/tipping/sqlalchemy-fauna/sqlalchemy_fauna/fauna/translation/create.py
+++ b/tipping/sqlalchemy-fauna/sqlalchemy_fauna/fauna/translation/create.py
@@ -418,6 +418,15 @@ def _translate_create_table(
         # document refs
         is_foreign_key = any(field_data["references"])
         if is_foreign_key:
+            index_queries.append(
+                q.create_index(
+                    {
+                        "name": index_by_field(common.IndexType.REF),
+                        "source": q.collection(table_name),
+                        "terms": [{"field": ["data", field_name]}],
+                    }
+                )
+            )
             # We create a foreign ref index per foreign ref that exists in the collection,
             # because this permits us to access any foreign ref we may need to continue
             # a chain of joins.

--- a/tipping/sqlalchemy-fauna/sqlalchemy_fauna/fauna/translation/fql.py
+++ b/tipping/sqlalchemy-fauna/sqlalchemy_fauna/fauna/translation/fql.py
@@ -1,6 +1,8 @@
 """Parse WHERE clauses to generate comparable FQL queries."""
 
-from functools import partial
+import typing
+import functools
+
 from faunadb.objects import _Expr as QueryExpression
 from faunadb import query as q
 
@@ -8,10 +10,15 @@ from sqlalchemy_fauna import exceptions
 from . import models, common
 
 
+MAX_PAGE_SIZE = 100000
+
+
 def _define_match_set(query_filter: models.Filter) -> QueryExpression:
     field_name = query_filter.column.name
     comparison_value = query_filter.value
-    index_name_for_collection = partial(common.index_name, query_filter.table_name)
+    index_name_for_collection = functools.partial(
+        common.index_name, query_filter.table_name
+    )
 
     convert_to_ref_set = lambda index_match: q.join(
         index_match,
@@ -28,7 +35,7 @@ def _define_match_set(query_filter: models.Filter) -> QueryExpression:
         [common.DATA, "metadata", "fields"], q.get(q.collection(name))
     )
 
-    index_name_for_field = partial(index_name_for_collection, field_name)
+    index_name_for_field = functools.partial(index_name_for_collection, field_name)
     equality_range = q.range(
         q.match(q.index(index_name_for_field(common.IndexType.VALUE))),
         [comparison_value],
@@ -128,3 +135,115 @@ def define_document_set(table: models.Table) -> QueryExpression:
 
     document_sets = [_define_match_set(query_filter) for query_filter in filters]
     return q.intersection(*document_sets)
+
+
+def _build_merge(*table_names: str):
+    merge = lambda agg_merge, table_name: q.merge(
+        agg_merge, q.var(f"{table_name}_data")
+    )
+    return functools.reduce(merge, table_names, q.merge({}, {}))
+
+
+def _build_page_query(
+    table: models.Table,
+    merge_func: typing.Callable[[str], QueryExpression],
+):
+    build_base_page = lambda inner_query: q.select(
+        "data",
+        q.map_(
+            q.lambda_(f"{table.name}_ref", inner_query),
+            q.paginate(q.var(f"joined_{table.name}"), size=MAX_PAGE_SIZE),
+        ),
+    )
+
+    partial_merge_func = functools.partial(merge_func, table.name)
+    right_table = table.right_join_table
+    left_table = table.left_join_table
+
+    assert right_table is not None or left_table is not None, (
+        "At least two tables must be included in a join query. "
+        "If only querying one table, use `define_document_set` instead."
+    )
+
+    if right_table is None:
+        # The inner-most page doesn't need a Union, because there aren't nested pages
+        # to flatten
+        inner_query = q.let(
+            {
+                f"{table.name}_doc": q.get(q.var(f"{table.name}_ref")),
+                f"{table.name}_data": q.merge(
+                    q.select("data", q.var(f"{table.name}_doc")),
+                    {"ref": q.select("ref", q.var(f"{table.name}_doc"))},
+                ),
+            },
+            partial_merge_func(),
+        )
+        page = build_base_page(inner_query)
+    else:
+        page = q.union(
+            build_base_page(_build_page_query(right_table, partial_merge_func))
+        )
+
+    if left_table is None:
+        return q.let(
+            {
+                f"joined_{table.name}": define_document_set(table),
+            },
+            page,
+        )
+
+    left_join_key = table.left_join_key
+
+    if left_join_key == "id":
+        left_foreign_key = left_table.right_join_key
+        assert left_foreign_key is not None
+        return q.let(
+            {
+                f"{left_table.name}_doc": q.get(q.var(f"{left_table.name}_ref")),
+                f"{left_table.name}_data": q.merge(
+                    q.select("data", q.var(f"{left_table.name}_doc")),
+                    {"ref": q.select("ref", q.var(f"{left_table.name}_doc"))},
+                ),
+                f"{table.name}_ref": q.select(
+                    left_foreign_key.name, q.var(f"{left_table.name}_data")
+                ),
+                table.name: define_document_set(table),
+                f"joined_{table.name}": q.intersection(
+                    q.singleton(q.var(f"{table.name}_ref")), q.var(table.name)
+                ),
+            },
+            page,
+        )
+
+    left_foreign_key = left_join_key
+    assert left_foreign_key is not None
+    return q.let(
+        {
+            f"{left_table.name}_doc": q.get(q.var(f"{left_table.name}_ref")),
+            f"{left_table.name}_data": q.merge(
+                q.select("data", q.var(f"{left_table.name}_doc")),
+                {"ref": q.select("ref", q.var(f"{left_table.name}_doc"))},
+            ),
+            table.name: define_document_set(table),
+            f"joined_{table.name}": q.intersection(
+                q.match(
+                    q.index(f"{table.name}_by_{left_foreign_key.name}_ref"),
+                    q.var(f"{left_table.name}_ref"),
+                ),
+                q.var(table.name),
+            ),
+        },
+        page,
+    )
+
+
+def join_collections(left_most_table: models.Table) -> QueryExpression:
+    """Join together multiple collections to return their documents in the response.
+
+    Params:
+    -------
+    left_most_table: The first table in a chain of JOINS
+
+    """
+    assert left_most_table.left_join_table is None
+    return _build_page_query(left_most_table, _build_merge)

--- a/tipping/sqlalchemy-fauna/sqlalchemy_fauna/fauna/translation/fql.py
+++ b/tipping/sqlalchemy-fauna/sqlalchemy_fauna/fauna/translation/fql.py
@@ -139,7 +139,7 @@ def define_document_set(table: models.Table) -> QueryExpression:
 
 def _build_merge(*table_names: str):
     merge = lambda agg_merge, table_name: q.merge(
-        agg_merge, q.var(f"{table_name}_data")
+        agg_merge, {table_name: q.var(f"{table_name}_data")}
     )
     return functools.reduce(merge, table_names, q.merge({}, {}))
 

--- a/tipping/sqlalchemy-fauna/sqlalchemy_fauna/fauna/translation/fql.py
+++ b/tipping/sqlalchemy-fauna/sqlalchemy_fauna/fauna/translation/fql.py
@@ -44,11 +44,7 @@ def _define_match_set(query_filter: models.Filter) -> QueryExpression:
 
         return q.let(
             {
-                "ref_index": q.index(
-                    index_name_for_field(
-                        common.IndexType.REF, foreign_key_name=field_name
-                    )
-                ),
+                "ref_index": q.index(index_name_for_field(common.IndexType.REF)),
                 "term_index": q.index(index_name_for_field(common.IndexType.TERM)),
                 "references": q.select(
                     [field_name, "references"],
@@ -59,12 +55,10 @@ def _define_match_set(query_filter: models.Filter) -> QueryExpression:
             },
             q.if_(
                 q.exists(q.var("ref_index")),
-                convert_to_ref_set(
-                    q.match(
-                        q.var("ref_index"),
-                        common.get_foreign_key_ref(
-                            q.var("comparison_value"), q.var("references")
-                        ),
+                q.match(
+                    q.var("ref_index"),
+                    common.get_foreign_key_ref(
+                        q.var("comparison_value"), q.var("references")
                     ),
                 ),
                 q.if_(

--- a/tipping/sqlalchemy-fauna/sqlalchemy_fauna/fauna/translation/select.py
+++ b/tipping/sqlalchemy-fauna/sqlalchemy_fauna/fauna/translation/select.py
@@ -172,9 +172,8 @@ def _translate_select_with_functions(
     )
 
 
-def _translate_select_without_functions(
-    tables: typing.List[models.Table], distinct=False
-):
+def _translate_select_without_functions(sql_query: models.SQLQuery, distinct=False):
+    tables = sql_query.tables
     from_table = tables[0]
     if len(tables) > 1:
         documents_to_select = fql.join_collections(from_table)
@@ -185,8 +184,8 @@ def _translate_select_without_functions(
 
     initial_field_alias_map: typing.Dict[str, str] = {}
     field_alias_map = functools.reduce(
-        lambda alias_map, table: {**alias_map, **table.column_alias_map},
-        tables,
+        lambda alias_map, column: {**alias_map, **column.alias_map},
+        sql_query.columns,
         initial_field_alias_map,
     )
 
@@ -291,7 +290,7 @@ def _translate_select_from_table(
 
             return _translate_select_with_functions(table, field_functions)
 
-    return _translate_select_without_functions(tables, distinct=sql_query.distinct)
+    return _translate_select_without_functions(sql_query, distinct=sql_query.distinct)
 
 
 def _translate_select_from_info_schema_constraints(

--- a/tipping/sqlalchemy-fauna/tests/integration/test_sqlalchemy_fauna.py
+++ b/tipping/sqlalchemy-fauna/tests/integration/test_sqlalchemy_fauna.py
@@ -495,3 +495,33 @@ def test_select_is_null(fauna_session, user_model):
 
     assert len(queried_users) == 1
     assert queried_users[0].job is None
+
+
+def test_join(fauna_session, parent_child):
+    Base = parent_child["base"]
+    fauna_engine = fauna_session.get_bind()
+    Base.metadata.create_all(fauna_engine)
+
+    Parent = parent_child["parent"]
+    Child = parent_child["child"]
+
+    parents = [
+        ("Bob", ["Louise", "Tina", "Gene"]),
+        ("Jimmy", ["Jimmy Jr.", "Ollie", "Andy"]),
+    ]
+
+    for parent_name, child_names in parents:
+        parent = Parent(name=parent_name)
+        fauna_session.add(parent)
+
+        for child_name in child_names:
+            child = Child(name=child_name, parent=parent)
+            fauna_session.add(child)
+
+    queried_parent_children = fauna_session.execute(
+        select(Parent.id, Child.name)
+        .join(Parent.children)
+        .where(Child.name == "Louise")
+    )
+
+    assert len(list(queried_parent_children)) == 1

--- a/tipping/sqlalchemy-fauna/tests/integration/test_sqlalchemy_fauna.py
+++ b/tipping/sqlalchemy-fauna/tests/integration/test_sqlalchemy_fauna.py
@@ -518,10 +518,12 @@ def test_join(fauna_session, parent_child):
             child = Child(name=child_name, parent=parent)
             fauna_session.add(child)
 
-    queried_parent_children = fauna_session.execute(
-        select(Parent.id, Child.name)
-        .join(Parent.children)
-        .where(Child.name == "Louise")
+    result = fauna_session.execute(
+        select(Parent, Child).join(Parent.children).where(Child.name == "Louise")
     )
+    rows = list(result)
 
-    assert len(list(queried_parent_children)) == 1
+    assert len(rows) == 1
+    queried_parent, queried_child = rows[0]
+    assert queried_child.name == "Louise"
+    assert queried_parent.name == queried_child.parent.name

--- a/tipping/sqlalchemy-fauna/tests/unit/translation/test_models.py
+++ b/tipping/sqlalchemy-fauna/tests/unit/translation/test_models.py
@@ -159,7 +159,7 @@ def test_sql_add_filter_to_table():
 
 
 @pytest.mark.parametrize("distinct", ["DISTINCT", ""])
-def test_sql_query_from_statement(distinct):
+def test_sql_query_from_statement_distinct(distinct):
     table_name = "users"
     column_name = "name"
     sql_string = f"SELECT {distinct} users.{column_name} FROM {table_name}"
@@ -171,6 +171,27 @@ def test_sql_query_from_statement(distinct):
     assert table.name == table_name
     assert column.name == column_name
     assert sql_query.distinct == bool(distinct)
+
+
+@pytest.mark.parametrize(
+    "sql_string",
+    [
+        (
+            "SELECT users.id, users.name, users.date_joined, users.age, users.finger_count "
+            "FROM users"
+        ),
+        "INSERT INTO users (name, age, finger_count) VALUES ('Bob', 30, 10)",
+        "DELETE FROM users",
+        "UPDATE users SET users.name = 'Bob'",
+    ],
+)
+def test_sql_query_from_statement(sql_string):
+    table_name = "users"
+    statement = sqlparse.parse(sql_string)[0]
+
+    sql_query = models.SQLQuery.from_statement(statement)
+    table = sql_query.tables[0]
+    assert table.name == table_name
 
 
 @pytest.mark.parametrize(

--- a/tipping/sqlalchemy-fauna/tests/unit/translation/test_select.py
+++ b/tipping/sqlalchemy-fauna/tests/unit/translation/test_select.py
@@ -53,6 +53,10 @@ select_avg = "SELECT avg(users.id) AS avg_1 from users"
         ),
         (select_sum, "SUM"),
         (select_avg, "AVG"),
+        (
+            "SELECT COUNT(users.id) FROM users JOIN accounts ON users.id = accounts.user_id",
+            "SQL functions across multiple tables are not yet supported",
+        ),
     ],
 )
 def test_translating_unsupported_select(sql_query, error_message):
@@ -75,10 +79,14 @@ select_aliases = (
 )
 select_where_equals = select_values + " WHERE users.name = 'Bob'"
 select_count = "SELECT count(users.id) AS count_1 FROM users"
+select_join = (
+    "SELECT users.name, accounts.number FROM users "
+    "JOIN accounts ON users.id = accounts.user_id"
+)
 
 
 @pytest.mark.parametrize(
-    "sql_query",
+    "sql_string",
     [
         select_info_schema_tables,
         select_info_schema_columns,
@@ -87,10 +95,11 @@ select_count = "SELECT count(users.id) AS count_1 FROM users"
         select_aliases,
         select_where_equals,
         select_count,
+        select_join,
     ],
 )
-def test_translate_select(sql_query):
-    fql_queries = select.translate_select(sqlparse.parse(sql_query)[0])
+def test_translate_select(sql_string):
+    fql_queries = select.translate_select(sqlparse.parse(sql_string)[0])
 
     for fql_query in fql_queries:
         assert isinstance(fql_query, QueryExpression)


### PR DESCRIPTION
Multi-table queries is basic functionality that the Fauna dialect needs. Otherwise, we'd end up making multiple, expensive calls to the DB and stitching together the results in-memory, which is terribly inefficient. I settled on forcing use of `JOIN` in multi-table queries for now, because it's usually preferable to N+1 queries, and only supporting inner joins for now, since that's typically the type that I use.

There are a few ways to re-create join functionality in Fauna. I ~~went with~~ tried using the `Join` function and combining the different combinations required to get all the queried document fields, but couldn't figure out how to maintain document associations without the nested maps. I feel like there has to be a better way to do this, but NoSQL DBs aren't known for their elegant joins, so maybe not.