### PR TITLE
Update index definition to support more-flexible join queries

### DIFF
--- a/tipping/scripts/reset_fauna_data.py
+++ b/tipping/scripts/reset_fauna_data.py
@@ -64,7 +64,7 @@ def _execute_with_retries(query, retries=0):
 def _print_document_counts():
     print("\nDocument counts by collection")
     for collection in COLLECTIONS:
-        result = _execute_with_retries(q.count(q.match(q.index(f"all_{collection}"))))
+        result = _execute_with_retries(q.count(q.match(q.index(f"{collection}_all"))))
         print(f"\t{collection}: {result}")
 
 
@@ -237,7 +237,7 @@ def _assign_ids_to_teams(teams):
     result = _execute_with_retries(
         q.map_(
             q.lambda_("team", q.get(q.var("team"))),
-            q.paginate(q.match(q.index("all_teams"))),
+            q.paginate(q.match(q.index("teams_all"))),
         )
     )
     team_documents = result["data"]

--- a/tipping/sqlalchemy-fauna/sqlalchemy_fauna/fauna/translation/common.py
+++ b/tipping/sqlalchemy-fauna/sqlalchemy_fauna/fauna/translation/common.py
@@ -1,5 +1,6 @@
 """Shared SQL translations and utilities for various statement types."""
 
+import enum
 import typing
 import re
 from datetime import datetime, timezone
@@ -35,6 +36,15 @@ DATA = "data"
 
 class _NumericString(Exception):
     pass
+
+
+class IndexType(enum.Enum):
+    """Enum for the different types of Fauna indices used."""
+
+    ALL = "all"
+    REF = "ref"
+    TERM = "term"
+    VALUE = "value"
 
 
 def _parse_date_value(value):
@@ -142,3 +152,26 @@ def get_foreign_key_ref(
             q.ref(q.collection(q.var("reference_collection")), foreign_value),
         ),
     )
+
+
+def index_name(
+    table_name: str,
+    column_name: typing.Optional[str] = None,
+    index_type: IndexType = IndexType.ALL,
+) -> str:
+    """Get index name based on its configuration and internal conventions.
+
+    Params:
+    -------
+    table_name: Name of the index's source collection as represented by the SQL table.
+    column_name: Name of the column whose values are used to match index terms or values.
+    index_type: Internal convention that determines how the index matches documents
+        and what values are returned.
+    """
+    assert (column_name is not None and index_type != IndexType.ALL) or (
+        column_name is None and index_type in [IndexType.ALL, IndexType.REF]
+    )
+
+    column_substring = "" if column_name is None else f"_by_{column_name}"
+    index_type_substring = f"_{index_type.value}"
+    return table_name + column_substring + index_type_substring

--- a/tipping/sqlalchemy-fauna/sqlalchemy_fauna/fauna/translation/common.py
+++ b/tipping/sqlalchemy-fauna/sqlalchemy_fauna/fauna/translation/common.py
@@ -158,6 +158,7 @@ def index_name(
     table_name: str,
     column_name: typing.Optional[str] = None,
     index_type: IndexType = IndexType.ALL,
+    foreign_key_name: typing.Optional[str] = None,
 ) -> str:
     """Get index name based on its configuration and internal conventions.
 
@@ -168,10 +169,24 @@ def index_name(
     index_type: Internal convention that determines how the index matches documents
         and what values are returned.
     """
-    assert (column_name is not None and index_type != IndexType.ALL) or (
-        column_name is None and index_type in [IndexType.ALL, IndexType.REF]
+    is_valid_column_name = (
+        column_name is not None and index_type != IndexType.ALL
+    ) or (column_name is None and index_type in [IndexType.ALL, IndexType.REF])
+    assert is_valid_column_name
+
+    is_valid_foreign_key_name = (
+        foreign_key_name is None
+        and (index_type != IndexType.REF or column_name is None)
+    ) or (
+        foreign_key_name is not None
+        and column_name is not None
+        and index_type == IndexType.REF
     )
+    assert is_valid_foreign_key_name
 
     column_substring = "" if column_name is None else f"_by_{column_name}"
     index_type_substring = f"_{index_type.value}"
-    return table_name + column_substring + index_type_substring
+    foreign_key_substring = (
+        "" if foreign_key_name is None else f"_to_{foreign_key_name}"
+    )
+    return table_name + column_substring + index_type_substring + foreign_key_substring

--- a/tipping/sqlalchemy-fauna/sqlalchemy_fauna/fauna/translation/fql.py
+++ b/tipping/sqlalchemy-fauna/sqlalchemy_fauna/fauna/translation/fql.py
@@ -44,7 +44,11 @@ def _define_match_set(query_filter: models.Filter) -> QueryExpression:
 
         return q.let(
             {
-                "ref_index": q.index(index_name_for_field(common.IndexType.REF)),
+                "ref_index": q.index(
+                    index_name_for_field(
+                        common.IndexType.REF, foreign_key_name=field_name
+                    )
+                ),
                 "term_index": q.index(index_name_for_field(common.IndexType.TERM)),
                 "references": q.select(
                     [field_name, "references"],
@@ -55,10 +59,12 @@ def _define_match_set(query_filter: models.Filter) -> QueryExpression:
             },
             q.if_(
                 q.exists(q.var("ref_index")),
-                q.match(
-                    q.var("ref_index"),
-                    common.get_foreign_key_ref(
-                        q.var("comparison_value"), q.var("references")
+                convert_to_ref_set(
+                    q.match(
+                        q.var("ref_index"),
+                        common.get_foreign_key_ref(
+                            q.var("comparison_value"), q.var("references")
+                        ),
                     ),
                 ),
                 q.if_(

--- a/tipping/sqlalchemy-fauna/sqlalchemy_fauna/fauna/translation/fql.py
+++ b/tipping/sqlalchemy-fauna/sqlalchemy_fauna/fauna/translation/fql.py
@@ -71,7 +71,7 @@ def _define_match_set(query_filter: models.Filter) -> QueryExpression:
                     q.exists(q.var("term_index")),
                     q.match(
                         q.var("term_index"),
-                        comparison_value,
+                        q.var("comparison_value"),
                     ),
                     convert_to_ref_set(equality_range),
                 ),

--- a/tipping/sqlalchemy-fauna/sqlalchemy_fauna/fauna/translation/fql.py
+++ b/tipping/sqlalchemy-fauna/sqlalchemy_fauna/fauna/translation/fql.py
@@ -1,5 +1,6 @@
 """Parse WHERE clauses to generate comparable FQL queries."""
 
+from functools import partial
 from faunadb.objects import _Expr as QueryExpression
 from faunadb import query as q
 
@@ -10,12 +11,16 @@ from . import models, common
 def _define_match_set(query_filter: models.Filter) -> QueryExpression:
     field_name = query_filter.column.name
     comparison_value = query_filter.value
+    index_name_for_collection = partial(common.index_name, query_filter.table_name)
 
     convert_to_ref_set = lambda index_match: q.join(
         index_match,
         q.lambda_(
             ["value", "ref"],
-            q.match(q.index(f"{query_filter.table_name}_by_ref_terms"), q.var("ref")),
+            q.match(
+                q.index(index_name_for_collection(index_type=common.IndexType.REF)),
+                q.var("ref"),
+            ),
         ),
     )
 
@@ -23,8 +28,9 @@ def _define_match_set(query_filter: models.Filter) -> QueryExpression:
         [common.DATA, "metadata", "fields"], q.get(q.collection(name))
     )
 
+    index_name_for_field = partial(index_name_for_collection, field_name)
     equality_range = q.range(
-        q.match(q.index(f"{query_filter.table_name}_by_{field_name}")),
+        q.match(q.index(index_name_for_field(common.IndexType.VALUE))),
         [comparison_value],
         [comparison_value],
     )
@@ -38,10 +44,8 @@ def _define_match_set(query_filter: models.Filter) -> QueryExpression:
 
         return q.let(
             {
-                "ref_index": q.index(f"{query_filter.table_name}_by_{field_name}_refs"),
-                "term_index": q.index(
-                    f"{query_filter.table_name}_by_{field_name}_terms"
-                ),
+                "ref_index": q.index(index_name_for_field(common.IndexType.REF)),
+                "term_index": q.index(index_name_for_field(common.IndexType.TERM)),
                 "references": q.select(
                     [field_name, "references"],
                     get_collection_fields(query_filter.table_name),
@@ -75,7 +79,7 @@ def _define_match_set(query_filter: models.Filter) -> QueryExpression:
     # all query translation, so I'm leaving this note as a warning.
     if query_filter.operator in [">=", ">"]:
         inclusive_comparison_range = q.range(
-            q.match(q.index(f"{query_filter.table_name}_by_{field_name}")),
+            q.match(q.index(index_name_for_field(common.IndexType.VALUE))),
             [comparison_value],
             [],
         )
@@ -89,7 +93,7 @@ def _define_match_set(query_filter: models.Filter) -> QueryExpression:
 
     if query_filter.operator in ["<=", "<"]:
         inclusive_comparison_range = q.range(
-            q.match(q.index(f"{query_filter.table_name}_by_{field_name}")),
+            q.match(q.index(index_name_for_field(common.IndexType.VALUE))),
             [],
             [comparison_value],
         )
@@ -120,7 +124,7 @@ def define_document_set(table: models.Table) -> QueryExpression:
     filters = table.filters
 
     if not any(filters):
-        return q.intersection(q.match(q.index(f"all_{table.name}")))
+        return q.intersection(q.match(q.index(common.index_name(table.name))))
 
     document_sets = [_define_match_set(query_filter) for query_filter in filters]
     return q.intersection(*document_sets)

--- a/tipping/sqlalchemy-fauna/tests/integration/test_dialect.py
+++ b/tipping/sqlalchemy-fauna/tests/integration/test_dialect.py
@@ -7,6 +7,7 @@ from sqlalchemy.ext.declarative import declarative_base
 from sqlalchemy import Column, Integer, String, DateTime, Boolean, Float
 
 from sqlalchemy_fauna import dialect
+from sqlalchemy_fauna.fauna.translation import common
 
 
 @pytest.fixture()
@@ -79,8 +80,10 @@ def test_get_indexes(user_model, fauna_engine):
         queried_indexes = fauna_dialect.get_indexes(connection, "users")
         index_names = {index["name"] for index in queried_indexes}
         expected_index_names = [
-            f"users_by_{col}" for col in users_columns if col != "id"
-        ] + ["all_users", "users_by_ref_terms", "users_by_name_terms"]
+            common.index_name("users", col, common.IndexType.VALUE)
+            for col in users_columns
+            if col != "id"
+        ] + ["users_all", "users_ref", "users_by_name_term"]
 
         assert index_names == set(expected_index_names)
 

--- a/tipping/sqlalchemy-fauna/tests/integration/test_sqlalchemy_fauna.py
+++ b/tipping/sqlalchemy-fauna/tests/integration/test_sqlalchemy_fauna.py
@@ -108,7 +108,7 @@ def test_create_index(fauna_engine):
     name_index = None
 
     for index in indexes:
-        if index["name"] == "users_by_name":
+        if index["name"] == "users_by_name_value":
             name_index = index
             break
 

--- a/tipping/sqlalchemy-fauna/tests/unit/translation/test_common.py
+++ b/tipping/sqlalchemy-fauna/tests/unit/translation/test_common.py
@@ -3,23 +3,20 @@
 from datetime import timezone
 
 import pytest
-from sqlparse import sql as token_groups
-from sqlparse import tokens as token_types
+from sqlparse import sql as token_groups, tokens as token_types
 from faker import Faker
-import sqlparse
 from faunadb.objects import _Expr as QueryExpression
 from faunadb import query as q
 
-from sqlalchemy_fauna import exceptions
-from sqlalchemy_fauna.fauna.translation import common, models
+from sqlalchemy_fauna.fauna.translation import common
 
-FAKE = Faker()
+Fake = Faker()
 
-word = FAKE.word()
-integer = FAKE.pyint()
-float_number = FAKE.pyfloat()
-fake_datetime = FAKE.date_time_this_year(tzinfo=timezone.utc)
-naive_datetime = FAKE.date_time_this_year()
+word = Fake.word()
+integer = Fake.pyint()
+float_number = Fake.pyfloat()
+fake_datetime = Fake.date_time_this_year(tzinfo=timezone.utc)
+naive_datetime = Fake.date_time_this_year()
 
 
 @pytest.mark.parametrize(
@@ -53,8 +50,28 @@ def test_extract_value(_label, token_value, expected):
 
 def test_get_foreign_key_ref():
     fql_query = q.let(
-        {"references": {}, "foreign_key": FAKE.credit_card_number()},
+        {"references": {}, "foreign_key": Fake.credit_card_number()},
         common.get_foreign_key_ref(q.var("foreign_key"), q.var("references")),
     )
 
     assert isinstance(fql_query, QueryExpression)
+
+
+@pytest.mark.parametrize(
+    ["params", "expected_name"],
+    [
+        (("users",), "users_all"),
+        (("users", None, common.IndexType.REF), "users_ref"),
+        (("users", "name", common.IndexType.TERM), "users_by_name_term"),
+    ],
+)
+def test_index_name(params, expected_name):
+    assert common.index_name(*params) == expected_name
+
+
+@pytest.mark.parametrize(
+    "params", [("users", "name"), ("users", None, common.IndexType.VALUE)]
+)
+def test_invalid_index_name(params):
+    with pytest.raises(AssertionError):
+        common.index_name(*params)

--- a/tipping/sqlalchemy-fauna/tests/unit/translation/test_common.py
+++ b/tipping/sqlalchemy-fauna/tests/unit/translation/test_common.py
@@ -63,6 +63,7 @@ def test_get_foreign_key_ref():
         (("users",), "users_all"),
         (("users", None, common.IndexType.REF), "users_ref"),
         (("users", "name", common.IndexType.TERM), "users_by_name_term"),
+        (("users", "name", common.IndexType.REF, "age"), "users_by_name_ref_to_age"),
     ],
 )
 def test_index_name(params, expected_name):
@@ -70,7 +71,13 @@ def test_index_name(params, expected_name):
 
 
 @pytest.mark.parametrize(
-    "params", [("users", "name"), ("users", None, common.IndexType.VALUE)]
+    "params",
+    [
+        ("users", "name"),
+        ("users", None, common.IndexType.VALUE),
+        ("users", None, common.IndexType.REF, "age"),
+        ("users", "name", common.IndexType.VALUE, "age"),
+    ],
 )
 def test_invalid_index_name(params):
     with pytest.raises(AssertionError):


### PR DESCRIPTION
My idea for multi-directional `Join` via FQL ran into a snag, because the foreign-ref indices need to return all possible refs (both for the source collection and its foreign refs), so that we can join going from left to right as well as right to left, from parent to child as well as child to parent. This doesn't currently work, because you can't call `Get` inside a `Lambda` in order to dynamically populate the expected params, which we would need to do if we just had one index with multiple values per foreign reference.

This PR will require a reset of the prod DB in order to update the indices.