### PR TITLE
Add updating of match results in Fauna DB

### DIFF
--- a/backend/server/models/match.py
+++ b/backend/server/models/match.py
@@ -225,10 +225,6 @@ class Match(models.Model):
     def has_been_played(self):
         """Return whether a match has been played yet."""
         match_end_time = self.start_date_time + timedelta(hours=GAME_LENGTH_HRS)
-
-        # We need to check the scores in case the data hasn't been updated since the
-        # match was played, because as far as the data is concerned it hasn't, even though
-        # the date has passed.
         return match_end_time < timezone.localtime()
 
     @property

--- a/tipping/sqlalchemy-fauna/tests/integration/test_sqlalchemy_fauna.py
+++ b/tipping/sqlalchemy-fauna/tests/integration/test_sqlalchemy_fauna.py
@@ -628,3 +628,29 @@ def test_update(fauna_session, user_model):
 
     assert queried_user.name == new_name
     assert queried_user.age == new_age
+
+
+def test_multiple_update(fauna_session, user_model):
+    User, Base = user_model
+    fauna_engine = fauna_session.get_bind()
+    Base.metadata.create_all(fauna_engine)
+
+    user_count = 5
+    users = [User(name=Fake.first_name(), age=Fake.pyint()) for _ in range(user_count)]
+
+    for user in users:
+        fauna_session.add(user)
+
+    fauna_session.commit()
+
+    new_names = []
+    for user in users:
+        new_name = Fake.first_name()
+        user.name = new_name
+        new_names.append(new_name)
+
+    fauna_session.commit()
+
+    queried_users = fauna_session.execute(sql.select(User)).scalars().all()
+    for user in queried_users:
+        assert user.name in new_names

--- a/tipping/src/tests/fixtures/data_factories.py
+++ b/tipping/src/tests/fixtures/data_factories.py
@@ -16,28 +16,12 @@ FAKE = Faker()
 
 MATCH_RESULTS_COLS = [
     "date",
-    "tz",
-    "updated",
-    "round",
-    "roundname",
     "year",
-    "hbehinds",
-    "hgoals",
-    "hscore",
-    "hteam",
-    "hteamid",
-    "abehinds",
-    "agoals",
-    "ascore",
-    "ateam",
-    "ateamid",
-    "winner",
-    "winnerteamid",
-    "is_grand_final",
-    "complete",
-    "is_final",
-    "id",
-    "venue",
+    "round_number",
+    "home_score",
+    "home_team",
+    "away_score",
+    "away_team",
 ]
 
 TEAM_TYPES = ("home", "away")
@@ -126,43 +110,9 @@ def fake_match_results_data(
         len(match_results["year"].drop_duplicates()) == 1
     ), "Match results data is fetched one season at a time."
 
-    return (
-        match_results.query("round_number == @round_number")
-        .assign(
-            updated=lambda df: pd.to_datetime(df["date"]) + timedelta(hours=3),
-            tz="+10:00",
-            # AFLTables match_results already have a 'round' column,
-            # so we have to replace rather than rename.
-            round=lambda df: df["round_number"],
-            roundname=lambda df: "Round " + df["round_number"].astype(str),
-            hteam=lambda df: df["home_team"].map(
-                lambda team: settings.TEAM_TRANSLATIONS.get(team, team)
-            ),
-            ateam=lambda df: df["away_team"].map(
-                lambda team: settings.TEAM_TRANSLATIONS.get(team, team)
-            ),
-            hteamid=lambda df: df["hteam"].map(settings.TEAM_NAMES.index),
-            ateamid=lambda df: df["ateam"].map(settings.TEAM_NAMES.index),
-            winner=lambda df: np.where(df["margin"] >= 0, df["hteam"], df["ateam"]),
-            winnerteamid=lambda df: df["winner"].map(settings.TEAM_NAMES.index),
-            is_grand_final=0,
-            complete=100,
-            is_final=0,
-        )
-        .astype({"updated": str})
-        .reset_index(drop=False)
-        .rename(
-            columns={
-                "index": "id",
-                "home_behinds": "hbehinds",
-                "home_goals": "hgoals",
-                "away_behinds": "abehinds",
-                "away_goals": "agoals",
-                "home_score": "hscore",
-                "away_score": "ascore",
-            }
-        )
-    ).loc[:, MATCH_RESULTS_COLS]
+    return (match_results.query("round_number == @round_number")).loc[
+        :, MATCH_RESULTS_COLS
+    ]
 
 
 def _build_team_matches(match_data: pd.DataFrame, team_type: str) -> pd.DataFrame:

--- a/tipping/src/tests/fixtures/data_factories.py
+++ b/tipping/src/tests/fixtures/data_factories.py
@@ -1,7 +1,6 @@
 """Module for factory functions that create raw data objects."""
 
 from typing import Tuple, Union, Optional
-from datetime import timedelta
 
 from faker import Faker
 import numpy as np
@@ -53,7 +52,12 @@ def fake_match_data(
             }
         )
         # Recreates data cleaning performed in data_import
-        .assign(date=lambda df: pd.to_datetime(df["date"], utc=True))
+        .assign(
+            date=lambda df: pd.to_datetime(df["date"], utc=True),
+            # Team name translations happen in augury's data pipeline
+            home_team=_translate_team_names("home"),
+            away_team=_translate_team_names("away"),
+        )
     )
 
 

--- a/tipping/src/tests/integration/models/test_match.py
+++ b/tipping/src/tests/integration/models/test_match.py
@@ -106,6 +106,9 @@ def test_from_future_fixtures_with_skipped_round(fauna_session):
             Match.from_future_fixtures(
                 fauna_session, fixture_matches, upcoming_round_number
             )
+            # Logging to catch cause of flaky test
+            print(first_match)
+            print(next_match)
 
 
 def test_played_without_results(fauna_session):

--- a/tipping/src/tests/integration/models/test_match.py
+++ b/tipping/src/tests/integration/models/test_match.py
@@ -4,22 +4,22 @@ from datetime import timedelta, timezone, datetime
 
 import numpy as np
 from faker import Faker
-from sqlalchemy import select, func
+from sqlalchemy import select, func, sql
 from freezegun import freeze_time
 import pytest
 
 from tests.fixtures import data_factories
-from tipping.models.match import Match, TeamMatch, Team
+from tipping import models
 
 
-FAKE = Faker()
+Fake = Faker()
 
 
 def test_match_creation(fauna_session):
-    match = Match(
-        start_date_time=FAKE.date_time(tzinfo=timezone.utc),
+    match = models.Match(
+        start_date_time=Fake.date_time(tzinfo=timezone.utc),
         round_number=np.random.randint(1, 100),
-        venue=FAKE.company(),
+        venue=Fake.company(),
     )
     fauna_session.add(match)
     fauna_session.commit()
@@ -37,9 +37,9 @@ def test_from_future_fixtures(fauna_session):
     )
 
     with freeze_time(patched_date):
-        assert fauna_session.execute(select(func.count(Match.id))).scalar() == 0
+        assert fauna_session.execute(select(func.count(models.Match.id))).scalar() == 0
 
-        matches = Match.from_future_fixtures(
+        matches = models.Match.from_future_fixtures(
             fauna_session, upcoming_fixture_matches, upcoming_round_number
         )
         created_match_count = len(matches)
@@ -54,12 +54,14 @@ def test_from_future_fixtures(fauna_session):
         fauna_session.commit()
 
         # With existing matches in DB
-        matches = Match.from_future_fixtures(
+        matches = models.Match.from_future_fixtures(
             fauna_session, upcoming_fixture_matches, upcoming_round_number
         )
 
         assert len(matches) == 0
-        total_match_count = fauna_session.execute(select(func.count(Match.id))).scalar()
+        total_match_count = fauna_session.execute(
+            select(func.count(models.Match.id))
+        ).scalar()
         assert total_match_count == created_match_count
 
 
@@ -90,7 +92,7 @@ def test_from_future_fixtures_with_skipped_round(fauna_session):
     upcoming_round_number = int(next_match["round_number"]) + 1
 
     fauna_session.add(
-        Match(
+        models.Match(
             start_date_time=first_match["date"].to_pydatetime(),
             round_number=first_match["round_number"],
             venue=first_match["venue"],
@@ -103,7 +105,7 @@ def test_from_future_fixtures_with_skipped_round(fauna_session):
             AssertionError,
             match="Expected upcoming round number to be 1 greater than previous round",
         ):
-            Match.from_future_fixtures(
+            models.Match.from_future_fixtures(
                 fauna_session, fixture_matches, upcoming_round_number
             )
             # Logging to catch cause of flaky test
@@ -113,32 +115,36 @@ def test_from_future_fixtures_with_skipped_round(fauna_session):
 
 def test_played_without_results(fauna_session):
     right_now = datetime.now(tz=timezone.utc)
-    two_teams = fauna_session.execute(select(Team).limit(2)).scalars().all()
+    two_teams = fauna_session.execute(select(models.Team).limit(2)).scalars().all()
 
-    played_with_results = Match(
+    played_with_results = models.Match(
         start_date_time=right_now - timedelta(days=3),
-        venue=FAKE.company(),
+        venue=Fake.company(),
         round_number=1,
     )
     for team in two_teams:
         played_with_results.team_matches.append(
-            TeamMatch(team=team, score=np.random.randint(1, 150))
+            models.TeamMatch(team=team, score=np.random.randint(1, 150))
         )
 
     resultless_matches = []
     for n in range(2):
-        played_without_results = Match(
+        played_without_results = models.Match(
             start_date_time=right_now - timedelta(days=(n + 2)),
-            venue=FAKE.company(),
+            venue=Fake.company(),
             round_number=(n + 2),
         )
         for team in two_teams:
-            played_without_results.team_matches.append(TeamMatch(team=team, score=None))
+            played_without_results.team_matches.append(
+                models.TeamMatch(team=team, score=None)
+            )
         resultless_matches.append(played_without_results)
 
-    unplayed = Match(start_date_time=right_now, venue=FAKE.company(), round_number=4)
+    unplayed = models.Match(
+        start_date_time=right_now, venue=Fake.company(), round_number=4
+    )
     for team in two_teams:
-        unplayed.team_matches.append(TeamMatch(team=team, score=None))
+        unplayed.team_matches.append(models.TeamMatch(team=team, score=None))
 
     fauna_session.add(played_with_results)
     for resultless_match in resultless_matches:
@@ -146,7 +152,7 @@ def test_played_without_results(fauna_session):
     fauna_session.add(unplayed)
     fauna_session.commit()
 
-    match_query = Match.played_without_results()
+    match_query = models.Match.played_without_results()
     queried_matches = fauna_session.execute(match_query).scalars().all()
 
     assert len(queried_matches) == 2
@@ -156,30 +162,93 @@ def test_played_without_results(fauna_session):
 
 def test_earliest_without_results(fauna_session):
     right_now = datetime.now(tz=timezone.utc)
-    two_teams = fauna_session.execute(select(Team).limit(2)).scalars().all()
+    two_teams = fauna_session.execute(select(models.Team).limit(2)).scalars().all()
 
-    played_without_results = Match(
+    played_without_results = models.Match(
         start_date_time=right_now - timedelta(days=1),
-        venue=FAKE.company(),
+        venue=Fake.company(),
         round_number=2,
     )
     for team in two_teams:
-        played_without_results.team_matches.append(TeamMatch(team=team, score=None))
+        played_without_results.team_matches.append(
+            models.TeamMatch(team=team, score=None)
+        )
 
     earliest_date = right_now - timedelta(days=2)
-    earliest_without_results = Match(
+    earliest_without_results = models.Match(
         start_date_time=earliest_date,
-        venue=FAKE.company(),
+        venue=Fake.company(),
         round_number=1,
     )
     for team in two_teams:
-        earliest_without_results.team_matches.append(TeamMatch(team=team, score=None))
+        earliest_without_results.team_matches.append(
+            models.TeamMatch(team=team, score=None)
+        )
 
     fauna_session.add(played_without_results)
     fauna_session.add(earliest_without_results)
     fauna_session.commit()
 
-    query = Match.earliest_without_results()
+    query = models.Match.earliest_without_results()
     queried_matches = fauna_session.execute(query).scalars().all()
     assert len(queried_matches) == 1
     assert queried_matches[0] == earliest_without_results
+
+
+def test_update_results(fauna_session):
+    match_results = data_factories.fake_match_results_data()
+    match_results_to_update = match_results.iloc[:3, :]
+    matches = []
+
+    for _idx, match_result in match_results_to_update.iterrows():
+        home_team, away_team = [
+            fauna_session.execute(
+                sql.select(models.Team).where(models.Team.name == match_result[team])
+            )
+            .scalars()
+            .first()
+            for team in ["home_team", "away_team"]
+        ]
+
+        match = models.Match(
+            start_date_time=match_result["date"],
+            venue=Fake.company(),
+            round_number=match_result["round_number"],
+            team_matches=[
+                models.TeamMatch(
+                    team=home_team,
+                    at_home=True,
+                ),
+                models.TeamMatch(
+                    team=away_team,
+                    at_home=False,
+                ),
+            ],
+            predictions=[
+                models.Prediction(
+                    ml_model=models.MLModel(
+                        name=Fake.company(), prediction_type="margin"
+                    ),
+                    predicted_winner=home_team,
+                    predicted_margin=np.random.randint(0, 100),
+                )
+            ],
+        )
+        matches.append(match)
+        fauna_session.add(match)
+
+    fauna_session.commit()
+
+    models.Match.update_results(matches, match_results)
+    fauna_session.commit()
+
+    queried_matches = fauna_session.execute(sql.select(models.Match)).scalars().all()
+    for match in queried_matches:
+        assert match.margin is not None
+        assert match.winner_id is not None
+
+        for team_match in match.team_matches:
+            assert team_match.score is not None
+
+        for prediction in match.predictions:
+            assert prediction.is_correct is not None

--- a/tipping/src/tests/integration/models/test_match.py
+++ b/tipping/src/tests/integration/models/test_match.py
@@ -1,6 +1,6 @@
 # pylint: disable=missing-docstring,redefined-outer-name
 
-from datetime import timedelta, timezone
+from datetime import timedelta, timezone, datetime
 
 import numpy as np
 from faker import Faker
@@ -9,7 +9,7 @@ from freezegun import freeze_time
 import pytest
 
 from tests.fixtures import data_factories
-from tipping.models.match import Match
+from tipping.models.match import Match, TeamMatch, Team
 
 
 FAKE = Faker()
@@ -106,3 +106,46 @@ def test_from_future_fixtures_with_skipped_round(fauna_session):
             Match.from_future_fixtures(
                 fauna_session, fixture_matches, upcoming_round_number
             )
+
+
+def test_played_without_results(fauna_session):
+    right_now = datetime.now(tz=timezone.utc)
+    two_teams = fauna_session.execute(select(Team).limit(2)).scalars().all()
+
+    played_with_results = Match(
+        start_date_time=right_now - timedelta(days=3),
+        venue=FAKE.company(),
+        round_number=1,
+    )
+    for team in two_teams:
+        played_with_results.team_matches.append(
+            TeamMatch(team=team, score=np.random.randint(1, 150))
+        )
+
+    resultless_matches = []
+    for n in range(2):
+        played_without_results = Match(
+            start_date_time=right_now - timedelta(days=(n + 2)),
+            venue=FAKE.company(),
+            round_number=(n + 2),
+        )
+        for team in two_teams:
+            played_without_results.team_matches.append(TeamMatch(team=team, score=None))
+        resultless_matches.append(played_without_results)
+
+    unplayed = Match(start_date_time=right_now, venue=FAKE.company(), round_number=4)
+    for team in two_teams:
+        unplayed.team_matches.append(TeamMatch(team=team, score=None))
+
+    fauna_session.add(played_with_results)
+    for resultless_match in resultless_matches:
+        fauna_session.add(resultless_match)
+    fauna_session.add(unplayed)
+    fauna_session.commit()
+
+    match_query = Match.played_without_results()
+    queried_matches = fauna_session.execute(match_query).scalars().all()
+
+    assert len(queried_matches) == 2
+    for queried_match in queried_matches:
+        assert queried_match in resultless_matches

--- a/tipping/src/tests/unit/models/test_match.py
+++ b/tipping/src/tests/unit/models/test_match.py
@@ -1,15 +1,19 @@
 # pylint: disable=missing-docstring,redefined-outer-name
 
-from datetime import timezone
+from datetime import timezone, datetime, timedelta
+from unittest import mock
 
 import pytest
 from faker import Faker
 import numpy as np
 
+from tests.fixtures import data_factories
+from tipping import models
 from tipping.models.match import Match, ValidationError
+from tipping.models.team import TeamName
 
 
-FAKE = Faker()
+Fake = Faker()
 
 
 @pytest.mark.parametrize(
@@ -17,13 +21,13 @@ FAKE = Faker()
     [
         ({"round_number": np.random.randint(-100, 1)}, r"round_number"),
         ({"margin": np.random.randint(-100, 0)}, r"margin"),
-        ({"start_date_time": FAKE.date_time()}, r"start_date_time"),
+        ({"start_date_time": Fake.date_time()}, r"start_date_time"),
     ],
 )
 def test_match_validation(attribute, error_message):
     default_input = {
-        "start_date_time": FAKE.date_time(tzinfo=timezone.utc),
-        "venue": FAKE.street_name(),
+        "start_date_time": Fake.date_time(tzinfo=timezone.utc),
+        "venue": Fake.street_name(),
         "margin": np.random.randint(0, 100),
         "round_number": np.random.randint(1, 100),
     }
@@ -35,3 +39,106 @@ def test_match_validation(attribute, error_message):
                 **attribute,
             }
         )
+
+
+@mock.patch("tipping.models.match.Match.update_result")
+def test_update_results(mock_update_result):
+    match_results = data_factories.fake_match_results_data()
+    calls = []
+    matches = []
+
+    for _idx, match_result in match_results.iterrows():
+        home_team = models.Team(name=match_result["home_team"])
+        match = Match(
+            start_date_time=match_result["date"],
+            venue=Fake.company(),
+            round_number=match_result["round_number"],
+            team_matches=[
+                models.TeamMatch(
+                    team=home_team,
+                    at_home=True,
+                ),
+                models.TeamMatch(
+                    team=models.Team(name=match_result["away_team"]),
+                    at_home=False,
+                ),
+            ],
+            predictions=[
+                models.Prediction(
+                    ml_model=models.MLModel(
+                        name=Fake.company(), prediction_type="margin"
+                    ),
+                    predicted_winner=home_team,
+                    predicted_margin=np.random.randint(0, 100),
+                )
+            ],
+        )
+        matches.append(match)
+        calls.append(mock.call(match_result))
+
+    Match.update_results(matches, match_results)
+
+    assert mock_update_result.call_count == len(match_results)
+
+
+@pytest.mark.parametrize(
+    ["start_date_time", "expected_winner"],
+    [
+        (
+            datetime.now(tz=timezone.utc) - timedelta(days=1),
+            np.random.choice(TeamName.values()),
+        ),
+        (datetime.now(tz=timezone.utc), None),
+        (datetime.now(tz=timezone.utc) + timedelta(days=1), None),
+    ],
+)
+def test_update_result(start_date_time, expected_winner):
+    match_results = data_factories.fake_match_results_data()
+    home_team_name = expected_winner or np.random.choice(TeamName.values())
+    home_team = models.Team(name=home_team_name)
+    home_team_results = match_results.query("home_team == @home_team_name")
+    random_row_idx = np.random.randint(0, len(home_team_results))
+    match_result = home_team_results.iloc[random_row_idx : (random_row_idx + 1), :]
+    match_result["home_score"] = match_result["away_score"] * 2
+    match = Match(
+        start_date_time=start_date_time,
+        venue=Fake.company(),
+        round_number=np.random.randint(1, 100),
+        team_matches=[
+            models.TeamMatch(
+                team=home_team,
+                at_home=True,
+            ),
+            models.TeamMatch(
+                team=models.Team(name=match_result.iloc[0, :]["away_team"]),
+                at_home=False,
+            ),
+        ],
+        predictions=[
+            models.Prediction(
+                ml_model=models.MLModel(name=Fake.company(), prediction_type="margin"),
+                predicted_winner=home_team,
+                predicted_margin=np.random.randint(0, 100),
+            )
+        ],
+    )
+
+    match.update_result(match_result)
+
+    if expected_winner is None:
+        assert match.margin is None
+        assert match.winner is None
+        for team_match in match.team_matches:
+            assert team_match.score is None
+        for prediction in match.predictions:
+            assert prediction.is_correct is None
+    else:
+        assert match.margin == abs(
+            match_result.iloc[0, :]["home_score"]
+            - match_result.iloc[0, :]["away_score"]
+        )
+        assert match.winner.name == home_team.name
+        for team_match in match.team_matches:
+            assert team_match.score is not None
+        for prediction in match.predictions:
+            assert prediction.is_correct is not None

--- a/tipping/src/tests/unit/models/test_team_match.py
+++ b/tipping/src/tests/unit/models/test_team_match.py
@@ -4,6 +4,8 @@ import pytest
 from faker import Faker
 import numpy as np
 
+from tests.fixtures import data_factories
+from tipping import models
 from tipping.models.team_match import TeamMatch, ValidationError
 
 
@@ -31,3 +33,18 @@ def test_team_match_validation(attribute, error_message):
                 **attribute,
             }
         )
+
+
+match_results = data_factories.fake_match_results_data()
+
+
+def test_update_score():
+    random_row_idx = np.random.randint(0, len(match_results))
+    match_result = match_results.iloc[random_row_idx, :]
+    team_match = TeamMatch(
+        team=models.Team(name=match_result["home_team"]), at_home=True
+    )
+
+    team_match.update_score(match_result)
+
+    assert team_match.score == match_result["home_score"]

--- a/tipping/src/tests/unit/test_api.py
+++ b/tipping/src/tests/unit/test_api.py
@@ -9,9 +9,11 @@ import pandas as pd
 import numpy as np
 from freezegun import freeze_time
 from candystore import CandyStore
+from faker import Faker
 
 from tests.fixtures import data_factories
 from tipping import api
+from tipping import models
 from tipping.tipping import FootyTipsSubmitter
 
 from tipping.models import Match
@@ -30,6 +32,8 @@ TIP_SEASON_RANGE = (min(MATCH_SEASON_RANGE), max(MATCH_SEASON_RANGE) + 1)
 TIP_DATES = [
     datetime(season, 1, 1, tzinfo=pytz.UTC) for season in range(*TIP_SEASON_RANGE)
 ]
+
+Fake = Faker()
 
 
 class TestApi(TestCase):
@@ -57,7 +61,7 @@ class TestApi(TestCase):
     @patch("tipping.api.data_export")
     @patch("tipping.api.data_import.DataImporter")
     @patch("tipping.api.settings.Session")
-    @patch("tipping.api.Match")
+    @patch("tipping.api.models.Match")
     def test_update_fixture_data(
         self, MockMatch, MockSession, MockDataImporter, mock_data_export
     ):
@@ -110,14 +114,41 @@ class TestApi(TestCase):
             self.assertEqual(mock_db_session.add.call_count, len(mock_matches))
             mock_db_session.commit.assert_called()
 
+    @patch("tipping.api.settings.Session")
     @patch("tipping.api.data_export")
-    @patch("tipping.api.data_import.DataImporter._fetch_data")
-    def test_update_matches(self, mock_fetch_data, mock_data_export):
+    @patch("tipping.api.data_import.DataImporter.fetch_match_data")
+    def test_update_matches(self, mock_fetch_match_data, mock_data_export, MockSession):
         matches = data_factories.fake_match_data()
-        matches_response = matches.astype({"date": str}).to_dict(orient="records")
 
-        mock_fetch_data.return_value = matches_response
+        mock_fetch_match_data.return_value = matches
         mock_data_export.update_matches = MagicMock()
+
+        mock_db_session = MagicMock()
+        mock_db_session.add = MagicMock()
+        mock_db_session.commit = MagicMock()
+        mock_scalars = MagicMock()
+        mock_scalars.all = MagicMock(
+            return_value=[
+                models.Match(
+                    start_date_time=data["date"],
+                    round_number=data["round_number"],
+                    venue=Fake.company(),
+                    team_matches=[
+                        models.TeamMatch(
+                            team=models.Team(name=data["home_team"]), at_home=True
+                        ),
+                        models.TeamMatch(
+                            team=models.Team(name=data["away_team"]), at_home=False
+                        ),
+                    ],
+                )
+                for _, data in matches.iterrows()
+            ]
+        )
+        mock_result = MagicMock()
+        mock_result.scalars = MagicMock(return_value=mock_scalars)
+        mock_db_session.execute = MagicMock(return_value=mock_result)
+        MockSession.return_value = mock_db_session
 
         self.api.update_matches(verbose=0)
 
@@ -127,11 +158,22 @@ class TestApi(TestCase):
         data_are_equal = (call_args[0] == matches).all().all()
         self.assertTrue(data_are_equal)
 
+        mock_db_session.commit.assert_called()
+
+    @patch("tipping.api.settings.Session")
     @patch("tipping.api.data_export")
     @patch("tipping.api.data_import.DataImporter")
-    def test_update_match_results(self, MockDataImporter, mock_data_export):
+    def test_update_match_results(
+        self, MockDataImporter, mock_data_export, MockSession
+    ):
         season = MATCH_SEASON_RANGE[0]
         seasons = (season, season + 1)
+
+        mock_db_session = MagicMock()
+        mock_db_session.add = MagicMock()
+        mock_db_session.commit = MagicMock()
+        mock_db_session.execute = MagicMock()
+        MockSession.return_value = mock_db_session
         # We want a date roughly in the middle of the season to make sure
         # we get matches before and after in the fixture
         with freeze_time(datetime(season, 7, 1, tzinfo=pytz.UTC)):
@@ -154,6 +196,29 @@ class TestApi(TestCase):
 
             mock_data_export.update_match_results = MagicMock()
 
+            mock_scalars = MagicMock()
+            mock_scalars.all = MagicMock(
+                return_value=[
+                    models.Match(
+                        start_date_time=data["date"],
+                        round_number=data["round_number"],
+                        venue=Fake.company(),
+                        team_matches=[
+                            models.TeamMatch(
+                                team=models.Team(name=data["home_team"]), at_home=True
+                            ),
+                            models.TeamMatch(
+                                team=models.Team(name=data["away_team"]), at_home=False
+                            ),
+                        ],
+                    )
+                    for _, data in match_results.iterrows()
+                ]
+            )
+            mock_result = MagicMock()
+            mock_result.scalars = MagicMock(return_value=mock_scalars)
+            mock_db_session.execute = MagicMock(return_value=mock_result)
+
             self.api.update_match_results(verbose=0)
 
             # It posts data to main app
@@ -162,9 +227,11 @@ class TestApi(TestCase):
             # It posts data for the round from the most-recent match
             call_args = mock_data_export.update_match_results.call_args[0]
             data_are_equal = (
-                (call_args[0]["round"] == last_match_round_number).all().all()
+                (call_args[0]["round_number"] == last_match_round_number).all().all()
             )
             self.assertTrue(data_are_equal)
+
+            mock_db_session.commit.assert_called()
 
     @patch("tipping.api.data_export")
     @patch("tipping.api.data_import.DataImporter")

--- a/tipping/src/tipping/api.py
+++ b/tipping/src/tipping/api.py
@@ -10,7 +10,7 @@ from tipping import data_import, data_export
 from tipping.helpers import pivot_team_matches_to_matches
 from tipping.tipping import MonashSubmitter
 
-from tipping.models import Match
+from tipping import models
 from tipping import settings
 
 
@@ -107,7 +107,9 @@ def update_fixture_data(verbose: int = 1) -> None:
     data_export.update_fixture_data(future_matches, upcoming_round)
 
     db_session = settings.Session()
-    matches = Match.from_future_fixtures(db_session, future_matches, upcoming_round)
+    matches = models.Match.from_future_fixtures(
+        db_session, future_matches, upcoming_round
+    )
 
     for match in matches:
         db_session.add(match)
@@ -196,6 +198,16 @@ def update_matches(verbose=1) -> None:
 
     data_export.update_matches(match_data)
 
+    db_session = settings.Session()
+    match_query = models.Match.played_without_results()
+    matches_without_results = db_session.execute(match_query).scalars().all()
+
+    if not any(matches_without_results):
+        return None
+
+    models.Match.update_results(matches_without_results, match_data)
+    db_session.commit()
+
     if verbose == 1:
         print("Match data sent!")
 
@@ -220,13 +232,23 @@ def update_match_results(verbose=1) -> None:
         current_round
     )
 
-    if verbose == 1:
-        print("Match results data received!")
+    if match_results_data.empty:
+        return None
 
     data_export.update_match_results(match_results_data)
 
+    db_session = settings.Session()
+    match_query = models.Match.played_without_results()
+    matches_without_results = db_session.execute(match_query).scalars().all()
+
+    if not any(matches_without_results):
+        return None
+
+    models.Match.update_results(matches_without_results, match_results_data)
+    db_session.commit()
+
     if verbose == 1:
-        print("Match data sent!")
+        print("Match data saved!")
 
     return None
 

--- a/tipping/src/tipping/models/match.py
+++ b/tipping/src/tipping/models/match.py
@@ -4,6 +4,8 @@ from __future__ import annotations
 
 import typing
 from datetime import datetime, timedelta, timezone
+from warnings import warn
+import functools
 
 from sqlalchemy import (
     Column,
@@ -28,6 +30,7 @@ MIN_MARGIN = 0
 FIRST_ROUND = 1
 JAN = 1
 FIRST = 1
+WEEK_IN_DAYS = 7
 # Rough estimate, but exactitude isn't necessary here. The AFL fixture tends to separate
 # match start times by just under 3 hrs (2:50 - 2:55 from my small sample).
 GAME_LENGTH_HRS = 3
@@ -217,6 +220,152 @@ class Match(Base):
         Date-time for the first past match without scores.
         """
         return cls.played_without_results().order_by(Match.start_date_time).limit(1)
+
+    @classmethod
+    def update_results(cls, matches: typing.List[Match], match_results: pd.DataFrame):
+        """
+        Fill in match results data for all matches that have been played.
+
+        Params:
+        -------
+        matches: List of match objects without saved results.
+        match_results: Raw match results data.
+        """
+        for match in matches:
+            match_result = match_results.query(
+                "year == @match.year & "
+                "round_number == @match.round_number & "
+                "home_team == @match.team(at_home=True).name & "
+                "away_team == @match.team(at_home=False).name"
+            )
+
+            match.update_result(match_result)
+
+    def update_result(self, match_result: pd.DataFrame):
+        """
+        Fill in match results data for a match that's been played.
+
+        Params:
+        -------
+        match_result: Raw data for a single match.
+        """
+        if not self.has_been_played or not self._validate_results_data_presence(
+            match_result
+        ):
+            return None
+
+        self._validate_one_result_row(match_result)
+
+        for team_match in self.team_matches:
+            team_match.update_score(match_result.iloc[0, :])
+
+        self.margin = self._calculate_margin()
+        self.winner = self._calculate_winner()
+
+        for prediction in self.predictions:
+            prediction.update_correctness()
+
+        return None
+
+    @property
+    def has_been_played(self) -> bool:
+        """Whether a match has been played yet."""
+        match_end_time = self.start_date_time + timedelta(hours=GAME_LENGTH_HRS)
+        return match_end_time < datetime.now(tz=timezone.utc)
+
+    @property
+    def is_draw(self) -> bool:
+        """Indicate whether a match result was a draw."""
+        return self.has_results and functools.reduce(
+            lambda score_x, score_y: score_x == score_y, self._match_scores
+        )
+
+    @property
+    def has_results(self) -> bool:
+        """Whether a match has a final score."""
+        return self.has_been_played and self._has_score
+
+    @property
+    def year(self) -> int:
+        """The year in which the match is played."""
+        return self.start_date_time.year
+
+    def team(self, at_home: typing.Optional[bool] = None) -> Team:
+        """The home or away team for this match."""
+        if at_home is None:
+            raise ValueError("Must pass a boolean value for at_home")
+
+        return next(
+            team_match.team
+            for team_match in self.team_matches
+            if team_match.at_home == at_home
+        )
+
+    @property
+    def _has_score(self) -> bool:
+        return any(score > 0 for score in self._match_scores)
+
+    @property
+    def _match_scores(self):
+        return [team_match.score for team_match in self.team_matches]
+
+    def _calculate_margin(self):
+        if not self.has_been_played:
+            return None
+
+        return functools.reduce(
+            lambda score_x, score_y: abs(score_x - score_y), self._match_scores
+        )
+
+    def _calculate_winner(self):
+        """Return the record for the winning team of the match."""
+        if not self.has_been_played or self.is_draw:
+            return None
+
+        return max(self.team_matches, key=lambda tm: tm.score).team
+
+    def _validate_results_data_presence(self, match_result: pd.DataFrame) -> bool:
+        # AFLTables usually updates match results a few days after the round
+        # is finished. Allowing for the occasional delay, we accept matches without
+        # results data for a week before raising an error.
+        if (
+            self.start_date_time
+            > datetime.now(tz=timezone.utc) - timedelta(days=WEEK_IN_DAYS)
+            and not match_result.size
+        ):
+            warn(
+                f"Unable to update the match between {self.team(at_home=True).name} "
+                f"and {self.team(at_home=False).name} from round {self.round_number}. "
+                "This is likely due to AFLTables not having updated the match results "
+                "yet."
+            )
+
+            return False
+
+        team_match_info = [
+            {"team": team_match.team.name, "at_home": team_match.at_home}
+            for team_match in self.team_matches
+        ]
+        assert match_result.size, (
+            "Didn't find any match data rows that matched match record:\n"
+            "{\n"
+            f"\tstart_date_time: {self.start_date_time},\n"
+            f"\tround_number: {self.round_number},\n"
+            f"\tvenue: {self.venue},\n"
+            f"\tteam_matches: {team_match_info}"
+            "}"
+        )
+
+        return True
+
+    @staticmethod
+    def _validate_one_result_row(match_result: pd.DataFrame):
+        assert len(match_result) == 1, (
+            "Filtering match results by year, round_number and team name "
+            "should result in a single row, but instead the following was "
+            "returned:\n"
+            f"{match_result}"
+        )
 
     @validates("round_number")
     def validate_at_least_min_round(self, _key, round_number):

--- a/tipping/src/tipping/models/match.py
+++ b/tipping/src/tipping/models/match.py
@@ -208,6 +208,16 @@ class Match(Base):
             .distinct()
         )
 
+    @classmethod
+    def earliest_without_results(cls) -> Select:
+        """
+        Get the earliest start_date_time of played matches without results.
+        Returns:
+        --------
+        Date-time for the first past match without scores.
+        """
+        return cls.played_without_results().order_by(Match.start_date_time).limit(1)
+
     @validates("round_number")
     def validate_at_least_min_round(self, _key, round_number):
         """Validate that the round number is >= 1."""

--- a/tipping/src/tipping/models/team.py
+++ b/tipping/src/tipping/models/team.py
@@ -39,7 +39,7 @@ class TeamName(enum.Enum):
         return name in cls.values()
 
     @classmethod
-    def values(cls) -> List:
+    def values(cls) -> List[str]:
         """Returns all name values in TeamName."""
         return [member.value for member in cls]
 

--- a/tipping/src/tipping/models/team_match.py
+++ b/tipping/src/tipping/models/team_match.py
@@ -65,7 +65,7 @@ class TeamMatch(Base):
     @validates("score")
     def validate_postive_score(self, _key, score):
         """Validate that the score isn't negative."""
-        if score >= MIN_SCORE:
+        if score is None or score >= MIN_SCORE:
             return score
 
         raise ValidationError(

--- a/tipping/src/tipping/models/team_match.py
+++ b/tipping/src/tipping/models/team_match.py
@@ -4,13 +4,11 @@ from __future__ import annotations
 
 import typing
 
-from sqlalchemy import Column, Integer, ForeignKey, Boolean, select
-from sqlalchemy.orm import relationship, validates, session as orm_session
+from sqlalchemy import Column, Integer, ForeignKey, Boolean, sql, orm
 import pandas as pd
 
 from .base import Base, ValidationError
 from .team import Team
-
 
 MIN_SCORE = 0
 
@@ -22,15 +20,15 @@ class TeamMatch(Base):
 
     id = Column(Integer, primary_key=True)
     team_id = Column(Integer, ForeignKey("teams.id"), nullable=False)
-    team = relationship(Team)
+    team = orm.relationship(Team)
     match_id = Column(Integer, ForeignKey("matches.id"), nullable=False)
-    match = relationship("Match", back_populates="team_matches")
+    match = orm.relationship("Match", back_populates="team_matches")
     at_home = Column(Boolean, nullable=False)
     score = Column(Integer)
 
     @classmethod
     def from_fixture(
-        cls, session: orm_session.Session, fixture_data: pd.Series
+        cls, session: orm.session.Session, fixture_data: pd.Series
     ) -> typing.Tuple[TeamMatch, TeamMatch]:
         """Instantiate home and away team_matches from raw fixture data.
 
@@ -50,19 +48,33 @@ class TeamMatch(Base):
 
     @classmethod
     def _single_team_match_from_fixture(
-        cls, session: orm_session.Session, fixture_data: pd.Series, at_home: bool
+        cls, session: orm.session.Session, fixture_data: pd.Series, at_home: bool
     ) -> TeamMatch:
         team_prefix = "home" if at_home else "away"
         team_name = fixture_data[f"{team_prefix}_team"]
         team = (
-            session.execute(select(Team).where(Team.name == team_name)).scalars().one()
+            session.execute(sql.select(Team).where(Team.name == team_name))
+            .scalars()
+            .one()
         )
-
         team_score = fixture_data.get(f"{team_prefix}_score", 0)
 
         return TeamMatch(team=team, at_home=at_home, score=team_score)
 
-    @validates("score")
+    def update_score(self, match_result: pd.Series):
+        """
+        Update the final scores for each team that played in a match.
+
+        Params:
+        -------
+        match_result: A row of raw match data with final scores.
+        """
+        team_type_prefix = "home" if self.at_home else "away"
+        assert self.team.name == match_result[f"{team_type_prefix}_team"]
+
+        self.score = match_result[f"{team_type_prefix}_score"]
+
+    @orm.validates("score")
     def validate_postive_score(self, _key, score):
         """Validate that the score isn't negative."""
         if score is None or score >= MIN_SCORE:


### PR DESCRIPTION
This adds updating data in Fauna when updating match results. The basic logic is copied over from the `Match` model in the `backend` Django app, with changes to make the query work with SQLAlchemy.