### PR TITLE
Add support for ORDER BY to sqlalchemy-fauna

### DIFF
--- a/tipping/sqlalchemy-fauna/README.md
+++ b/tipping/sqlalchemy-fauna/README.md
@@ -10,11 +10,21 @@ A Fauna dialect for SQLAlchemy
 - Alembic's `autogenerate` option for creating migrations doesn't work very well, because it includes a whole bunch of changes that already exist in the schema. I think this has to do with bugs in how the dialect responds to `INFORMATION_SCHEMA` queries. However, the auto-generated migrations include all the desired changes: you just have to delete the undesired ones.
   - Possible solution: investigate what alembic does with the `INFORMATION_SCHEMA` data and maybe fix those responses to match what the equivalent SQL queries return.
 
+- Queries that refer to multiple tables **must** use `JOIN`s to connect them (`SELECT <columns> FROM <table1>, <table2>` doesn't work, but `SELECT <columns> FROM <table1> JOIN <table2>` does). This includes any cross-table references in the selected columns, `WHERE` clauses, or `ORDER BY` clause.
+
+- Due to how Fauna implements results sorting via matching on indices, there are some limitations on queries with an `ORDER BY` clause:
+  - Can only sort by one column per query.
+    - Sorting by multiple is probably possible, but would require such a massive increase in the number of Fauna indices as well as extra complication in the query logic, that it doesn't seem worth implementing for now.
+  - Works fine for queries that only include one table (i.e. no `JOIN`s)
+  - For queries with `JOIN`s, we can only sort by a column from the principal table (i.e. `FROM <table>`), not any of the tables included via `JOIN`s.
+    - I'm not sure that sorting on any table in the query is even possible, but if it is, it would require completely changing how `JOIN` queries are implemented, and I had a difficult enough time figuring that out without this extra complexity.
+
 - Many valid SQL queries are not supported due to a combination of their being really difficult to make work in Fauna and their use cases not having come up in my own projects. These, in theory, could be supported eventually, and I've tried to mark as many of them as possible with `NotSupported` errors and unit tests.
 
 ## TODO
 
 For keeping track of next steps for extending SQL support. Not meant to be comprehensive.
 
+- Support `LIMIT`
 - Support `ON DELETE` strategies for foreign keys (currently is just `SET NULL` I suppose since the ref no longer exists)
 - Support `GROUP BY`

--- a/tipping/sqlalchemy-fauna/sqlalchemy_fauna/fauna/translation/common.py
+++ b/tipping/sqlalchemy-fauna/sqlalchemy_fauna/fauna/translation/common.py
@@ -45,6 +45,7 @@ class IndexType(enum.Enum):
     REF = "ref"
     TERM = "term"
     VALUE = "value"
+    SORT = "sort"
 
 
 def _parse_date_value(value):

--- a/tipping/sqlalchemy-fauna/tests/integration/test_sqlalchemy_fauna.py
+++ b/tipping/sqlalchemy-fauna/tests/integration/test_sqlalchemy_fauna.py
@@ -518,12 +518,36 @@ def test_join(fauna_session, parent_child):
             child = Child(name=child_name, parent=parent)
             fauna_session.add(child)
 
-    result = fauna_session.execute(
-        select(Parent, Child).join(Parent.children).where(Child.name == "Louise")
+    parents = (
+        fauna_session.execute(
+            select(Parent, Child).join(Parent.children).where(Child.name == "Louise")
+        )
+        .scalars()
+        .all()
     )
-    rows = list(result)
 
-    assert len(rows) == 1
-    queried_parent, queried_child = rows[0]
-    assert queried_child.name == "Louise"
-    assert queried_parent.name == queried_child.parent.name
+    assert len(parents) == 1
+    queried_parent = parents[0]
+    assert queried_parent.name == "Bob"
+
+
+def test_order_by(fauna_session, user_model):
+    User, Base = user_model
+    fauna_engine = fauna_session.get_bind()
+    Base.metadata.create_all(fauna_engine)
+
+    names = ["Zoe", "Anne", "Mary", "Diana", "Tina"]
+    for name in names:
+        fauna_session.add(User(name=name))
+
+    fauna_session.commit()
+
+    users = fauna_session.execute(select(User).order_by(User.name)).scalars().all()
+    user_names = [user.name for user in users]
+    assert user_names == sorted(names)
+
+    users = (
+        fauna_session.execute(select(User).order_by(User.name.desc())).scalars().all()
+    )
+    user_names = [user.name for user in users]
+    assert user_names == list(reversed(sorted(names)))

--- a/tipping/sqlalchemy-fauna/tests/integration/test_sqlalchemy_fauna.py
+++ b/tipping/sqlalchemy-fauna/tests/integration/test_sqlalchemy_fauna.py
@@ -1,6 +1,7 @@
 # pylint: disable=missing-docstring,redefined-outer-name
 
 from datetime import datetime, timezone
+import functools
 
 from sqlalchemy.ext.declarative import declarative_base
 from sqlalchemy import (
@@ -551,3 +552,38 @@ def test_order_by(fauna_session, user_model):
     )
     user_names = [user.name for user in users]
     assert user_names == list(reversed(sorted(names)))
+
+
+def test_join_order_by(fauna_session, parent_child):
+    Base = parent_child["base"]
+    fauna_engine = fauna_session.get_bind()
+    Base.metadata.create_all(fauna_engine)
+
+    Parent = parent_child["parent"]
+    Child = parent_child["child"]
+
+    parents = [
+        ("Bob", ["Louise", "Tina", "Gene"]),
+        ("Jimmy", ["Jimmy Jr.", "Ollie", "Andy"]),
+    ]
+
+    for parent_name, child_names in parents:
+        parent = Parent(name=parent_name)
+        fauna_session.add(parent)
+
+        for child_name in child_names:
+            child = Child(name=child_name, parent=parent)
+            fauna_session.add(child)
+
+    children = (
+        fauna_session.execute(
+            select(Child, Parent).join(Child.parent).order_by(Child.name)
+        )
+        .scalars()
+        .all()
+    )
+
+    child_names = functools.reduce(
+        lambda agg_names, curr_names: agg_names + curr_names[1], parents, []
+    )
+    assert [child.name for child in children] == sorted(child_names)

--- a/tipping/sqlalchemy-fauna/tests/unit/translation/test_select.py
+++ b/tipping/sqlalchemy-fauna/tests/unit/translation/test_select.py
@@ -18,7 +18,14 @@ partial_select_info_schema_constraints = (
 )
 select_sum = "SELECT sum(users.id) AS sum_1 from users"
 select_avg = "SELECT avg(users.id) AS avg_1 from users"
-
+select_join_order_by = (
+    "SELECT users.name, accounts.number FROM users "
+    "JOIN accounts ON users.id = accounts.user_id "
+    "ORDER BY accounts.number"
+)
+select_order_multiple = (
+    "SELECT users.name, users.age FROM users ORDER BY users.name, users.age"
+)
 # These are meant to be examples of SQL queries that are not currently supported,
 # but that are valid SQL and so should be supported eventually.
 # Regarding some of the more esoteric queries (e.g. INFORMATION_SCHEMA), I'm not certain
@@ -57,6 +64,11 @@ select_avg = "SELECT avg(users.id) AS avg_1 from users"
             "SELECT COUNT(users.id) FROM users JOIN accounts ON users.id = accounts.user_id",
             "SQL functions across multiple tables are not yet supported",
         ),
+        (
+            select_join_order_by,
+            "Either select one table at a time or remove the ordering constraint",
+        ),
+        (select_order_multiple, "Ordering by multiple columns is not yet supported"),
     ],
 )
 def test_translating_unsupported_select(sql_query, error_message):
@@ -83,6 +95,10 @@ select_join = (
     "SELECT users.name, accounts.number FROM users "
     "JOIN accounts ON users.id = accounts.user_id"
 )
+select_order_by = "SELECT users.name, users.age FROM users ORDER BY users.name"
+select_order_by_desc = (
+    "SELECT users.name, users.age FROM users ORDER BY users.name DESC"
+)
 
 
 @pytest.mark.parametrize(
@@ -96,6 +112,8 @@ select_join = (
         select_where_equals,
         select_count,
         select_join,
+        select_order_by,
+        select_order_by_desc,
     ],
 )
 def test_translate_select(sql_string):

--- a/tipping/sqlalchemy-fauna/tests/unit/translation/test_select.py
+++ b/tipping/sqlalchemy-fauna/tests/unit/translation/test_select.py
@@ -66,7 +66,7 @@ select_order_multiple = (
         ),
         (
             select_join_order_by,
-            "Either select one table at a time or remove the ordering constraint",
+            "we currently can only sort the principal table",
         ),
         (select_order_multiple, "Ordering by multiple columns is not yet supported"),
     ],
@@ -99,6 +99,11 @@ select_order_by = "SELECT users.name, users.age FROM users ORDER BY users.name"
 select_order_by_desc = (
     "SELECT users.name, users.age FROM users ORDER BY users.name DESC"
 )
+select_join_order_by_principal = (
+    "SELECT users.name, accounts.number FROM users "
+    "JOIN accounts ON users.id = accounts.user_id "
+    "ORDER BY users.name"
+)
 
 
 @pytest.mark.parametrize(
@@ -114,6 +119,7 @@ select_order_by_desc = (
         select_join,
         select_order_by,
         select_order_by_desc,
+        select_join_order_by_principal,
     ],
 )
 def test_translate_select(sql_string):


### PR DESCRIPTION
I had to impose some limitations on use of `ORDER BY` due to the fact that Fauna bases ordering on indices, which are also used for filtering and joins. However, I think supporting ordering for single-table queries and for the `FROM` table in multi-table queries covers most use cases, and (ok, maybe hacky) work-arounds should be possible for when more-complicated ordering is needed.