### PR TITLE
Add support for LIMIT clause in SQL queries

### DIFF
--- a/tipping/sqlalchemy-fauna/README.md
+++ b/tipping/sqlalchemy-fauna/README.md
@@ -25,6 +25,5 @@ A Fauna dialect for SQLAlchemy
 
 For keeping track of next steps for extending SQL support. Not meant to be comprehensive.
 
-- Support `LIMIT`
 - Support `ON DELETE` strategies for foreign keys (currently is just `SET NULL` I suppose since the ref no longer exists)
 - Support `GROUP BY`

--- a/tipping/sqlalchemy-fauna/sqlalchemy_fauna/fauna/translation/models.py
+++ b/tipping/sqlalchemy-fauna/sqlalchemy_fauna/fauna/translation/models.py
@@ -590,6 +590,7 @@ class SQLQuery:
         columns: typing.List[Column] = None,
         distinct: bool = False,
         order_by: typing.Optional[OrderBy] = None,
+        limit: typing.Optional[int] = None,
     ):
         self.distinct = distinct
         tables = tables or []
@@ -597,6 +598,7 @@ class SQLQuery:
         columns = columns or []
         self._columns = columns
         self._order_by = order_by
+        self.limit = limit
 
     @classmethod
     def from_statement(cls, statement: token_groups.Statement) -> SQLQuery:
@@ -721,10 +723,18 @@ class SQLQuery:
 
         _, distinct = statement.token_next_by(m=(token_types.Keyword, "DISTINCT"))
 
+        idx, _ = statement.token_next_by(m=(token_types.Keyword, "LIMIT"))
+        _, limit = statement.token_next(skip_cm=True, skip_ws=True, idx=idx)
+        limit_value = None if limit is None else int(limit.value)
+
         order_by = OrderBy.from_statement(statement)
 
         return cls(
-            tables=tables, columns=columns, distinct=bool(distinct), order_by=order_by
+            tables=tables,
+            columns=columns,
+            distinct=bool(distinct),
+            order_by=order_by,
+            limit=limit_value,
         )
 
     @classmethod

--- a/tipping/sqlalchemy-fauna/sqlalchemy_fauna/fauna/translation/select.py
+++ b/tipping/sqlalchemy-fauna/sqlalchemy_fauna/fauna/translation/select.py
@@ -216,6 +216,9 @@ def _translate_select_without_functions(sql_query: models.SQLQuery, distinct=Fal
                 q.paginate(ordered_result, size=fql.MAX_PAGE_SIZE),
             )
 
+    if sql_query.limit is not None:
+        maybe_documents_to_select = q.take(sql_query.limit, maybe_documents_to_select)
+
     initial_field_alias_map: typing.Dict[str, typing.Dict[str, str]] = {}
     field_alias_map: typing.Dict[str, typing.Dict[str, str]] = functools.reduce(
         lambda alias_map, column: {

--- a/tipping/sqlalchemy-fauna/tests/unit/translation/test_models.py
+++ b/tipping/sqlalchemy-fauna/tests/unit/translation/test_models.py
@@ -234,6 +234,17 @@ def test_sql_query_from_statement_order_by():
         assert column.name == column_names[idx]
 
 
+def test_sql_query_from_statement_limit():
+    table_name = "users"
+
+    sql_string = f"SELECT users.name, users.age FROM {table_name} LIMIT 1"
+    statement = sqlparse.parse(sql_string)[0]
+
+    sql_query = models.SQLQuery.from_statement(statement)
+
+    assert sql_query.limit == 1
+
+
 @pytest.mark.parametrize(
     ["sql_string", "expected_table_names", "expected_column_names"],
     [


### PR DESCRIPTION
One of those clauses that I missed, because it goes by different names/labels depending on the SQL engine, but SQLAlchemy uses `LIMIT`, so I will as well.