### PR TITLE
Add model factories to simplify integration tests

### DIFF
--- a/tipping/requirements.txt
+++ b/tipping/requirements.txt
@@ -13,3 +13,4 @@ factory_boy
 coverage
 candystore==0.3.3
 responses
+factory_boy

--- a/tipping/src/tests/fixtures/__init__.py
+++ b/tipping/src/tests/fixtures/__init__.py
@@ -1,0 +1,3 @@
+"""Fake data and model objects for use in tests."""
+
+from .session import Session

--- a/tipping/src/tests/fixtures/model_factories.py
+++ b/tipping/src/tests/fixtures/model_factories.py
@@ -1,0 +1,279 @@
+"""Factory classes for generating realistic DB records for tests."""
+
+from datetime import date, datetime, timedelta, timezone
+import math
+import pytz
+
+import factory
+from factory.alchemy import SQLAlchemyModelFactory
+from faker import Faker
+import numpy as np
+from sqlalchemy import sql
+
+from tipping.models import Team, Prediction, Match, MLModel, TeamMatch
+from tipping.models.ml_model import PredictionType
+from tipping import settings
+
+FAKE = Faker()
+TODAY = date.today()
+JAN = 1
+FIRST = 1
+DEC = 12
+THIRTY_FIRST = 31
+MAR = 3
+ONE_WEEK = 7
+SIX_MONTHS_IN_WEEKS = 26
+
+# A full round with all teams playing each other currently has 9 matches.
+TYPICAL_N_MATCHES_PER_ROUND = 9
+# A typical regular season has 24 rounds, so we set that as the limit
+# to keep round number realistic.
+N_ROUNDS_PER_REGULAR_SEASON = 24
+
+N_ML_MODELS = 5
+ML_MODEL_NAMES = [factory.Faker("company") for _ in range(N_ML_MODELS)]
+
+
+class TeamFactory(SQLAlchemyModelFactory):
+    """Factory class for the Team data model."""
+
+    class Meta:
+        """Factory attributes for recreating the associated model's attributes."""
+
+        model = Team
+        sqlalchemy_get_or_create = ("name",)
+
+    name = factory.Sequence(lambda n: settings.TEAM_NAMES[n % len(settings.TEAM_NAMES)])
+
+
+def _fake_datetime(match_factory, n, start_month_day=(MAR, FIRST)) -> datetime:
+    round_week_delta = timedelta(days=ONE_WEEK)
+    start_month, start_day = start_month_day
+
+    # Since we create match records per year, we don't want dates running
+    # into the next year.
+    max_datetime = datetime(match_factory.year, DEC, THIRTY_FIRST, tzinfo=timezone.utc)
+    now_for_factory = datetime(
+        match_factory.year, start_month, start_day, tzinfo=timezone.utc
+    )
+
+    # We cycle through six month periods (or however many weeks are left in the year,
+    # whichever is less), because the sequence doesn't reset between tests
+    # and eventually hits the end of the year for every test, resulting in duplicate
+    # venue/date combinations that raise validation errors.
+    n_days_left_in_year = (max_datetime - now_for_factory).days
+    n_weeks_left_in_year = math.floor(n_days_left_in_year / ONE_WEEK)
+    n_weeks_left_in_season = min([n_weeks_left_in_year, SIX_MONTHS_IN_WEEKS])
+    start_round_week_delta = (
+        timedelta(days=0)
+        if n_weeks_left_in_season == 0
+        else round_week_delta
+        * (math.ceil(n / TYPICAL_N_MATCHES_PER_ROUND) % n_weeks_left_in_season)
+    )
+
+    try:
+        datetime_start = now_for_factory + start_round_week_delta
+    except ValueError:
+        # Trying to create a datetime for 29 Feb in a non-leap year raises an error,
+        # (e.g. 2018-2-29 doesn't exist), so we retry with an extra day in the future
+        # (e.g. 2018-3-1).
+        datetime_start = (
+            datetime(match_factory.year, MAR, FIRST, tzinfo=timezone.utc)
+            + start_round_week_delta
+            + timedelta(days=1)
+        )
+
+    try:
+        # Rounds last about a week, so that's how big we make our date range per round
+        datetime_end = datetime_start + round_week_delta
+    except ValueError:
+        # Trying to create a datetime for 29 Feb in a non-leap year raises an error,
+        # (e.g. 2018-2-29 doesn't exist), so we retry with an extra day in the future
+        # (e.g. 2018-3-1).
+        datetime_end = datetime_start + round_week_delta + timedelta(days=1)
+
+    return FAKE.date_time_between_dates(
+        datetime_start=min(datetime_start, max_datetime),
+        datetime_end=min(datetime_end, max_datetime),
+        tzinfo=pytz.UTC,
+    )
+
+
+def _fake_future_datetime(match_factory, n) -> datetime:
+    """Return a realistic future datetime value for a match's start_date_time."""
+    if TODAY.month == 12 and TODAY.day == 31:
+        match_factory.year = match_factory.year + 1
+
+    tomorrow = TODAY + timedelta(days=1)
+
+    return _fake_datetime(
+        match_factory, n, start_month_day=(tomorrow.month, tomorrow.day)
+    )
+
+
+class MatchFactory(SQLAlchemyModelFactory):
+    """Factory class for the Match data model."""
+
+    class Meta:
+        """Factory attributes for recreating the associated model's attributes."""
+
+        model = Match
+
+    start_date_time = factory.LazyAttributeSequence(_fake_datetime)
+    round_number = factory.Sequence(
+        lambda n: math.ceil((n + 1) / TYPICAL_N_MATCHES_PER_ROUND)
+        % N_ROUNDS_PER_REGULAR_SEASON
+    )
+    venue = factory.LazyFunction(
+        lambda: settings.VENUES[
+            FAKE.pyint(min_value=0, max_value=(len(settings.VENUES) - 1))
+        ]
+    )
+
+    class Params:
+        """Params for modifying the factory's default attributes."""
+
+        year = TODAY.year
+        # A lot of functionality depends on future matches for generating predictions
+        future = factory.Trait(
+            start_date_time=factory.LazyAttributeSequence(_fake_future_datetime)
+        )
+
+
+class TeamMatchFactory(SQLAlchemyModelFactory):
+    """Factory class for the TeamMatch data model."""
+
+    class Meta:
+        """Factory attributes for recreating the associated model's attributes."""
+
+        model = TeamMatch
+
+    team = factory.SubFactory(TeamFactory)
+    match = factory.SubFactory(MatchFactory)
+    at_home = factory.Faker("pybool")
+    score = factory.LazyAttribute(
+        lambda team_match: FAKE.pyint(min_value=50, max_value=150)
+        if team_match.match.start_date_time < datetime.now(tz=timezone.utc)
+        else 0
+    )
+
+    @factory.post_generation
+    def save_match_result(
+        obj, _create, _extracted, **_kwargs
+    ):  # pylint: disable=no-self-argument
+        """Update associated match with result."""
+        obj.match._save_result()  # pylint: disable=protected-access
+
+
+class MLModelFactory(SQLAlchemyModelFactory):
+    """Factory class for the MLModel data model."""
+
+    class Meta:
+        """Factory attributes for recreating the associated model's attributes."""
+
+        model = MLModel
+
+    name = factory.Faker("company")
+    description = factory.Faker("paragraph", nb_sentences=4)
+    is_principal = False
+    used_in_competitions = False
+
+
+class PredictionFactory(SQLAlchemyModelFactory):
+    """Factory class for the Prediction data model."""
+
+    class Meta:
+        """Factory attributes for recreating the associated model's attributes."""
+
+        model = Prediction
+
+    class Params:
+        """
+        Params for modifying the factory's default attributes.
+
+        Params:
+        -------
+        force_correct: A factory trait that, when present, forces the predicted_winner
+            to equal the actual match winner. We sometimes need this for tests
+            that check prediction metric calculations.
+        """
+
+        force_correct = factory.Trait(
+            predicted_winner=factory.LazyAttribute(
+                lambda pred: max(
+                    pred.match.teammatch_set.all(), key=lambda pred: pred.score
+                ).team
+            )
+        )
+
+        force_incorrect = factory.Trait(
+            predicted_winner=factory.LazyAttribute(
+                lambda pred: min(
+                    pred.match.teammatch_set.all(), key=lambda pred: pred.score
+                ).team
+            )
+        )
+
+    match = factory.SubFactory(MatchFactory)
+    # Can't use SubFactory for associated MLModel, because it's not realistic to have
+    # one model per prediction, and in cases where there are a lot of predictions,
+    # we risk duplicate model names, which is invalid
+    ml_model = factory.Iterator(sql.select(MLModel))
+    # Have to make sure we get a team from the associated match
+    # for realistic prediction metrics
+    predicted_winner = factory.LazyAttribute(
+        lambda pred: pred.match.teammatch_set.all()[np.random.randint(0, 2)].team
+    )
+    predicted_margin = factory.LazyAttribute(
+        lambda pred: np.random.random() * 50
+        if pred.ml_model.prediction_type == PredictionType.MARGIN
+        else None
+    )
+    # Doesn't give realistic win probabilities (i.e. between 0.5 and 1.0)
+    # due to an open issue in faker: https://github.com/joke2k/faker/issues/1068
+    # Since they're taking this as an opportunity to completely change the method,
+    # they're going to wait for a major version rather than just permit floats...
+    predicted_win_probability = factory.LazyAttribute(
+        lambda pred: np.random.uniform(0.5, 1.0)
+        if pred.ml_model.prediction_type == PredictionType.WIN_PROBABILITY
+        else None
+    )
+    is_correct = factory.LazyAttribute(
+        lambda pred: (
+            None
+            if pred.match.start_date_time > datetime.now(tz=timezone.utc)
+            else pred.match.teammatch_set.order_by("-score").first().team
+            == pred.predicted_winner
+        )
+    )
+
+
+class FullMatchFactory(MatchFactory):
+    """
+    Factory for creating a match with all associated records.
+
+    Given the difficulty in recreating all the associations in a flexible way,
+    the predictions associated with the created match are hard-coded to be two,
+    which limits us to two models. So far, this has been sufficient for testing
+    functionality.
+    """
+
+    class Params:
+        """
+        Params for modifying the factory's default attributes.
+
+        Params:
+        -------
+        with_predictions: A factory trait that, when present, creates ML model
+            predictions associated with the match.
+        """
+
+        with_predictions = factory.Trait(
+            prediction=factory.RelatedFactory(PredictionFactory, "match"),
+            prediction_two=factory.RelatedFactory(PredictionFactory, "match"),
+        )
+
+    # TeamMatchFactory calls must come before PredictionFactory calls,
+    # so predictions can refer to associated teams for predicted_winner.
+    home_team_match = factory.RelatedFactory(TeamMatchFactory, "match", at_home=True)
+    away_team_match = factory.RelatedFactory(TeamMatchFactory, "match", at_home=False)

--- a/tipping/src/tests/fixtures/model_factories.py
+++ b/tipping/src/tests/fixtures/model_factories.py
@@ -13,6 +13,7 @@ from sqlalchemy import sql
 from tipping.models import Team, Prediction, Match, MLModel, TeamMatch
 from tipping.models.ml_model import PredictionType
 from tipping import settings
+from .session import Session
 
 FAKE = Faker()
 TODAY = date.today()
@@ -42,6 +43,7 @@ class TeamFactory(SQLAlchemyModelFactory):
 
         model = Team
         sqlalchemy_get_or_create = ("name",)
+        sqlalchemy_session = Session
 
     name = factory.Sequence(lambda n: settings.TEAM_NAMES[n % len(settings.TEAM_NAMES)])
 
@@ -118,6 +120,7 @@ class MatchFactory(SQLAlchemyModelFactory):
         """Factory attributes for recreating the associated model's attributes."""
 
         model = Match
+        sqlalchemy_session = Session
 
     start_date_time = factory.LazyAttributeSequence(_fake_datetime)
     round_number = factory.Sequence(
@@ -147,6 +150,7 @@ class TeamMatchFactory(SQLAlchemyModelFactory):
         """Factory attributes for recreating the associated model's attributes."""
 
         model = TeamMatch
+        sqlalchemy_session = Session
 
     team = factory.SubFactory(TeamFactory)
     match = factory.SubFactory(MatchFactory)
@@ -172,6 +176,7 @@ class MLModelFactory(SQLAlchemyModelFactory):
         """Factory attributes for recreating the associated model's attributes."""
 
         model = MLModel
+        sqlalchemy_session = Session
 
     name = factory.Faker("company")
     description = factory.Faker("paragraph", nb_sentences=4)
@@ -186,6 +191,7 @@ class PredictionFactory(SQLAlchemyModelFactory):
         """Factory attributes for recreating the associated model's attributes."""
 
         model = Prediction
+        sqlalchemy_session = Session
 
     class Params:
         """

--- a/tipping/src/tests/fixtures/session.py
+++ b/tipping/src/tests/fixtures/session.py
@@ -1,0 +1,5 @@
+"""Base SQLAlchemy session for use in integration tests."""
+
+from sqlalchemy.orm import scoped_session, session
+
+Session = scoped_session(session.sessionmaker())

--- a/tipping/src/tests/integration/conftest.py
+++ b/tipping/src/tests/integration/conftest.py
@@ -9,7 +9,8 @@ import subprocess
 import pytest
 from sqlalchemy import create_engine
 from sqlalchemy.dialects import registry
-from sqlalchemy.orm import sessionmaker
+
+from tests.fixtures import Session
 
 
 CAPTURED_MATCH = 1
@@ -87,9 +88,11 @@ def fauna_session():
     """Set up an SQLAlchemy DB session for use in tests."""
     with _setup_teardown_test_db() as secret_key:
         engine = create_engine(f"fauna://faunadb:8443/?secret={secret_key}")
-        Session = sessionmaker(bind=engine)
+        Session.configure(bind=engine)
 
         with patch("tipping.settings.Session", Session):
             session = Session()
 
             yield session
+
+        Session.remove()

--- a/tipping/src/tests/integration/models/test_match.py
+++ b/tipping/src/tests/integration/models/test_match.py
@@ -8,15 +8,15 @@ from sqlalchemy import select, func, sql
 from freezegun import freeze_time
 import pytest
 
-from tests.fixtures import data_factories
-from tipping import models
+from tests.fixtures import data_factories, model_factories
+from tipping.models import Match
 
 
 Fake = Faker()
 
 
 def test_match_creation(fauna_session):
-    match = models.Match(
+    match = Match(
         start_date_time=Fake.date_time(tzinfo=timezone.utc),
         round_number=np.random.randint(1, 100),
         venue=Fake.company(),
@@ -37,9 +37,9 @@ def test_from_future_fixtures(fauna_session):
     )
 
     with freeze_time(patched_date):
-        assert fauna_session.execute(select(func.count(models.Match.id))).scalar() == 0
+        assert fauna_session.execute(select(func.count(Match.id))).scalar() == 0
 
-        matches = models.Match.from_future_fixtures(
+        matches = Match.from_future_fixtures(
             fauna_session, upcoming_fixture_matches, upcoming_round_number
         )
         created_match_count = len(matches)
@@ -54,14 +54,12 @@ def test_from_future_fixtures(fauna_session):
         fauna_session.commit()
 
         # With existing matches in DB
-        matches = models.Match.from_future_fixtures(
+        matches = Match.from_future_fixtures(
             fauna_session, upcoming_fixture_matches, upcoming_round_number
         )
 
         assert len(matches) == 0
-        total_match_count = fauna_session.execute(
-            select(func.count(models.Match.id))
-        ).scalar()
+        total_match_count = fauna_session.execute(select(func.count(Match.id))).scalar()
         assert total_match_count == created_match_count
 
 
@@ -92,7 +90,7 @@ def test_from_future_fixtures_with_skipped_round(fauna_session):
     upcoming_round_number = int(next_match["round_number"]) + 1
 
     fauna_session.add(
-        models.Match(
+        Match(
             start_date_time=first_match["date"].to_pydatetime(),
             round_number=first_match["round_number"],
             venue=first_match["venue"],
@@ -105,7 +103,7 @@ def test_from_future_fixtures_with_skipped_round(fauna_session):
             AssertionError,
             match="Expected upcoming round number to be 1 greater than previous round",
         ):
-            models.Match.from_future_fixtures(
+            Match.from_future_fixtures(
                 fauna_session, fixture_matches, upcoming_round_number
             )
             # Logging to catch cause of flaky test
@@ -115,44 +113,31 @@ def test_from_future_fixtures_with_skipped_round(fauna_session):
 
 def test_played_without_results(fauna_session):
     right_now = datetime.now(tz=timezone.utc)
-    two_teams = fauna_session.execute(select(models.Team).limit(2)).scalars().all()
 
-    played_with_results = models.Match(
+    model_factories.FullMatchFactory(
         start_date_time=right_now - timedelta(days=3),
-        venue=Fake.company(),
         round_number=1,
     )
-    for team in two_teams:
-        played_with_results.team_matches.append(
-            models.TeamMatch(team=team, score=np.random.randint(1, 150))
-        )
 
     resultless_matches = []
     for n in range(2):
-        played_without_results = models.Match(
-            start_date_time=right_now - timedelta(days=(n + 2)),
-            venue=Fake.company(),
-            round_number=(n + 2),
-        )
-        for team in two_teams:
-            played_without_results.team_matches.append(
-                models.TeamMatch(team=team, score=None)
+        resultless_matches.append(
+            model_factories.FullMatchFactory(
+                start_date_time=right_now - timedelta(days=(n + 2)),
+                round_number=(n + 2),
+                home_team_match__score=None,
+                away_team_match__score=None,
             )
-        resultless_matches.append(played_without_results)
+        )
 
-    unplayed = models.Match(
-        start_date_time=right_now, venue=Fake.company(), round_number=4
+    model_factories.FullMatchFactory(
+        start_date_time=right_now,
+        round_number=4,
+        home_team_match__score=None,
+        away_team_match__score=None,
     )
-    for team in two_teams:
-        unplayed.team_matches.append(models.TeamMatch(team=team, score=None))
 
-    fauna_session.add(played_with_results)
-    for resultless_match in resultless_matches:
-        fauna_session.add(resultless_match)
-    fauna_session.add(unplayed)
-    fauna_session.commit()
-
-    match_query = models.Match.played_without_results()
+    match_query = Match.played_without_results()
     queried_matches = fauna_session.execute(match_query).scalars().all()
 
     assert len(queried_matches) == 2
@@ -162,34 +147,23 @@ def test_played_without_results(fauna_session):
 
 def test_earliest_without_results(fauna_session):
     right_now = datetime.now(tz=timezone.utc)
-    two_teams = fauna_session.execute(select(models.Team).limit(2)).scalars().all()
 
-    played_without_results = models.Match(
+    model_factories.FullMatchFactory(
         start_date_time=right_now - timedelta(days=1),
-        venue=Fake.company(),
         round_number=2,
+        home_team_match__score=None,
+        away_team_match__score=None,
     )
-    for team in two_teams:
-        played_without_results.team_matches.append(
-            models.TeamMatch(team=team, score=None)
-        )
 
     earliest_date = right_now - timedelta(days=2)
-    earliest_without_results = models.Match(
+    earliest_without_results = model_factories.FullMatchFactory(
         start_date_time=earliest_date,
-        venue=Fake.company(),
         round_number=1,
+        home_team_match__score=None,
+        away_team_match__score=None,
     )
-    for team in two_teams:
-        earliest_without_results.team_matches.append(
-            models.TeamMatch(team=team, score=None)
-        )
 
-    fauna_session.add(played_without_results)
-    fauna_session.add(earliest_without_results)
-    fauna_session.commit()
-
-    query = models.Match.earliest_without_results()
+    query = Match.earliest_without_results()
     queried_matches = fauna_session.execute(query).scalars().all()
     assert len(queried_matches) == 1
     assert queried_matches[0] == earliest_without_results
@@ -201,48 +175,18 @@ def test_update_results(fauna_session):
     matches = []
 
     for _idx, match_result in match_results_to_update.iterrows():
-        home_team, away_team = [
-            fauna_session.execute(
-                sql.select(models.Team).where(models.Team.name == match_result[team])
-            )
-            .scalars()
-            .first()
-            for team in ["home_team", "away_team"]
-        ]
-
-        match = models.Match(
+        match = model_factories.FullMatchFactory(
             start_date_time=match_result["date"],
-            venue=Fake.company(),
             round_number=match_result["round_number"],
-            team_matches=[
-                models.TeamMatch(
-                    team=home_team,
-                    at_home=True,
-                ),
-                models.TeamMatch(
-                    team=away_team,
-                    at_home=False,
-                ),
-            ],
-            predictions=[
-                models.Prediction(
-                    ml_model=models.MLModel(
-                        name=Fake.company(), prediction_type="margin"
-                    ),
-                    predicted_winner=home_team,
-                    predicted_margin=np.random.randint(0, 100),
-                )
-            ],
+            home_team_match__team__name=match_result["home_team"],
+            away_team_match__team__name=match_result["away_team"],
         )
+
         matches.append(match)
-        fauna_session.add(match)
 
-    fauna_session.commit()
+    Match.update_results(matches, match_results)
 
-    models.Match.update_results(matches, match_results)
-    fauna_session.commit()
-
-    queried_matches = fauna_session.execute(sql.select(models.Match)).scalars().all()
+    queried_matches = fauna_session.execute(sql.select(Match)).scalars().all()
     for match in queried_matches:
         assert match.margin is not None
         assert match.winner_id is not None

--- a/tipping/src/tests/integration/models/test_prediction.py
+++ b/tipping/src/tests/integration/models/test_prediction.py
@@ -1,47 +1,18 @@
 # pylint: disable=missing-docstring,redefined-outer-name
 
-from datetime import timezone
-
 import numpy as np
-from faker import Faker
-import pytest
 
+from tests.fixtures import model_factories
 from tipping.models.prediction import Prediction
-from tipping.models.ml_model import MLModel, PredictionType
-from tipping.models.match import Match
 
 
-FAKE = Faker()
-
-
-@pytest.fixture
-def match():
-    return Match(
-        start_date_time=FAKE.date_time(tzinfo=timezone.utc),
-        round_number=np.random.randint(1, 100),
-        venue=FAKE.company(),
-    )
-
-
-@pytest.fixture
-def ml_model():
-    return MLModel(
-        name=FAKE.job(),
-        description=FAKE.paragraph(),
-        is_principal=False,
-        used_in_competitions=False,
-        prediction_type=np.random.choice(PredictionType.values()),
-    )
-
-
-def test_prediction_creation(fauna_session, match, ml_model):
-    fauna_session.add(match)
-    fauna_session.add(ml_model)
-    fauna_session.commit()
+def test_prediction_creation(fauna_session):
+    match = model_factories.MatchFactory()
+    ml_model = model_factories.MLModelFactory()
 
     prediction = Prediction(
-        match_id=match.id,
-        ml_model_id=ml_model.id,
+        match=match,
+        ml_model=ml_model,
         predicted_margin=np.random.randint(0, 100),
         predicted_win_probability=np.random.random(),
     )

--- a/tipping/src/tests/integration/models/test_team_match.py
+++ b/tipping/src/tests/integration/models/test_team_match.py
@@ -1,43 +1,23 @@
 # pylint: disable=missing-docstring,redefined-outer-name
 
-from datetime import timezone
-
 import numpy as np
 from faker import Faker
-import pytest
-from sqlalchemy import select
 
-from tests.fixtures import data_factories
-from tipping.models import TeamMatch, Team, Match
-from tipping.models.team import TeamName
+from tests.fixtures import data_factories, model_factories
+from tipping.models import TeamMatch
 
 
-FAKE = Faker()
+Fake = Faker()
 
 
-@pytest.fixture
-def match():
-    return Match(
-        start_date_time=FAKE.date_time(tzinfo=timezone.utc),
-        round_number=np.random.randint(1, 100),
-        venue=FAKE.company(),
-    )
-
-
-def test_team_match_creation(fauna_session, match):
-    team_name = np.random.choice(TeamName.values())
-    team = (
-        fauna_session.execute(select(Team).where(Team.name == team_name))
-        .scalars()
-        .one()
-    )
-    fauna_session.add(match)
-    fauna_session.commit()
+def test_team_match_creation(fauna_session):
+    team = model_factories.TeamFactory()
+    match = model_factories.MatchFactory()
 
     team_match = TeamMatch(
-        team_id=team.id,
-        match_id=match.id,
-        at_home=FAKE.pybool(),
+        team=team,
+        match=match,
+        at_home=Fake.pybool(),
         score=np.random.randint(0, 100),
     )
     fauna_session.add(team_match)


### PR DESCRIPTION
Mostly copy/pasted from the existing factories in the Django app, with an update to use SQLAlchemy instead.