### PR TITLE
Add model factories to tipping

### DIFF
--- a/tipping/sqlalchemy-fauna/requirements.txt
+++ b/tipping/sqlalchemy-fauna/requirements.txt
@@ -15,3 +15,4 @@ pytest>=5.0,<7.0
 coverage
 numpy==1.20.2 # just used for random numbers in tests
 faker==8.1.0
+factory_boy

--- a/tipping/sqlalchemy-fauna/tests/fixtures/__init__.py
+++ b/tipping/sqlalchemy-fauna/tests/fixtures/__init__.py
@@ -1,0 +1,3 @@
+"""Fake data and objects for use in tests."""
+
+from .session import Session

--- a/tipping/sqlalchemy-fauna/tests/fixtures/__init__.py
+++ b/tipping/sqlalchemy-fauna/tests/fixtures/__init__.py
@@ -1,3 +1,4 @@
 """Fake data and objects for use in tests."""
 
 from .session import Session, Base
+from . import models

--- a/tipping/sqlalchemy-fauna/tests/fixtures/__init__.py
+++ b/tipping/sqlalchemy-fauna/tests/fixtures/__init__.py
@@ -1,3 +1,3 @@
 """Fake data and objects for use in tests."""
 
-from .session import Session
+from .session import Session, Base

--- a/tipping/sqlalchemy-fauna/tests/fixtures/factories.py
+++ b/tipping/sqlalchemy-fauna/tests/fixtures/factories.py
@@ -1,0 +1,26 @@
+"""Factories for example model classes."""
+
+import factory
+from factory.alchemy import SQLAlchemyModelFactory
+
+from .session import Session
+from .models import User
+
+
+class UserFactory(SQLAlchemyModelFactory):
+    """Factory class for the User data model."""
+
+    class Meta:
+        """Factory attributes for recreating the associated model's attributes."""
+
+        model = User
+        sqlalchemy_get_or_create = ("name",)
+        sqlalchemy_session = Session
+
+    name = factory.Faker("first_name")
+    date_joined = factory.Faker("date_this_decade")
+    age = factory.Faker("pyint")
+    finger_count = factory.Faker("pyint")
+    is_premium_member = factory.Faker("pybool")
+    account_credit = factory.Faker("pyfloat")
+    job = factory.Faker("job")

--- a/tipping/sqlalchemy-fauna/tests/fixtures/factories.py
+++ b/tipping/sqlalchemy-fauna/tests/fixtures/factories.py
@@ -4,7 +4,7 @@ import factory
 from factory.alchemy import SQLAlchemyModelFactory
 
 from .session import Session
-from .models import User
+from .models import User, Child
 
 
 class UserFactory(SQLAlchemyModelFactory):
@@ -24,3 +24,17 @@ class UserFactory(SQLAlchemyModelFactory):
     is_premium_member = factory.Faker("pybool")
     account_credit = factory.Faker("pyfloat")
     job = factory.Faker("job")
+
+
+class ChildFactory(SQLAlchemyModelFactory):
+    """Factory class for the Child data model."""
+
+    class Meta:
+        """Factory attributes for recreating the associated model's attributes."""
+
+        model = Child
+        sqlalchemy_get_or_create = ("name",)
+        sqlalchemy_session = Session
+
+    name = factory.Faker("first_name")
+    user = factory.SubFactory(UserFactory)

--- a/tipping/sqlalchemy-fauna/tests/fixtures/models.py
+++ b/tipping/sqlalchemy-fauna/tests/fixtures/models.py
@@ -1,6 +1,7 @@
 """Example model classes for use in integration tests."""
 
 from sqlalchemy import Column, Integer, String, DateTime, Boolean, Float
+import pytest
 
 from .session import Base
 
@@ -18,3 +19,9 @@ class User(Base):
     is_premium_member = Column(Boolean, default=False)
     account_credit = Column(Float, default=0.0)
     job = Column(String)
+
+
+@pytest.fixture
+def user_columns():
+    """Pytest fixture for the column names on the User table."""
+    return User.__table__.columns.keys()

--- a/tipping/sqlalchemy-fauna/tests/fixtures/models.py
+++ b/tipping/sqlalchemy-fauna/tests/fixtures/models.py
@@ -1,13 +1,13 @@
 """Example model classes for use in integration tests."""
 
-from sqlalchemy import Column, Integer, String, DateTime, Boolean, Float
-import pytest
+from sqlalchemy import Column, Integer, String, DateTime, Boolean, Float, orm
+from sqlalchemy.sql.schema import ForeignKey
 
 from .session import Base
 
 
 class User(Base):
-    """Fake User class for use in integration tests."""
+    """Fake User model for use in integration tests."""
 
     __tablename__ = "users"
 
@@ -19,9 +19,15 @@ class User(Base):
     is_premium_member = Column(Boolean, default=False)
     account_credit = Column(Float, default=0.0)
     job = Column(String)
+    children = orm.relationship("Child", back_populates="user")
 
 
-@pytest.fixture
-def user_columns():
-    """Pytest fixture for the column names on the User table."""
-    return User.__table__.columns.keys()
+class Child(Base):
+    """Fake Child model for use in integration tests."""
+
+    __tablename__ = "orders"
+
+    id = Column(Integer, primary_key=True)
+    user_id = Column(Integer, ForeignKey("users.id"))
+    user = orm.relationship("User", back_populates="children")
+    name = Column(String, unique=True)

--- a/tipping/sqlalchemy-fauna/tests/fixtures/models.py
+++ b/tipping/sqlalchemy-fauna/tests/fixtures/models.py
@@ -1,0 +1,20 @@
+"""Example model classes for use in integration tests."""
+
+from sqlalchemy import Column, Integer, String, DateTime, Boolean, Float
+
+from .session import Base
+
+
+class User(Base):
+    """Fake User class for use in integration tests."""
+
+    __tablename__ = "users"
+
+    id = Column(Integer, primary_key=True)
+    name = Column(String, unique=True)
+    date_joined = Column(DateTime, nullable=False)
+    age = Column(Integer)
+    finger_count = Column(Integer, default=10)
+    is_premium_member = Column(Boolean, default=False)
+    account_credit = Column(Float, default=0.0)
+    job = Column(String)

--- a/tipping/sqlalchemy-fauna/tests/fixtures/session.py
+++ b/tipping/sqlalchemy-fauna/tests/fixtures/session.py
@@ -1,5 +1,7 @@
 """Base SQLAlchemy session for use in integration tests."""
 
 from sqlalchemy.orm import scoped_session, session
+from sqlalchemy.ext.declarative import declarative_base
 
+Base = declarative_base()
 Session = scoped_session(session.sessionmaker())

--- a/tipping/sqlalchemy-fauna/tests/fixtures/session.py
+++ b/tipping/sqlalchemy-fauna/tests/fixtures/session.py
@@ -1,0 +1,5 @@
+"""Base SQLAlchemy session for use in integration tests."""
+
+from sqlalchemy.orm import scoped_session, session
+
+Session = scoped_session(session.sessionmaker())

--- a/tipping/sqlalchemy-fauna/tests/integration/conftest.py
+++ b/tipping/sqlalchemy-fauna/tests/integration/conftest.py
@@ -8,9 +8,8 @@ from unittest.mock import patch
 import pytest
 from sqlalchemy import create_engine
 from sqlalchemy.dialects import registry
-from sqlalchemy.orm import sessionmaker
 
-from tests.fixtures import Session
+from tests.fixtures import Session, Base
 
 
 CAPTURED_MATCH = 1
@@ -63,6 +62,7 @@ def fauna_engine():
     """
     with _setup_teardown_test_db() as secret_key:
         engine = create_engine(f"fauna://faunadb:8443/?secret={secret_key}")
+        Base.metadata.create_all(engine)
 
         yield engine
 
@@ -72,6 +72,7 @@ def fauna_session():
     """Set up an SQLAlchemy DB session for use in tests."""
     with _setup_teardown_test_db() as secret_key:
         engine = create_engine(f"fauna://faunadb:8443/?secret={secret_key}")
+        Base.metadata.create_all(engine)
         Session.configure(bind=engine)
         session = Session()
 

--- a/tipping/sqlalchemy-fauna/tests/integration/conftest.py
+++ b/tipping/sqlalchemy-fauna/tests/integration/conftest.py
@@ -10,6 +10,8 @@ from sqlalchemy import create_engine
 from sqlalchemy.dialects import registry
 from sqlalchemy.orm import sessionmaker
 
+from tests.fixtures import Session
+
 
 CAPTURED_MATCH = 1
 
@@ -70,8 +72,9 @@ def fauna_session():
     """Set up an SQLAlchemy DB session for use in tests."""
     with _setup_teardown_test_db() as secret_key:
         engine = create_engine(f"fauna://faunadb:8443/?secret={secret_key}")
-        Session = sessionmaker(bind=engine)
-
+        Session.configure(bind=engine)
         session = Session()
 
         yield session
+
+        Session.remove()

--- a/tipping/sqlalchemy-fauna/tests/integration/conftest.py
+++ b/tipping/sqlalchemy-fauna/tests/integration/conftest.py
@@ -9,7 +9,7 @@ import pytest
 from sqlalchemy import create_engine
 from sqlalchemy.dialects import registry
 
-from tests.fixtures import Session, Base
+from tests.fixtures import Session, Base, models
 
 
 CAPTURED_MATCH = 1
@@ -79,3 +79,9 @@ def fauna_session():
         yield session
 
         Session.remove()
+
+
+@pytest.fixture
+def user_columns():
+    """Pytest fixture for the column names on the User table."""
+    return models.User.__table__.columns.keys()


### PR DESCRIPTION
Similar to #1125 but for the `tipping` service and the `sqlalchemy-fauna` package. Simplifies test setup for integration tests quite a bit.