### PR TITLE
Create information schema collections for metadata

### DIFF
--- a/tipping/sqlalchemy-fauna/sqlalchemy_fauna/fauna/translation/common.py
+++ b/tipping/sqlalchemy-fauna/sqlalchemy_fauna/fauna/translation/common.py
@@ -86,7 +86,7 @@ def extract_value(
     """
     value = token.value
 
-    if value.upper() == "NONE":
+    if value.upper() == "NONE" or value.upper() == "NULL":
         return None
 
     if value.upper() == "TRUE":

--- a/tipping/sqlalchemy-fauna/tests/fixtures/factories.py
+++ b/tipping/sqlalchemy-fauna/tests/fixtures/factories.py
@@ -2,9 +2,13 @@
 
 import factory
 from factory.alchemy import SQLAlchemyModelFactory
+from faker import Faker
 
 from .session import Session
 from .models import User, Child
+
+
+Fake = Faker()
 
 
 class UserFactory(SQLAlchemyModelFactory):
@@ -14,10 +18,9 @@ class UserFactory(SQLAlchemyModelFactory):
         """Factory attributes for recreating the associated model's attributes."""
 
         model = User
-        sqlalchemy_get_or_create = ("name",)
         sqlalchemy_session = Session
 
-    name = factory.Faker("first_name")
+    name = factory.Sequence(lambda n: f"{Fake.first_name()} {n}")
     date_joined = factory.Faker("date_this_decade")
     age = factory.Faker("pyint")
     finger_count = factory.Faker("pyint")
@@ -33,8 +36,7 @@ class ChildFactory(SQLAlchemyModelFactory):
         """Factory attributes for recreating the associated model's attributes."""
 
         model = Child
-        sqlalchemy_get_or_create = ("name",)
         sqlalchemy_session = Session
 
-    name = factory.Faker("first_name")
+    name = factory.Sequence(lambda n: f"{Fake.first_name()} {n}")
     user = factory.SubFactory(UserFactory)

--- a/tipping/sqlalchemy-fauna/tests/fixtures/models.py
+++ b/tipping/sqlalchemy-fauna/tests/fixtures/models.py
@@ -25,7 +25,7 @@ class User(Base):
 class Child(Base):
     """Fake Child model for use in integration tests."""
 
-    __tablename__ = "orders"
+    __tablename__ = "children"
 
     id = Column(Integer, primary_key=True)
     user_id = Column(Integer, ForeignKey("users.id"))

--- a/tipping/sqlalchemy-fauna/tests/integration/conftest.py
+++ b/tipping/sqlalchemy-fauna/tests/integration/conftest.py
@@ -36,8 +36,6 @@ def _setup_teardown_test_db():
     )
 
     with patch.dict(os.environ, {**os.environ, "FAUNA_SECRET": secret_key}):
-        os.system("alembic upgrade head")
-
         try:
             yield secret_key
         finally:

--- a/tipping/sqlalchemy-fauna/tests/integration/test_sqlalchemy_fauna.py
+++ b/tipping/sqlalchemy-fauna/tests/integration/test_sqlalchemy_fauna.py
@@ -1,6 +1,6 @@
 # pylint: disable=missing-docstring,redefined-outer-name
 
-from datetime import datetime, timezone
+from datetime import timezone
 import functools
 
 from sqlalchemy import inspect, exc as sqlalchemy_exceptions, sql
@@ -192,8 +192,9 @@ def test_select_by_numeric_field_comparison(filter_age, fauna_session):
 def test_delete_record_conditionally(fauna_session):
     names = ["Bob", "Linda"]
     users = [factories.UserFactory(name=name) for name in names]
-    user_to_delete, user_to_keep = users
+    fauna_session.commit()
 
+    user_to_delete, user_to_keep = users
     fauna_session.execute(
         sql.delete(models.User).where(models.User.id == user_to_delete.id)
     )


### PR DESCRIPTION
This simplifies translation of SELECT queries at the cost of more-complicated CREATE queries. Mostly, though, this will make it easier to separate SQL parsing from FQL query-building, as INFORMATION_SCHEMA queries required a bunch of custom logic to parse collections' metadata objects, but now they can be treated like normal SELECT queries.

I ended up implementing a modified version of Postgres's INFORMATION_SCHEMA, because a lot of the tables and columns have nothing to do with how Fauna structures data, and it was getting really awkward trying to shoehorn the latter into the former. I ended up simplifying the information available and renaming where appropriate. A lot of the field names are also SQL keywords, so I appended a _ to all collection & field names to avoid clashes and allow for reasonable SQL parsing.