### PR TITLE
Refactor insert to separate SQL parsing from FQL building

### DIFF
--- a/tipping/sqlalchemy-fauna/sqlalchemy_fauna/fauna/translation/base.py
+++ b/tipping/sqlalchemy-fauna/sqlalchemy_fauna/fauna/translation/base.py
@@ -43,7 +43,6 @@ def translate_sql_to_fql(
     sql_statement = sql_statements[0]
 
     if sql_statement.token_first().match(token_types.DML, "SELECT"):
-
         return [translate_select(sql_statement)]
 
     if sql_statement.token_first().match(token_types.DDL, "CREATE"):
@@ -53,7 +52,8 @@ def translate_sql_to_fql(
         return translate_drop(sql_statement)
 
     if sql_statement.token_first().match(token_types.DML, "INSERT"):
-        return translate_insert(sql_statement)
+        sql_query = models.SQLQuery.from_statement(sql_statement)
+        return [translate_insert(sql_query)]
 
     if sql_statement.token_first().match(token_types.DML, "DELETE"):
         return translate_delete(sql_statement)

--- a/tipping/sqlalchemy-fauna/sqlalchemy_fauna/fauna/translation/models.py
+++ b/tipping/sqlalchemy-fauna/sqlalchemy_fauna/fauna/translation/models.py
@@ -815,7 +815,18 @@ class SQLQuery:
         )
 
         _, value_group = statement.token_next_by(i=token_groups.Values)
-        _, column_value_group = value_group.token_next_by(i=token_groups.Parenthesis)
+        val_idx, column_value_group = value_group.token_next_by(
+            i=token_groups.Parenthesis
+        )
+
+        _, additional_parenthesis_group = value_group.token_next_by(
+            i=token_groups.Parenthesis, idx=val_idx
+        )
+        if additional_parenthesis_group is not None:
+            raise exceptions.NotSupportedError(
+                "INSERT for multiple rows is not supported yet."
+            )
+
         _, column_value_identifiers = column_value_group.token_next_by(
             i=(token_groups.IdentifierList, token_groups.Identifier),
         )

--- a/tipping/sqlalchemy-fauna/tests/unit/translation/test_insert.py
+++ b/tipping/sqlalchemy-fauna/tests/unit/translation/test_insert.py
@@ -4,37 +4,16 @@ import pytest
 import sqlparse
 from faunadb.objects import _Expr as QueryExpression
 
-from sqlalchemy_fauna import exceptions
-from sqlalchemy_fauna.fauna.translation import insert
-
-
-insert_user = "INSERT INTO users (name, age, finger_count) VALUES ('Bob', 30, 10)"
-
-
-@pytest.mark.parametrize("sql_query", [insert_user])
-def test_translate_create(sql_query):
-    fql_queries = insert.translate_insert(sqlparse.parse(sql_query)[0])
-
-    for fql_query in fql_queries:
-        assert isinstance(fql_query, QueryExpression)
-
-
-insert_all_cols = "INSERT INTO users VALUES ('Bob', 30, 10)"
-insert_multiple = (
-    "INSERT INTO users (name, age) VALUES ('Bob', 45), ('Linda', 45), ('Tina', 14)"
-)
+from sqlalchemy_fauna.fauna.translation import insert, models
 
 
 @pytest.mark.parametrize(
-    ["sql_query", "error_message"],
-    [
-        (
-            insert_all_cols,
-            "INSERT INTO statements without column names are not currently supported",
-        ),
-        (insert_multiple, "INSERT for multiple rows is not supported yet"),
-    ],
+    "sql_string", ["INSERT INTO users (name, age, finger_count) VALUES ('Bob', 30, 10)"]
 )
-def test_translating_unsupported_create(sql_query, error_message):
-    with pytest.raises(exceptions.NotSupportedError, match=error_message):
-        insert.translate_insert(sqlparse.parse(sql_query)[0])
+def test_translate_insert(sql_string):
+    sql_statement = sqlparse.parse(sql_string)[0]
+    sql_query = models.SQLQuery.from_statement(sql_statement)
+
+    fql_query = insert.translate_insert(sql_query)
+
+    assert isinstance(fql_query, QueryExpression)

--- a/tipping/sqlalchemy-fauna/tests/unit/translation/test_models.py
+++ b/tipping/sqlalchemy-fauna/tests/unit/translation/test_models.py
@@ -269,11 +269,20 @@ def test_sql_query_from_statement_limit():
     assert sql_query.limit == 1
 
 
-def test_sql_query_from_statement_insert():
+@pytest.mark.parametrize(
+    ["column_names", "column_values", "expected_values"],
+    [
+        (
+            ["name", "age", "finger_count", "job", "has_mustache"],
+            ["'Bob'", "30", "10", "NONE", "TRUE"],
+            ["Bob", 30, 10, None, True],
+        ),
+        (["name"], ["'Bob'"], ["Bob"]),
+    ],
+)
+def test_sql_query_from_statement_insert(column_names, column_values, expected_values):
     table_name = "users"
-    column_names = ["name", "age", "finger_count", "job", "has_mustache"]
-    column_values = ["'Bob'", "30", "10", "NONE", "TRUE"]
-    expected_column_values = ["Bob", 30, 10, None, True]
+
     sql_string = (
         f"INSERT INTO {table_name} ({', '.join(column_names)}) "
         f"VALUES ({', '.join(column_values)})"
@@ -295,7 +304,7 @@ def test_sql_query_from_statement_insert():
     )
     assert set(query_column_names) == set(table_column_names)
     assert list(query_column_names) == column_names
-    assert list(query_column_values) == expected_column_values
+    assert list(query_column_values) == expected_values
 
 
 @pytest.mark.parametrize(
@@ -362,6 +371,14 @@ def test_sql_query_from_statement(
             "SELECT users.name, accounts.number FROM users "
             "JOIN accounts ON users.name = accounts.user_name",
             "Table joins are only permitted on IDs and foreign keys that refer to IDs",
+        ),
+        (
+            "INSERT INTO users VALUES ('Bob', 30, 10)",
+            "INSERT INTO statements without column names are not currently supported",
+        ),
+        (
+            "INSERT INTO users (name, age) VALUES ('Bob', 45), ('Linda', 45), ('Tina', 14)",
+            "INSERT for multiple rows is not supported yet",
         ),
     ],
 )


### PR DESCRIPTION
Part of the larger translation refactor to base all SQL parsing in the SQL model classes and base the building of all FQL queries on those classes.