### PR TITLE
Refactor DML queries to separate SQL parsing from FQL

### DIFF
--- a/tipping/sqlalchemy-fauna/sqlalchemy_fauna/fauna/translation/base.py
+++ b/tipping/sqlalchemy-fauna/sqlalchemy_fauna/fauna/translation/base.py
@@ -42,28 +42,29 @@ def translate_sql_to_fql(
 
     sql_statement = sql_statements[0]
 
-    if sql_statement.token_first().match(token_types.DML, "SELECT"):
-        return [translate_select(sql_statement)]
-
     if sql_statement.token_first().match(token_types.DDL, "CREATE"):
         return translate_create(sql_statement)
 
     if sql_statement.token_first().match(token_types.DDL, "DROP"):
         return translate_drop(sql_statement)
 
+    if sql_statement.token_first().match(token_types.DDL, "ALTER"):
+        return translate_alter(sql_statement)
+
+    if sql_statement.token_first().match(token_types.DML, "SELECT"):
+        return [translate_select(sql_statement)]
+
     if sql_statement.token_first().match(token_types.DML, "INSERT"):
         sql_query = models.SQLQuery.from_statement(sql_statement)
         return [translate_insert(sql_query)]
 
     if sql_statement.token_first().match(token_types.DML, "DELETE"):
-        return translate_delete(sql_statement)
+        sql_query = models.SQLQuery.from_statement(sql_statement)
+        return [translate_delete(sql_query)]
 
     if sql_statement.token_first().match(token_types.DML, "UPDATE"):
         sql_query = models.SQLQuery.from_statement(sql_statement)
         table = sql_query.tables[0]
         return [fql.update_documents(table)]
-
-    if sql_statement.token_first().match(token_types.DDL, "ALTER"):
-        return translate_alter(sql_statement)
 
     raise exceptions.NotSupportedError()

--- a/tipping/sqlalchemy-fauna/sqlalchemy_fauna/fauna/translation/base.py
+++ b/tipping/sqlalchemy-fauna/sqlalchemy_fauna/fauna/translation/base.py
@@ -52,7 +52,8 @@ def translate_sql_to_fql(
         return translate_alter(sql_statement)
 
     if sql_statement.token_first().match(token_types.DML, "SELECT"):
-        return [translate_select(sql_statement)]
+        sql_query = models.SQLQuery.from_statement(sql_statement)
+        return [translate_select(sql_query)]
 
     if sql_statement.token_first().match(token_types.DML, "INSERT"):
         sql_query = models.SQLQuery.from_statement(sql_statement)

--- a/tipping/sqlalchemy-fauna/sqlalchemy_fauna/fauna/translation/delete.py
+++ b/tipping/sqlalchemy-fauna/sqlalchemy_fauna/fauna/translation/delete.py
@@ -2,33 +2,29 @@
 
 import typing
 
-from sqlparse import sql as token_groups
 from faunadb import query as q
 from faunadb.objects import _Expr as QueryExpression
 
 from . import models, fql
 
 
-def translate_delete(statement: token_groups.Statement) -> typing.List[QueryExpression]:
+def translate_delete(sql_query: models.SQLQuery) -> typing.List[QueryExpression]:
     """Translate a DELETE SQL query into an equivalent FQL query.
 
     Params:
     -------
-    statement: An SQL statement returned by sqlparse.
+    sql_query: An SQLQuery instance.
 
     Returns:
     --------
     An FQL query expression.
     """
-    sql_query = models.SQLQuery.from_statement(statement)
     table = sql_query.tables[0]
 
     records_to_delete = fql.define_document_set(table)
     delete_records = q.delete(q.select("ref", q.get(records_to_delete)))
 
-    return [
-        q.let(
-            {"response": q.select("data", delete_records)},
-            {"data": [q.var("response")]},
-        )
-    ]
+    return q.let(
+        {"response": q.select("data", delete_records)},
+        {"data": [q.var("response")]},
+    )

--- a/tipping/sqlalchemy-fauna/sqlalchemy_fauna/fauna/translation/insert.py
+++ b/tipping/sqlalchemy-fauna/sqlalchemy_fauna/fauna/translation/insert.py
@@ -13,7 +13,7 @@ def translate_insert(sql_query: models.SQLQuery) -> typing.List[QueryExpression]
 
     Params:
     -------
-    statement: An SQL statement returned by sqlparse.
+    sql_query: An SQLQuery instance.
 
     Returns:
     --------

--- a/tipping/sqlalchemy-fauna/sqlalchemy_fauna/fauna/translation/models.py
+++ b/tipping/sqlalchemy-fauna/sqlalchemy_fauna/fauna/translation/models.py
@@ -78,7 +78,7 @@ class Column:
         self.name = name
         self.alias = alias
         self.value = value
-        self.function_name = function_name
+        self._function_name = function_name
         self._table_name = table_name
         self._table: typing.Optional[Table] = None
 
@@ -243,6 +243,16 @@ class Column:
     def alias_map(self) -> typing.Dict[str, str]:
         """Dictionary that maps the column name to its alias in the SQL query."""
         return {self.name: self.alias}
+
+    @property
+    def function_name(self) -> typing.Optional[str]:
+        """Name of a function to be applied to the query results."""
+        return None if self._function_name is None else self._function_name.value
+
+    @property
+    def is_function(self) -> bool:
+        """Whether the column represents the result of an SQL function."""
+        return self._function_name is not None
 
     def __str__(self) -> str:
         return self.name
@@ -896,6 +906,11 @@ class SQLQuery:
     def order_by(self) -> typing.Optional[OrderBy]:
         """How the results of the query should be ordered."""
         return self._order_by
+
+    @property
+    def has_functions(self) -> bool:
+        """"Whether the SQL query has any functions in its selected columns."""
+        return any(col.is_function for col in self.columns)
 
     def add_filter_to_table(self, sql_filter: Filter):
         """Associates the given Filter with the Table that it applies to.

--- a/tipping/sqlalchemy-fauna/sqlalchemy_fauna/fauna/translation/models.py
+++ b/tipping/sqlalchemy-fauna/sqlalchemy_fauna/fauna/translation/models.py
@@ -6,6 +6,7 @@ import itertools
 import typing
 from datetime import datetime
 import enum
+import re
 
 from sqlparse import sql as token_groups, tokens as token_types
 from mypy_extensions import TypedDict
@@ -42,6 +43,8 @@ REVERSE_JOIN = {
     JoinDirection.LEFT: JoinDirection.RIGHT,
     JoinDirection.RIGHT: JoinDirection.LEFT,
 }
+
+NOT_SUPPORTED_FUNCTION_REGEX = re.compile(r"^(?:MIN|MAX|AVG|SUM)\(.+\)$", re.IGNORECASE)
 
 
 class Column:
@@ -156,6 +159,11 @@ class Column:
                 i=token_groups.Identifier, idx=idx
             )
             alias = alias_identifier.value
+
+        if re.match(NOT_SUPPORTED_FUNCTION_REGEX, name):
+            raise exceptions.NotSupportedError(
+                "MIN, MAX, AVG, and SUM functions are not yet supported."
+            )
 
         column_params: ColumnParams = {
             "table_name": table_name,

--- a/tipping/sqlalchemy-fauna/sqlalchemy_fauna/fauna/translation/select.py
+++ b/tipping/sqlalchemy-fauna/sqlalchemy_fauna/fauna/translation/select.py
@@ -2,9 +2,8 @@
 
 import functools
 import typing
-from functools import reduce, partial
 
-from sqlparse import tokens as token_types, sql as token_groups
+from sqlparse import sql as token_groups
 from faunadb import query as q
 from faunadb.objects import _Expr as QueryExpression
 
@@ -17,162 +16,7 @@ FunctionMap = typing.Dict[str, CalculationFunction]
 TableFunctionMap = typing.Dict[str, FunctionMap]
 
 
-def _parse_function(
-    collection: QueryExpression,
-    function_map: typing.Dict[str, typing.Any],
-    identifier: token_groups.Identifier,
-) -> TableFunctionMap:
-    if not isinstance(identifier, token_groups.Identifier):
-        return function_map
-
-    _, function_token = identifier.token_next_by(i=token_groups.Function)
-
-    if function_token is None:
-        return function_map
-
-    function_name = function_token.value
-    _, function_id = function_token.token_next_by(i=token_groups.Identifier)
-    _, function_type = function_id.token_next_by(t=token_types.Name)
-    _, parenthesis = function_token.token_next_by(i=token_groups.Parenthesis)
-    _, table_column_identifier = parenthesis.token_next_by(i=token_groups.Identifier)
-    _, table_column_separator = table_column_identifier.token_next_by(
-        m=(token_types.Punctuation, ".")
-    )
-
-    if table_column_separator is None:
-        table_name = None
-    else:
-        _, table = table_column_identifier.token_next_by(t=token_types.Name)
-        table_name = table.value
-
-    if function_type.value.lower() == "count":
-        calculation = q.count(collection)
-    else:
-        raise exceptions.NotSupportedError(
-            "MIN, MAX, AVG, and SUM functions are not yet supported."
-        )
-
-    if table_name is None:
-        assert len(function_map.keys()) == 1
-        return {
-            key: {**value, function_name: calculation}
-            for key, value in function_map.items()
-        }
-
-    return {
-        **function_map,
-        table_name: {**function_map.get(table_name, {}), function_name: calculation},
-    }
-
-
-def _parse_functions(
-    collection: QueryExpression,
-    identifiers: typing.Union[
-        token_groups.Identifier, token_groups.IdentifierList, token_groups.Function
-    ],
-    table_name: str,
-) -> TableFunctionMap:
-    parse_function = partial(_parse_function, collection)
-
-    if isinstance(identifiers, token_groups.Function):
-        return parse_function({table_name: {}}, token_groups.Identifier([identifiers]))
-
-    if isinstance(identifiers, token_groups.Identifier):
-        return parse_function({table_name: {}}, identifiers)
-
-    return reduce(parse_function, identifiers, {table_name: {}})
-
-
-def _translate_select_with_functions(
-    table: models.Table,
-    field_functions: FunctionMap,
-):
-    documents_to_select = fql.define_document_set(table)
-    field_alias_map = table.column_alias_map
-    selected_fields = list(field_alias_map.keys())
-
-    apply_alias = lambda field_name: q.select(
-        field_name, field_alias_map, default=field_name
-    )
-
-    extract_basic_field_value = lambda document, field_name: q.let(
-        {"value": q.select(field_name, document, common.NULL)},
-        q.if_(q.equals(q.var("value"), common.NULL), None, q.var("value")),
-    )
-    extract_document_value = lambda document, field_name: q.select(
-        field_name,
-        field_functions,
-        default=extract_basic_field_value(document, field_name),
-    )
-    translate_to_alias = lambda document, field_name: [
-        apply_alias(field_name),
-        extract_document_value(document, field_name),
-    ]
-
-    flatten_document_fields = lambda document: q.let(
-        {
-            "field_items": q.map_(
-                q.lambda_(
-                    ["field_name", "field_value"],
-                    q.if_(
-                        q.equals(q.var("field_name"), common.DATA),
-                        q.to_array(q.var("field_value")),
-                        # We put single key/value pairs in nested arrays to match
-                        # the structure of the nested 'data' key/values
-                        [[q.var("field_name"), q.var("field_value")]],
-                    ),
-                ),
-                q.to_array(document),
-            ),
-            "flattened_items": q.if_(
-                q.is_empty(q.var("field_items")),
-                q.var("field_items"),
-                q.union(q.var("field_items")),
-            ),
-        },
-        q.to_object(q.var("flattened_items")),
-    )
-    # We map over selected_fields to build document object to maintain the order
-    # of fields as queried. Otherwise, SQLAlchemy gets confused and assigns values
-    # to the incorrect keys.
-    apply_field_aliases = lambda document: q.to_object(
-        q.map_(
-            q.lambda_(
-                "field_name",
-                translate_to_alias(document, q.var("field_name")),
-            ),
-            selected_fields,
-        )
-    )
-
-    # With aggregation functions, standard behaviour is to include the first value
-    # if any column selections are part of the query, at least until we add support
-    # for GROUP BY
-    get_first_document = lambda documents: q.let(
-        {
-            "first_document": q.select(
-                0, q.paginate(documents, size=fql.MAX_PAGE_SIZE), default=common.NULL
-            )
-        },
-        q.if_(
-            q.equals(q.var("first_document"), common.NULL),
-            {},
-            q.get(q.var("first_document")),
-        ),
-    )
-
-    return q.let(
-        {
-            "documents": documents_to_select,
-            "response": apply_field_aliases(
-                flatten_document_fields(get_first_document((q.var("documents"))))
-            ),
-        },
-        {common.DATA: [q.var("response")]},
-    )
-
-
-def _translate_select_without_functions(sql_query: models.SQLQuery, distinct=False):
+def _translate_select(sql_query: models.SQLQuery, distinct=False):
     tables = sql_query.tables
     from_table = tables[0]
     order_by = sql_query.order_by
@@ -192,7 +36,6 @@ def _translate_select_without_functions(sql_query: models.SQLQuery, distinct=Fal
                 "the ordering constraint."
             )
         maybe_documents_to_select = fql.join_collections(from_table, order_by)
-
     else:
         document_set = fql.define_document_set(from_table)
         if order_by is None:
@@ -216,7 +59,9 @@ def _translate_select_without_functions(sql_query: models.SQLQuery, distinct=Fal
                 q.paginate(ordered_result, size=fql.MAX_PAGE_SIZE),
             )
 
-    if sql_query.limit is not None:
+    # Don't want to apply limit to queries with functions, because we want the calculation
+    # for the entire document set, and functions only return the first row anyway
+    if sql_query.limit is not None and not sql_query.has_functions:
         maybe_documents_to_select = q.take(sql_query.limit, maybe_documents_to_select)
 
     initial_field_alias_map: typing.Dict[str, typing.Dict[str, str]] = {}
@@ -232,66 +77,116 @@ def _translate_select_without_functions(sql_query: models.SQLQuery, distinct=Fal
         initial_field_alias_map,
     )
 
-    translate_fields_to_aliases = lambda document: q.lambda_(
-        ["collection_name", "field_name"],
-        q.let(
-            {
-                "alias_name": q.select(
-                    [q.var("collection_name"), q.var("field_name")],
-                    field_alias_map,
-                    default=q.var("field_name"),
-                ),
-                "field_value": q.select(
-                    [q.var("collection_name"), q.var("field_name")],
-                    document,
-                    default=common.NULL,
-                ),
-            },
-            [
-                q.var("alias_name"),
-                q.if_(
-                    q.equals(q.var("field_value"), common.NULL),
-                    None,
-                    q.var("field_value"),
-                ),
-            ],
+    get_field_value = lambda function_value, raw_value: q.if_(
+        q.equals(function_value, common.NULL),
+        q.if_(q.equals(raw_value, common.NULL), None, raw_value),
+        q.select(["data", 0], function_value),
+    )
+
+    calculate_function_value = lambda document_set, function_name: q.if_(
+        q.is_null(function_name),
+        common.NULL,
+        q.if_(
+            q.equals(function_name, models.Function.COUNT.value),
+            q.count(document_set),
+            common.NULL,
         ),
     )
 
-    translate_document_fields = q.lambda_(
-        "maybe_document",
-        q.let(
-            {
-                "document": q.if_(
-                    q.is_ref(q.var("maybe_document")),
-                    {
-                        from_table.name: q.merge(
-                            q.select(common.DATA, q.get(q.var("maybe_document"))),
-                            {"ref": q.var("maybe_document")},
-                        )
-                    },
-                    q.var("maybe_document"),
-                ),
-            },
-            q.to_object(
-                q.map_(
-                    translate_fields_to_aliases(q.var("document")),
-                    # We map over selected_fields to build document object to maintain the order
-                    # of fields as queried. Otherwise, SQLAlchemy gets confused and assigns values
-                    # to the incorrect keys.
-                    [[col.table_name, col.name] for col in sql_query.columns],
-                )
-            ),
+    translate_fields_to_aliases = lambda collection_name, field_name: q.select(
+        [collection_name, field_name],
+        field_alias_map,
+        default=q.var("field_name"),
+    )
+
+    # With aggregation functions, standard behaviour is to include the first value
+    # if any column selections are part of the query, at least until we add support
+    # for GROUP BY
+    get_first_document = lambda documents: q.let(
+        {"maybe_first_document": q.select(0, documents, default=common.NULL)},
+        q.if_(
+            q.equals(q.var("maybe_first_document"), common.NULL),
+            [{}],
+            [q.get(q.var("maybe_first_document"))],
         ),
     )
-    translate_documents = lambda maybe_documents: q.map_(
-        translate_document_fields, maybe_documents
+
+    translate_document_fields = lambda maybe_documents: q.let(
+        {
+            # We map over selected_fields to build document object
+            # to maintain the order of fields as queried. Otherwise,
+            # SQLAlchemy gets confused and assigns values to the incorrect keys.
+            "selected_column_info": [
+                [col.table_name, col.name, col.function_name]
+                for col in sql_query.columns
+            ],
+            "has_functions": any(col.function_name for col in sql_query.columns),
+            "maybe_document_set": q.if_(
+                q.var("has_functions"),
+                get_first_document(maybe_documents),
+                maybe_documents,
+            ),
+        },
+        q.map_(
+            q.lambda_(
+                "maybe_document",
+                q.let(
+                    {
+                        "document": q.if_(
+                            q.is_ref(q.var("maybe_document")),
+                            {
+                                from_table.name: q.merge(
+                                    q.select(
+                                        common.DATA, q.get(q.var("maybe_document"))
+                                    ),
+                                    {"ref": q.var("maybe_document")},
+                                )
+                            },
+                            q.var("maybe_document"),
+                        ),
+                    },
+                    q.to_object(
+                        q.map_(
+                            q.lambda_(
+                                ["collection_name", "field_name", "function_name"],
+                                q.let(
+                                    {
+                                        "function_value": calculate_function_value(
+                                            maybe_documents, q.var("function_name")
+                                        ),
+                                        "raw_value": q.select(
+                                            [
+                                                q.var("collection_name"),
+                                                q.var("field_name"),
+                                            ],
+                                            q.var("document"),
+                                            default=common.NULL,
+                                        ),
+                                    },
+                                    [
+                                        translate_fields_to_aliases(
+                                            q.var("collection_name"),
+                                            q.var("field_name"),
+                                        ),
+                                        get_field_value(
+                                            q.var("function_value"), q.var("raw_value")
+                                        ),
+                                    ],
+                                ),
+                            ),
+                            q.var("selected_column_info"),
+                        )
+                    ),
+                ),
+            ),
+            q.var("maybe_document_set"),
+        ),
     )
 
     return q.let(
         {
             "maybe_documents": maybe_documents_to_select,
-            "translated_documents": translate_documents(q.var("maybe_documents")),
+            "translated_documents": translate_document_fields(q.var("maybe_documents")),
             "result": q.distinct(q.var("translated_documents"))
             if distinct
             else q.var("translated_documents"),
@@ -319,21 +214,4 @@ def translate_select(sql_statement: token_groups.Statement) -> QueryExpression:
     """
     sql_query = models.SQLQuery.from_statement(sql_statement)
 
-    _, identifiers = sql_statement.token_next_by(
-        i=(token_groups.Identifier, token_groups.IdentifierList, token_groups.Function)
-    )
-    tables = sql_query.tables
-
-    for table in tables:
-        table_functions = _parse_functions(q.var("documents"), identifiers, table.name)
-        field_functions = table_functions[table.name]
-
-        if any(field_functions):
-            if len(tables) > 1:
-                raise exceptions.NotSupportedError(
-                    "SQL functions across multiple tables are not yet supported."
-                )
-
-            return _translate_select_with_functions(table, field_functions)
-
-    return _translate_select_without_functions(sql_query, distinct=sql_query.distinct)
+    return _translate_select(sql_query, distinct=sql_query.distinct)

--- a/tipping/sqlalchemy-fauna/tests/integration/test_sqlalchemy_fauna.py
+++ b/tipping/sqlalchemy-fauna/tests/integration/test_sqlalchemy_fauna.py
@@ -404,7 +404,7 @@ def test_join_order_by(fauna_session):
 
 def test_limit(fauna_session):
     limit = 2
-    user_names = [Fake.first_name() for _ in range(limit * 2)]
+    user_names = [f"{Fake.first_name()} {n}" for n in range(limit * 2)]
 
     for name in user_names:
         factories.UserFactory(name=name)
@@ -415,6 +415,25 @@ def test_limit(fauna_session):
     queried_user_names = [user.name for user in queried_users]
 
     assert queried_user_names == user_names[:limit]
+
+
+def test_multi_table_limit(fauna_session):
+    limit = 2
+    children_names = [f"{Fake.first_name()} {n}" for n in range(limit * 2)]
+
+    for name in children_names:
+        factories.ChildFactory(name=name)
+
+    queried_children = (
+        fauna_session.execute(
+            sql.select(models.Child, models.User).join(models.Child.user).limit(limit)
+        )
+        .scalars()
+        .all()
+    )
+    queried_children_names = [child.name for child in queried_children]
+
+    assert queried_children_names == children_names[:limit]
 
 
 def test_update(fauna_session):

--- a/tipping/sqlalchemy-fauna/tests/unit/translation/test_delete.py
+++ b/tipping/sqlalchemy-fauna/tests/unit/translation/test_delete.py
@@ -4,16 +4,17 @@ import pytest
 import sqlparse
 from faunadb.objects import _Expr as QueryExpression
 
-from sqlalchemy_fauna.fauna.translation import delete
+from sqlalchemy_fauna.fauna.translation import delete, models
 
 
 base_delete = "DELETE FROM users"
 delete_where = base_delete + " WHERE users.name = 'Bob'"
 
 
-@pytest.mark.parametrize("sql_query", [base_delete, delete_where])
-def test_translate_delete(sql_query):
-    fql_queries = delete.translate_delete(sqlparse.parse(sql_query)[0])
+@pytest.mark.parametrize("sql_string", [base_delete, delete_where])
+def test_translate_delete(sql_string):
+    statement = sqlparse.parse(sql_string)[0]
+    sql_query = models.SQLQuery.from_statement(statement)
+    fql_query = delete.translate_delete(sql_query)
 
-    for fql_query in fql_queries:
-        assert isinstance(fql_query, QueryExpression)
+    assert isinstance(fql_query, QueryExpression)

--- a/tipping/sqlalchemy-fauna/tests/unit/translation/test_models.py
+++ b/tipping/sqlalchemy-fauna/tests/unit/translation/test_models.py
@@ -34,6 +34,19 @@ def test_column_from_identifier(column_sql, expected_table_name, expected_alias)
     assert column.alias == expected_alias
 
 
+@pytest.mark.parametrize(
+    ["column_sql_string", "error_message"],
+    [("SUM(users.id) AS sum_1", "SUM"), ("AVG(users.id) AS avg_1", "AVG")],
+)
+def test_unsupported_column_from_identifier(column_sql_string, error_message):
+    sql_string = f"SELECT {column_sql_string} FROM users"
+    statement = sqlparse.parse(sql_string)[0]
+    _, column_identifier = statement.token_next_by(i=(token_groups.Identifier))
+
+    with pytest.raises(exceptions.NotSupportedError, match=error_message):
+        models.Column.from_identifier(column_identifier)
+
+
 def test_column_from_comparison_group():
     sql_string = "UPDATE users SET users.name = 'Bob'"
     statement = sqlparse.parse(sql_string)[0]

--- a/tipping/sqlalchemy-fauna/tests/unit/translation/test_models.py
+++ b/tipping/sqlalchemy-fauna/tests/unit/translation/test_models.py
@@ -35,6 +35,27 @@ def test_column_from_identifier(column_sql, expected_table_name, expected_alias)
 
 
 @pytest.mark.parametrize(
+    ["column_sql", "expected_name", "expected_function"],
+    [
+        (
+            f"count(users.{column_name})",
+            f"count(users.{column_name})",
+            models.Function.COUNT,
+        ),
+    ],
+)
+def test_column_from_function_identifier(column_sql, expected_name, expected_function):
+    sql_string = f"SELECT {column_sql} FROM users"
+    statement = sqlparse.parse(sql_string)[0]
+    _, column_function = statement.token_next_by(i=(token_groups.Function))
+
+    column = models.Column.from_identifier(token_groups.Identifier([column_function]))
+
+    assert column.name == expected_name
+    assert column.function_name == expected_function
+
+
+@pytest.mark.parametrize(
     ["column_sql_string", "error_message"],
     [("SUM(users.id) AS sum_1", "SUM"), ("AVG(users.id) AS avg_1", "AVG")],
 )

--- a/tipping/sqlalchemy-fauna/tests/unit/translation/test_models.py
+++ b/tipping/sqlalchemy-fauna/tests/unit/translation/test_models.py
@@ -52,7 +52,7 @@ def test_column_from_function_identifier(column_sql, expected_name, expected_fun
     column = models.Column.from_identifier(token_groups.Identifier([column_function]))
 
     assert column.name == expected_name
-    assert column.function_name == expected_function
+    assert column.function_name == expected_function.value
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
`DELETE` and `SELECT` were the last of the DML queries that still included SQL parsing with their FQL query building. In order to remove the parsing from `translate_select`, I had to add some function-related methods to the `Column` and `SQLQuery` classes, as well as further complicate already-complicated FQL-building logic, but it seems to work.