### PR TITLE
Disable Lambdas for the end of the season

### DIFF
--- a/tipping/serverless.yml
+++ b/tipping/serverless.yml
@@ -51,20 +51,20 @@ functions:
       - schedule:
           # Monday-Tuesday, 12am UTC
           rate: cron(0 0 ? * 2-3 *)
-          enabled: true
+          enabled: false
   update_match_predictions:
     handler: handler.update_match_predictions
     events:
       - schedule:
           # Everyday, 12am UTC
           rate: cron(0 0 ? * 1-7 *)
-          enabled: true
+          enabled: false
           input:
             ml_model_names: tipresias_margin_2021,tipresias_proba_2021
       - schedule:
           # Everyday, 1am UTC
           rate: cron(0 1 ? * 1-7 *)
-          enabled: true
+          enabled: false
           input:
             ml_model_names: tipresias_margin_2020,tipresias_proba_2020
   update_matches:
@@ -73,11 +73,11 @@ functions:
       - schedule:
           # Wednesday, 12am UTC
           rate: cron(0 0 ? * 4 *)
-          enabled: true
+          enabled: false
   update_match_results:
     handler: handler.update_match_results
     events:
       - schedule:
           # Thurs-Sun, 2am-2pm UTC (next day, 12pm/1pm-12am/1am Melbourne time, depending on DST)
           rate: cron(0 2-14/3 ? * 1,5-7 *)
-          enabled: true
+          enabled: false


### PR DESCRIPTION
No reason to run them while there aren't any matches.