### PR TITLE
Add support for OR conditions in queries

### DIFF
--- a/tipping/sqlalchemy-fauna/sqlalchemy_fauna/fauna/client.py
+++ b/tipping/sqlalchemy-fauna/sqlalchemy_fauna/fauna/client.py
@@ -72,10 +72,7 @@ class FaunaClient:
             # to create anything. Rather than raise an error, we return an empty response.
             if (
                 all(
-                    [
-                        error["code"] == "invalid ref"
-                        for error in fauna_response["errors"]
-                    ]
+                    error["code"] == "invalid ref" for error in fauna_response["errors"]
                 )
                 and "FROM information_schema_tables_" in sql_query
             ):

--- a/tipping/sqlalchemy-fauna/sqlalchemy_fauna/fauna/fql/common.py
+++ b/tipping/sqlalchemy-fauna/sqlalchemy_fauna/fauna/fql/common.py
@@ -78,9 +78,7 @@ def index_name(
     assert is_valid_column_name
 
     is_valid_foreign_key_name = foreign_key_name is None or (
-        foreign_key_name is not None
-        and column_name is not None
-        and index_type == IndexType.REF
+        foreign_key_name is not None and index_type == IndexType.REF
     )
     assert is_valid_foreign_key_name
 

--- a/tipping/sqlalchemy-fauna/sqlalchemy_fauna/fauna/fql/common.py
+++ b/tipping/sqlalchemy-fauna/sqlalchemy_fauna/fauna/fql/common.py
@@ -254,164 +254,62 @@ def define_document_set(
     return q.intersection(*document_sets)
 
 
-def _build_merge(*table_names: str):
-    merge = lambda agg_merge, table_name: q.merge(
-        agg_merge, {table_name: q.var(f"{table_name}_data")}
-    )
-    return functools.reduce(merge, table_names, q.merge({}, {}))
-
-
-def _build_base_page(table_name: str, inner_query: QueryExpression, order_by=None):
-    if order_by is None:
-        return q.select(
-            DATA,
-            q.map_(
-                q.lambda_(f"{table_name}_ref", inner_query),
-                q.paginate(q.var(f"joined_{table_name}"), size=MAX_PAGE_SIZE),
-            ),
-        )
-
-    if len({column.table_name for column in order_by.columns}) != len(order_by.columns):
-        raise exceptions.NotSupportedError(
-            "Sorting by multiple columns in a single table is not supported."
-        )
-
-    try:
-        order_column_name = next(
-            column.name
-            for column in order_by.columns
-            if column.table_name == table_name
-        )
-    except StopIteration:
-        return q.select(
-            DATA,
-            q.map_(
-                q.lambda_(f"{table_name}_ref", inner_query),
-                q.paginate(q.var(f"joined_{table_name}"), size=MAX_PAGE_SIZE),
-            ),
-        )
-
-    ref_set = q.join(
-        q.var(f"joined_{table_name}"),
-        q.index(
-            index_name(
-                table_name,
-                column_name=order_column_name,
-                index_type=IndexType.SORT,
-            )
-        ),
-    )
-    if order_by.direction == sql.OrderDirection.DESC:
-        ref_set = q.reverse(ref_set)
-
-    return q.select(
-        DATA,
-        q.map_(
-            q.lambda_(["_", f"{table_name}_ref"], inner_query),
-            q.paginate(ref_set, size=MAX_PAGE_SIZE),
-        ),
-    )
-
-
-def _build_page_query(
+def _build_intersecting_query(
+    filter_group: sql.FilterGroup,
+    acc_query: typing.Optional[QueryExpression],
     table: sql.Table,
-    merge_func: typing.Callable[[str], QueryExpression],
-    filter_group: typing.Optional[sql.FilterGroup] = None,
-    order_by: typing.Optional[sql.OrderBy] = None,
-):
-    partial_merge_func = functools.partial(merge_func, table.name)
-    right_table = table.right_join_table
-    left_table = table.left_join_table
+    direction: str,
+) -> QueryExpression:
+    opposite_direction = "left" if direction == "right" else "right"
+    document_set = define_document_set(table, filter_group)
 
-    assert right_table is not None or left_table is not None, (
-        "At least two tables must be included in a join query. "
-        "If only querying one table, use `define_document_set` instead."
-    )
-
-    if right_table is None:
-        # The inner-most page doesn't need a Union, because there aren't nested pages
-        # to flatten
-        inner_query = q.let(
-            {
-                f"{table.name}_doc": q.get(q.var(f"{table.name}_ref")),
-                f"{table.name}_data": q.merge(
-                    q.select(DATA, q.var(f"{table.name}_doc")),
-                    {"ref": q.select("ref", q.var(f"{table.name}_doc"))},
-                ),
-            },
-            partial_merge_func(),
-        )
-        page = _build_base_page(table.name, inner_query, order_by=order_by)
+    if acc_query is None:
+        intersection = document_set
     else:
-        page = q.union(
-            _build_base_page(
-                table.name,
-                _build_page_query(
-                    right_table,
-                    partial_merge_func,
-                    filter_group=filter_group,
-                    order_by=order_by,
-                ),
-                order_by=order_by,
-            )
-        )
+        intersection = q.intersection(acc_query, document_set)
 
-    if left_table is None:
-        return q.let(
-            {
-                f"joined_{table.name}": define_document_set(table, filter_group),
-            },
-            page,
-        )
+    next_table = getattr(table, f"{direction}_join_table")
 
-    left_join_key = table.left_join_key
+    if next_table is None or table.has_columns:
+        return intersection
 
-    if left_join_key is not None and left_join_key.name == "ref":
-        left_foreign_key = left_table.right_join_key
-        assert left_foreign_key is not None
-        return q.let(
-            {
-                f"{left_table.name}_doc": q.get(q.var(f"{left_table.name}_ref")),
-                f"{left_table.name}_data": q.merge(
-                    q.select(DATA, q.var(f"{left_table.name}_doc")),
-                    {"ref": q.select("ref", q.var(f"{left_table.name}_doc"))},
-                ),
-                f"{table.name}_ref": q.select(
-                    left_foreign_key.name, q.var(f"{left_table.name}_data")
-                ),
-                table.name: define_document_set(table, filter_group),
-                f"joined_{table.name}": q.intersection(
-                    q.singleton(q.var(f"{table.name}_ref")), q.var(table.name)
-                ),
-            },
-            page,
-        )
+    next_join_key = getattr(table, f"{direction}_join_key")
+    assert next_join_key is not None
 
-    left_foreign_key = left_join_key
-    assert left_foreign_key is not None
-    return q.let(
-        {
-            f"{left_table.name}_doc": q.get(q.var(f"{left_table.name}_ref")),
-            f"{left_table.name}_data": q.merge(
-                q.select(DATA, q.var(f"{left_table.name}_doc")),
-                {"ref": q.select("ref", q.var(f"{left_table.name}_doc"))},
+    if next_join_key.name == "ref":
+        next_foreign_key = getattr(next_table, f"{opposite_direction}_join_key")
+        assert next_foreign_key is not None
+
+        return _build_intersecting_query(
+            filter_group,
+            q.join(
+                intersection,
+                q.index(
+                    index_name(
+                        next_table.name,
+                        column_name=next_foreign_key.name,
+                        index_type=IndexType.REF,
+                    )
+                ),
             ),
-            table.name: define_document_set(table, filter_group),
-            f"joined_{table.name}": q.intersection(
-                q.match(
-                    q.index(
-                        index_name(
-                            table.name,
-                            column_name=left_foreign_key.name,
-                            index_type=IndexType.REF,
-                        )
-                    ),
-                    q.var(f"{left_table.name}_ref"),
-                ),
-                q.var(table.name),
+            next_table,
+            direction,
+        )
+
+    return _build_intersecting_query(
+        filter_group,
+        q.join(
+            intersection,
+            q.index(
+                index_name(
+                    table.name,
+                    index_type=IndexType.REF,
+                    foreign_key_name=next_join_key.name,
+                )
             ),
-        },
-        page,
+        ),
+        next_table,
+        direction,
     )
 
 
@@ -429,32 +327,44 @@ def join_collections(sql_query: sql.SQLQuery) -> QueryExpression:
     tables = sql_query.tables
     order_by = sql_query.order_by
     from_table = tables[0]
+    to_table = tables[-1]
+    table_with_columns = next(table for table in tables if table.has_columns)
 
-    if order_by is not None and order_by.columns[0].table_name != from_table.name:
+    if (
+        order_by is not None
+        and order_by.columns[0].table_name != table_with_columns.name
+    ):
         raise exceptions.NotSupportedError(
             "Fauna uses indexes for both joining and ordering of results, "
             "and we currently can only sort the principal table "
-            "(i.e. the one after 'FROM') in the query. You can sort on a column "
-            "from the principal table, query one table at a time, or remove "
-            "the ordering constraint."
+            "(i.e. the one whose columns are being selected or modified) in the query. "
+            "You can sort on a column from the principal table, query one table at a time, "
+            "or remove the ordering constraint."
+        )
+
+    if not any(sql_query.filter_groups):
+        raise exceptions.NotSupportedError(
+            "Joining tables without cross-table filters via the WHERE clause is not supported. "
+            "Selecting columns from multiple tables is not supported either, "
+            "so there's no performance gain from joining tables without cross-table conditions "
+            "for filtering query results."
         )
 
     assert from_table.left_join_table is None
 
-    if any(sql_query.filter_groups):
-        return q.union(
-            [
-                _build_page_query(
-                    from_table,
-                    _build_merge,
-                    filter_group=filter_group,
-                    order_by=order_by,
-                )
-                for filter_group in sql_query.filter_groups
+    intersection_queries = []
+
+    for filter_group in sql_query.filter_groups:
+        intersection_query = q.intersection(
+            *[
+                _build_intersecting_query(filter_group, None, table, direction)
+                for table, direction in [(from_table, "right"), (to_table, "left")]
             ]
         )
 
-    return _build_page_query(from_table, _build_merge, order_by=order_by)
+        intersection_queries.append(intersection_query)
+
+    return q.union(*intersection_queries)
 
 
 def update_documents(sql_query: sql.SQLQuery) -> QueryExpression:

--- a/tipping/sqlalchemy-fauna/sqlalchemy_fauna/fauna/fql/select.py
+++ b/tipping/sqlalchemy-fauna/sqlalchemy_fauna/fauna/fql/select.py
@@ -49,7 +49,9 @@ def _define_document_pages(sql_query: sql.SQLQuery) -> QueryExpression:
         )
 
     if len(tables) > 1:
-        ordered_document_set = common.join_collections(sql_query)
+        ordered_document_set = q.paginate(
+            common.join_collections(sql_query), size=common.MAX_PAGE_SIZE
+        )
     else:
         ordered_document_set = _define_single_collection_pages(sql_query)
 

--- a/tipping/sqlalchemy-fauna/sqlalchemy_fauna/fauna/fql/select.py
+++ b/tipping/sqlalchemy-fauna/sqlalchemy_fauna/fauna/fql/select.py
@@ -1,5 +1,6 @@
 """Translate a SELECT SQL query into an equivalent FQL query."""
 
+import typing
 from faunadb import query as q
 from faunadb.objects import _Expr as QueryExpression
 
@@ -9,33 +10,44 @@ from . import common
 
 def _define_single_collection_pages(sql_query: sql.SQLQuery) -> QueryExpression:
     tables = sql_query.tables
-    order_by = sql_query.order_by
     from_table = tables[0]
     filter_group = (
         None if not any(sql_query.filter_groups) else sql_query.filter_groups[0]
     )
 
-    document_set = common.define_document_set(from_table, filter_group)
+    return common.define_document_set(from_table, filter_group)
 
+
+def _sort_document_set(
+    document_set: QueryExpression, order_by: typing.Optional[sql.OrderBy]
+):
     if order_by is None:
         return q.paginate(document_set, size=common.MAX_PAGE_SIZE)
 
-    ordered_result = q.join(
+    if len(order_by.columns) > 1:
+        raise exceptions.NotSupportedError(
+            "Ordering by multiple columns is not yet supported."
+        )
+
+    ordered_column = order_by.columns[0]
+    assert ordered_column.table_name is not None
+
+    ordered_document_set = q.join(
         document_set,
         q.index(
             common.index_name(
-                from_table.name,
-                column_name=order_by.columns[0].name,
+                ordered_column.table_name,
+                column_name=ordered_column.name,
                 index_type=common.IndexType.SORT,
             )
         ),
     )
     if order_by.direction == sql.OrderDirection.DESC:
-        ordered_result = q.reverse(ordered_result)
+        ordered_document_set = q.reverse(ordered_document_set)
 
     return q.map_(
         q.lambda_(["_", "ref"], q.var("ref")),
-        q.paginate(ordered_result, size=common.MAX_PAGE_SIZE),
+        q.paginate(ordered_document_set, size=common.MAX_PAGE_SIZE),
     )
 
 
@@ -43,18 +55,12 @@ def _define_document_pages(sql_query: sql.SQLQuery) -> QueryExpression:
     tables = sql_query.tables
     order_by = sql_query.order_by
 
-    if order_by is not None and len(order_by.columns) > 1:
-        raise exceptions.NotSupportedError(
-            "Ordering by multiple columns is not yet supported."
-        )
-
     if len(tables) > 1:
-        ordered_document_set = q.paginate(
-            common.join_collections(sql_query), size=common.MAX_PAGE_SIZE
-        )
+        document_set = common.join_collections(sql_query)
     else:
-        ordered_document_set = _define_single_collection_pages(sql_query)
+        document_set = _define_single_collection_pages(sql_query)
 
+    ordered_document_set = _sort_document_set(document_set, order_by)
     # Don't want to apply limit to queries with functions, because we want the calculation
     # for the entire document set, and functions only return the first row anyway
     if sql_query.limit is None or sql_query.has_functions:

--- a/tipping/sqlalchemy-fauna/sqlalchemy_fauna/fauna/translation/create.py
+++ b/tipping/sqlalchemy-fauna/sqlalchemy_fauna/fauna/translation/create.py
@@ -491,9 +491,13 @@ def _create_index_metadata(
         if field_name == "id":
             continue
 
-        index_by_field = partial(index_by_collection, field_name)
+        index_by_field = partial(index_by_collection, column_name=field_name)
 
-        indexes[index_by_field(fql.IndexType.VALUE)] = {
+        indexes[
+            index_by_field(  # pylint: disable=no-value-for-parameter
+                index_type=fql.IndexType.VALUE
+            )
+        ] = {
             "column_names_": f"{field_name},id",
             "unique_": False,
             "constrained_columns_": None,
@@ -503,7 +507,11 @@ def _create_index_metadata(
         # Sorting index, so we can support ORDER BY clauses in SQL queries.
         # This will allow us to order a set of refs by a value while still
         # keeping that same set of refs.
-        indexes[index_by_field(fql.IndexType.SORT)] = {
+        indexes[
+            index_by_field(  # pylint: disable=no-value-for-parameter
+                index_type=fql.IndexType.SORT
+            )
+        ] = {
             "column_names_": f"{field_name},id",
             "unique_": False,
             "constrained_columns_": None,
@@ -515,7 +523,11 @@ def _create_index_metadata(
         # contain the 'ref' field, which will never be duplicated
         is_unique = field_data["unique"]
         if is_unique:
-            indexes[index_by_field(fql.IndexType.TERM)] = {
+            indexes[
+                index_by_field(  # pylint: disable=no-value-for-parameter
+                    index_type=fql.IndexType.TERM
+                )
+            ] = {
                 "column_names_": f"{field_name},id",
                 "unique_": is_unique,
                 "constrained_columns_": None,
@@ -531,7 +543,11 @@ def _create_index_metadata(
             assert len(reference_items) == 1
             referred_table, referred_column = reference_items[0]
 
-            indexes[index_by_field(fql.IndexType.REF)] = {
+            indexes[
+                index_by_field(  # pylint: disable=no-value-for-parameter
+                    index_type=fql.IndexType.REF
+                )
+            ] = {
                 "column_names_": f"{field_name},id",
                 "unique_": False,
                 "constrained_columns_": field_name,
@@ -548,11 +564,13 @@ def _create_index_metadata(
                 referred_table, referred_column = reference_items[0]
 
                 indexes[
-                    index_by_field(fql.IndexType.REF, foreign_key_name=reference_name)
+                    index_by_collection(
+                        index_type=fql.IndexType.REF, foreign_key_name=reference_name
+                    )
                 ] = {
-                    "column_names_": ",".join(set([field_name, reference_name, "id"])),
+                    "column_names_": ",".join(set([reference_name, "id"])),
                     "unique_": False,
-                    "constrained_columns_": field_name,
+                    "constrained_columns_": reference_name,
                     "referred_table_": referred_table,
                     "referred_columns_": referred_column,
                 }
@@ -589,13 +607,15 @@ def _create_table_indices(
         if field_name == "id":
             continue
 
-        index_by_field = partial(index_by_collection, field_name)
+        index_by_field = partial(index_by_collection, column_name=field_name)
 
         index_queries.extend(
             [
                 q.create_index(
                     {
-                        "name": index_by_field(fql.IndexType.VALUE),
+                        "name": index_by_field(  # pylint: disable=no-value-for-parameter
+                            index_type=fql.IndexType.VALUE
+                        ),
                         "source": q.collection(table_name),
                         "values": [{"field": ["data", field_name]}, {"field": ["ref"]}],
                     }
@@ -605,7 +625,9 @@ def _create_table_indices(
                 # keeping that same set of refs.
                 q.create_index(
                     {
-                        "name": index_by_field(fql.IndexType.SORT),
+                        "name": index_by_field(  # pylint: disable=no-value-for-parameter
+                            index_type=fql.IndexType.SORT
+                        ),
                         "source": q.collection(table_name),
                         "terms": [{"field": ["ref"]}],
                         "values": [{"field": ["data", field_name]}, {"field": ["ref"]}],
@@ -621,7 +643,9 @@ def _create_table_indices(
             index_queries.append(
                 q.create_index(
                     {
-                        "name": index_by_field(fql.IndexType.TERM),
+                        "name": index_by_field(  # pylint: disable=no-value-for-parameter
+                            index_type=fql.IndexType.TERM
+                        ),
                         "source": q.collection(table_name),
                         "terms": [{"field": ["data", field_name]}],
                         "unique": is_unique,
@@ -636,7 +660,9 @@ def _create_table_indices(
             index_queries.append(
                 q.create_index(
                     {
-                        "name": index_by_field(fql.IndexType.REF),
+                        "name": index_by_field(  # pylint: disable=no-value-for-parameter
+                            index_type=fql.IndexType.REF
+                        ),
                         "source": q.collection(table_name),
                         "terms": [{"field": ["data", field_name]}],
                     }
@@ -649,14 +675,14 @@ def _create_table_indices(
                 index_queries.append(
                     q.create_index(
                         {
-                            "name": index_by_field(
-                                fql.IndexType.REF, foreign_key_name=foreign_reference
+                            "name": index_by_collection(
+                                index_type=fql.IndexType.REF,
+                                foreign_key_name=foreign_reference,
                             ),
                             "source": q.collection(table_name),
-                            "terms": [{"field": ["data", field_name]}],
+                            "terms": [{"field": ["ref"]}],
                             "values": [
                                 {"field": ["data", foreign_reference]},
-                                {"field": ["ref"]},
                             ],
                         }
                     )

--- a/tipping/sqlalchemy-fauna/sqlalchemy_fauna/sql/__init__.py
+++ b/tipping/sqlalchemy-fauna/sqlalchemy_fauna/sql/__init__.py
@@ -2,3 +2,4 @@
 
 from .sql_query import OrderDirection, SQLQuery, OrderBy
 from .sql_table import Table, Column, Filter, Function, FilterGroup
+from .common import extract_value

--- a/tipping/sqlalchemy-fauna/tests/fixtures/factories.py
+++ b/tipping/sqlalchemy-fauna/tests/fixtures/factories.py
@@ -5,7 +5,7 @@ from factory.alchemy import SQLAlchemyModelFactory
 from faker import Faker
 
 from .session import Session
-from .models import User, Child
+from .models import Food, User, Child
 
 
 Fake = Faker()
@@ -41,3 +41,16 @@ class ChildFactory(SQLAlchemyModelFactory):
     name = factory.Sequence(lambda n: f"{Fake.first_name()} {n}")
     user = factory.SubFactory(UserFactory)
     game = factory.Faker("bs")
+
+
+class FoodFactory(SQLAlchemyModelFactory):
+    """Factory class for the Food data model."""
+
+    class Meta:
+        """Factory attributes for recreating the associated model's attributes."""
+
+        model = Food
+        sqlalchemy_session = Session
+
+    name = factory.Sequence(lambda n: f"{Fake.word()} {n}")
+    flavor = factory.Faker("bs")

--- a/tipping/sqlalchemy-fauna/tests/fixtures/models.py
+++ b/tipping/sqlalchemy-fauna/tests/fixtures/models.py
@@ -1,9 +1,16 @@
 """Example model classes for use in integration tests."""
 
 from sqlalchemy import Column, Integer, String, DateTime, Boolean, Float, orm
-from sqlalchemy.sql.schema import ForeignKey
+from sqlalchemy.sql.schema import ForeignKey, Table
 
 from .session import Base
+
+users_foods_table = Table(
+    "users_foods",
+    Base.metadata,
+    Column("user_id", ForeignKey("users.id")),
+    Column("food_id", ForeignKey("foods.id")),
+)
 
 
 class User(Base):
@@ -20,6 +27,9 @@ class User(Base):
     account_credit = Column(Float, default=0.0)
     job = Column(String)
     children = orm.relationship("Child", back_populates="user")
+    favorite_foods = orm.relationship(
+        "Food", secondary=users_foods_table, back_populates="eaters"
+    )
 
 
 class Child(Base):
@@ -32,3 +42,16 @@ class Child(Base):
     user = orm.relationship("User", back_populates="children")
     name = Column(String, unique=True)
     game = Column(String)
+
+
+class Food(Base):
+    """Fake Food model for use in integration tests."""
+
+    __tablename__ = "foods"
+
+    id = Column(Integer, primary_key=True)
+    name = Column(String, unique=True)
+    flavor = Column(String)
+    eaters = orm.relationship(
+        "User", secondary=users_foods_table, back_populates="favorite_foods"
+    )

--- a/tipping/sqlalchemy-fauna/tests/fixtures/models.py
+++ b/tipping/sqlalchemy-fauna/tests/fixtures/models.py
@@ -5,13 +5,6 @@ from sqlalchemy.sql.schema import ForeignKey, Table
 
 from .session import Base
 
-users_foods_table = Table(
-    "users_foods",
-    Base.metadata,
-    Column("user_id", ForeignKey("users.id")),
-    Column("food_id", ForeignKey("foods.id")),
-)
-
 
 class User(Base):
     """Fake User model for use in integration tests."""
@@ -27,9 +20,7 @@ class User(Base):
     account_credit = Column(Float, default=0.0)
     job = Column(String)
     children = orm.relationship("Child", back_populates="user")
-    favorite_foods = orm.relationship(
-        "Food", secondary=users_foods_table, back_populates="eaters"
-    )
+    user_foods = orm.relationship("UserFood", back_populates="user")
 
 
 class Child(Base):
@@ -52,6 +43,16 @@ class Food(Base):
     id = Column(Integer, primary_key=True)
     name = Column(String, unique=True)
     flavor = Column(String)
-    eaters = orm.relationship(
-        "User", secondary=users_foods_table, back_populates="favorite_foods"
-    )
+    user_foods = orm.relationship("UserFood", back_populates="food")
+
+
+class UserFood(Base):
+    """Fake model for join table for users and foods."""
+
+    __tablename__ = "users_foods"
+
+    id = Column(Integer, primary_key=True)
+    user_id = Column(Integer, ForeignKey("users.id"))
+    user = orm.relationship("User", back_populates="user_foods")
+    food_id = Column(Integer, ForeignKey("foods.id"))
+    food = orm.relationship("Food", back_populates="user_foods")

--- a/tipping/sqlalchemy-fauna/tests/integration/test_sqlalchemy_fauna.py
+++ b/tipping/sqlalchemy-fauna/tests/integration/test_sqlalchemy_fauna.py
@@ -373,21 +373,6 @@ def test_order_by(fauna_session):
     assert user_names == list(reversed(sorted(names)))
 
 
-def test_join_order_by(fauna_session):
-    children = [ChildFactory() for _ in range(5)]
-    child_games = [child.game for child in children]
-
-    queried_children = (
-        fauna_session.execute(
-            sql.select(models.Child).join(models.Child.user).order_by(models.Child.game)
-        )
-        .scalars()
-        .all()
-    )
-
-    assert [child.game for child in queried_children] == sorted(child_games)
-
-
 def test_limit(fauna_session):
     limit = 2
     user_names = [f"{Fake.first_name()} {n}" for n in range(limit * 2)]
@@ -412,7 +397,10 @@ def test_multi_table_limit(fauna_session):
 
     queried_children = (
         fauna_session.execute(
-            sql.select(models.Child).join(models.Child.user).limit(limit)
+            sql.select(models.Child)
+            .join(models.Child.user)
+            .where(models.User.age > -1)
+            .limit(limit)
         )
         .scalars()
         .all()

--- a/tipping/sqlalchemy-fauna/tests/unit/fql/test_common.py
+++ b/tipping/sqlalchemy-fauna/tests/unit/fql/test_common.py
@@ -37,17 +37,24 @@ def test_index_name(params, expected_name):
 
 
 @pytest.mark.parametrize(
-    "params",
+    ["table_name", "kwargs"],
     [
-        ("users", "name"),
-        ("users", None, common.IndexType.VALUE),
-        ("users", None, common.IndexType.REF, "age"),
-        ("users", "name", common.IndexType.VALUE, "age"),
+        ("users", {"column_name": "name"}),
+        ("users", {"index_type": common.IndexType.VALUE}),
+        ("users", {"index_type": common.IndexType.VALUE, "foreign_key_name": "age"}),
+        (
+            "users",
+            {
+                "column_name": "name",
+                "index_type": common.IndexType.VALUE,
+                "foreign_key_name": "age",
+            },
+        ),
     ],
 )
-def test_invalid_index_name(params):
+def test_invalid_index_name(table_name, kwargs):
     with pytest.raises(AssertionError):
-        common.index_name(*params)
+        common.index_name(table_name, **kwargs)
 
 
 select_values = "SELECT * FROM users"

--- a/tipping/sqlalchemy-fauna/tests/unit/fql/test_common.py
+++ b/tipping/sqlalchemy-fauna/tests/unit/fql/test_common.py
@@ -145,9 +145,10 @@ def test_join_collections():
     select_string = f"SELECT {from_table}.name, {from_table}.age "
     from_string = f"FROM {from_table} "
     join_string = (
-        f"JOIN {first_child_table} ON {from_table}.id = {first_child_table}.user_id"
+        f"JOIN {first_child_table} ON {from_table}.id = {first_child_table}.user_id "
     )
-    sql_string = select_string + from_string + join_string
+    where_string = f"WHERE {first_child_table}.amount > 5.0"
+    sql_string = select_string + from_string + join_string + where_string
 
     sql_statement = sqlparse.parse(sql_string)[0]
     sql_query = sql.SQLQuery.from_statement(sql_statement)
@@ -156,12 +157,12 @@ def test_join_collections():
     assert isinstance(join_query, QueryExpression)
 
     second_child_table = "transactions"
-    select_string = select_string + f"{second_child_table}.amount "
     join_string = (
         join_string
-        + f" JOIN {second_child_table} ON {first_child_table}.id = {second_child_table}.account_id"
+        + f"JOIN {second_child_table} ON {first_child_table}.id = {second_child_table}.account_id "
     )
-    sql_string = select_string + from_string + join_string
+    where_string = where_string + f" AND {second_child_table}.count < 10"
+    sql_string = select_string + from_string + join_string + where_string
 
     sql_statement = sqlparse.parse(sql_string)[0]
     sql_query = sql.SQLQuery.from_statement(sql_statement)
@@ -170,12 +171,12 @@ def test_join_collections():
     assert isinstance(join_query, QueryExpression)
 
     first_parent_table = "banks"
-    select_string = select_string + f"{first_parent_table}.name "
     join_string = (
         join_string
-        + f" JOIN {first_parent_table} ON {first_parent_table}.id = {second_child_table}.bank_id"
+        + f"JOIN {first_parent_table} ON {first_parent_table}.id = {second_child_table}.bank_id "
     )
-    sql_string = select_string + from_string + join_string
+    where_string = where_string + f" OR {first_parent_table}.id = 'asdf1234'"
+    sql_string = select_string + from_string + join_string + where_string
 
     sql_statement = sqlparse.parse(sql_string)[0]
     sql_query = sql.SQLQuery.from_statement(sql_statement)
@@ -184,12 +185,12 @@ def test_join_collections():
     assert isinstance(join_query, QueryExpression)
 
     second_parent_table = "country"
-    select_string = select_string + f"{second_parent_table}.code "
     join_string = (
-        join_string + f" JOIN {second_parent_table} "
-        f"ON {first_parent_table}.id = {second_parent_table}.country_id"
+        join_string + f"JOIN {second_parent_table} "
+        f"ON {first_parent_table}.id = {second_parent_table}.country_id "
     )
-    sql_string = select_string + from_string + join_string
+    where_string = where_string + f" AND {second_parent_table}.code = 'AU'"
+    sql_string = select_string + from_string + join_string + where_string
 
     sql_statement = sqlparse.parse(sql_string)[0]
     sql_query = sql.SQLQuery.from_statement(sql_statement)
@@ -198,12 +199,25 @@ def test_join_collections():
     assert isinstance(join_query, QueryExpression)
 
 
-def test_invalid_join_collections():
-    sql_string = "SELECT users.name, users.age FROM users"
+@pytest.mark.parametrize(
+    ["sql_string", "error_message"],
+    [
+        (
+            "SELECT users.name, users.age FROM users",
+            "Joining tables without cross-table filters via the WHERE clause is not supported",
+        ),
+        (
+            "SELECT users.name, users.age FROM users JOIN transactions "
+            "ON users.id = transactions.user_id ORDER BY transactions.id",
+            "we currently can only sort the principal table",
+        ),
+    ],
+)
+def test_invalid_join_collections(sql_string, error_message):
     sql_statement = sqlparse.parse(sql_string)[0]
     sql_query = sql.SQLQuery.from_statement(sql_statement)
 
-    with pytest.raises(AssertionError):
+    with pytest.raises(exceptions.NotSupportedError, match=error_message):
         common.join_collections(sql_query)
 
 

--- a/tipping/sqlalchemy-fauna/tests/unit/fql/test_select.py
+++ b/tipping/sqlalchemy-fauna/tests/unit/fql/test_select.py
@@ -17,7 +17,7 @@ select_avg = "SELECT avg(users.id) AS avg_1 from users"
 select_join_order_by = (
     "SELECT accounts.name, accounts.number FROM users "
     "JOIN accounts ON users.id = accounts.user_id "
-    "ORDER BY accounts.number"
+    "ORDER BY users.id"
 )
 select_order_multiple = (
     "SELECT users.name, users.age FROM users ORDER BY users.name, users.age"
@@ -53,7 +53,8 @@ select_where_equals = select_values + " WHERE users.name = 'Bob'"
 select_count = "SELECT count(users.id) AS count_1 FROM users"
 select_join = (
     "SELECT users.name, users.age FROM users "
-    "JOIN accounts ON users.id = accounts.user_id"
+    "JOIN accounts ON users.id = accounts.user_id "
+    "WHERE accounts.amount > 5.0"
 )
 select_order_by = "SELECT users.name, users.age FROM users ORDER BY users.name"
 select_order_by_desc = (
@@ -62,6 +63,7 @@ select_order_by_desc = (
 select_join_order_by_principal = (
     "SELECT users.name, users.age FROM users "
     "JOIN accounts ON users.id = accounts.user_id "
+    "WHERE accounts.amount > 5.0 "
     "ORDER BY users.name"
 )
 
@@ -77,7 +79,10 @@ select_join_order_by_principal = (
         select_order_by,
         select_order_by_desc,
         select_join_order_by_principal,
-        "SELECT COUNT(users.id) FROM users JOIN accounts ON users.id = accounts.user_id",
+        (
+            "SELECT COUNT(users.id) FROM users JOIN accounts ON users.id = accounts.user_id "
+            "WHERE accounts.amount > 5.0"
+        ),
     ],
 )
 def test_translate_select(sql_string):

--- a/tipping/sqlalchemy-fauna/tests/unit/sql/test_sql_query.py
+++ b/tipping/sqlalchemy-fauna/tests/unit/sql/test_sql_query.py
@@ -20,6 +20,7 @@ class TestSQLQuery:
         column_name = Fake.word()
         column_alias = Fake.word()
         query = sql_query.SQLQuery(
+            "SELECT",
             tables=[
                 sql_table.Table(
                     name=table_name,
@@ -42,6 +43,7 @@ class TestSQLQuery:
     def test_validation():
         with pytest.raises(AssertionError, match="must have unique position values"):
             sql_query.SQLQuery(
+                "SELECT",
                 tables=[
                     sql_table.Table(
                         name=Fake.word(),
@@ -63,7 +65,7 @@ class TestSQLQuery:
             table_name="users", name="name", alias="name", position=0
         )
         table = sql_table.Table(name="users", columns=[column])
-        query = sql_query.SQLQuery(tables=[table])
+        query = sql_query.SQLQuery("SELECT", tables=[table])
         sql_filter = sql_table.Filter(column=column, operator="=", value="Bob")
 
         query.add_filter_to_table(sql_filter)

--- a/tipping/sqlalchemy-fauna/tests/unit/sql/test_sql_table.py
+++ b/tipping/sqlalchemy-fauna/tests/unit/sql/test_sql_table.py
@@ -178,10 +178,15 @@ class TestTable:
         assert table.filters[0].value == sql_filters[0].value
 
     @staticmethod
-    def test_table_from_identifier():
-        table_name = "users"
-        sql_query = f"SELECT users.name FROM {table_name}"
-        statement = sqlparse.parse(sql_query)[0]
+    @pytest.mark.parametrize(
+        ["table_name", "sql_string"],
+        [
+            ["users", "SELECT users.name FROM users"],
+            ["users", "SELECT users.name FROM users AS users_1"],
+        ],
+    )
+    def test_table_from_identifier(table_name, sql_string):
+        statement = sqlparse.parse(sql_string)[0]
         idx, _ = statement.token_next_by(m=(token_types.Keyword, "FROM"))
         _, table_identifier = statement.token_next_by(
             i=(token_groups.Identifier), idx=idx


### PR DESCRIPTION
I've managed to get pretty far without bothering with supporting `OR` in `WHERE` clauses, but now I need it. I scrapped the nested maps in favour of joining sets throughout the process of building the queries. This requires the restriction that queries with joins can only return documents from a single collection, but given typical ORM CRUD operations this seemed less of a problem than the incredibly expensive queries required to continue with the nested maps while also allowing for `OR` conditions. It also greatly simplifies the query-building logic, so I feel pretty good about it.

To be able to join sets properly, I changed the foreign-reference indices that we create on collection creation. These were holdovers from my initial ideas around how to join collections, but I didn't end up using them. It turns out that what I needed was not from one foreign key to another, but from a given collection's refs to the foreign ref.