### PR TITLE
Add support for 'OR' conditional logic in queries

### DIFF
--- a/tipping/sqlalchemy-fauna/sqlalchemy_fauna/fauna/client.py
+++ b/tipping/sqlalchemy-fauna/sqlalchemy_fauna/fauna/client.py
@@ -104,10 +104,14 @@ class FaunaClient:
             return self._execute_with_retries(query, retries=(retries + 1))
 
     def _fauna_data_to_sqlalchemy_result(
-        self, data: typing.Dict[str, typing.Union[str, bool, int, float, datetime]]
+        self,
+        result: typing.Dict[str, typing.Any],
     ) -> typing.Dict[str, typing.Any]:
+        data = {**result, **result.get("data", {})}
         return {
-            key: self._convert_fauna_to_python(value) for key, value in data.items()
+            key: self._convert_fauna_to_python(value)
+            for key, value in data.items()
+            if key != "data"
         }
 
     @staticmethod

--- a/tipping/sqlalchemy-fauna/sqlalchemy_fauna/fauna/fql/common.py
+++ b/tipping/sqlalchemy-fauna/sqlalchemy_fauna/fauna/fql/common.py
@@ -254,6 +254,30 @@ def define_document_set(
     return q.intersection(*document_sets)
 
 
+def build_document_set_union(
+    table: sql.Table, filter_groups: typing.List[sql.FilterGroup]
+) -> QueryExpression:
+    """Build an FQL match query that joins results from different filter groups.
+
+    Params:
+    -------
+    table: A Table object associated with a Fauna collection.
+    filter_groups: A list of groups of filters representing, each one an intersection
+        of filtered results.
+
+    Returns:
+    --------
+    FQL query expression that is a union of each filter group's intersection of results,
+        all associated with the given table's filters.
+    """
+    if not any(filter_groups):
+        return define_document_set(table, None)
+
+    return q.union(
+        *[define_document_set(table, filter_group) for filter_group in filter_groups]
+    )
+
+
 def _build_intersecting_query(
     filter_group: sql.FilterGroup,
     acc_query: typing.Optional[QueryExpression],

--- a/tipping/sqlalchemy-fauna/sqlalchemy_fauna/fauna/fql/select.py
+++ b/tipping/sqlalchemy-fauna/sqlalchemy_fauna/fauna/fql/select.py
@@ -8,16 +8,6 @@ from sqlalchemy_fauna import exceptions, sql
 from . import common
 
 
-def _define_single_collection_pages(sql_query: sql.SQLQuery) -> QueryExpression:
-    tables = sql_query.tables
-    from_table = tables[0]
-    filter_group = (
-        None if not any(sql_query.filter_groups) else sql_query.filter_groups[0]
-    )
-
-    return common.define_document_set(from_table, filter_group)
-
-
 def _sort_document_set(
     document_set: QueryExpression, order_by: typing.Optional[sql.OrderBy]
 ):
@@ -58,7 +48,9 @@ def _define_document_pages(sql_query: sql.SQLQuery) -> QueryExpression:
     if len(tables) > 1:
         document_set = common.join_collections(sql_query)
     else:
-        document_set = _define_single_collection_pages(sql_query)
+        document_set = common.build_document_set_union(
+            tables[0], sql_query.filter_groups
+        )
 
     ordered_document_set = _sort_document_set(document_set, order_by)
     # Don't want to apply limit to queries with functions, because we want the calculation

--- a/tipping/sqlalchemy-fauna/tests/unit/fql/test_common.py
+++ b/tipping/sqlalchemy-fauna/tests/unit/fql/test_common.py
@@ -78,7 +78,7 @@ where_or = (
     "filter_params",
     [{"operator": "LIKE"}],
 )
-def test_unsupported_define_document_set(filter_params):
+def test_unsupported_build_document_set_intersection(filter_params):
     table_name = Fake.word()
     column_params = {
         "name": Fake.word(),
@@ -100,7 +100,7 @@ def test_unsupported_define_document_set(filter_params):
     filter_group = sql.FilterGroup(filters=[query_filter])
 
     with pytest.raises(exceptions.NotSupportedError, match="Unsupported operator"):
-        common.define_document_set(table, filter_group)
+        common.build_document_set_intersection(table, filter_group)
 
 
 @pytest.mark.parametrize(
@@ -114,7 +114,7 @@ def test_unsupported_define_document_set(filter_params):
         ({"operator": "<", "value": Fake.pyint()}, {}),
     ],
 )
-def test_define_document_set(filter_params, column_params):
+def test_build_document_set_intersection(filter_params, column_params):
     table_name = Fake.word()
     base_column_params = {
         "name": Fake.word(),
@@ -134,7 +134,7 @@ def test_define_document_set(filter_params, column_params):
     table = sql.Table(name=table_name, columns=[column], filters=[query_filter])
     filter_group = sql.FilterGroup(filters=[query_filter])
 
-    fql_query = common.define_document_set(table, filter_group)
+    fql_query = common.build_document_set_intersection(table, filter_group)
     assert isinstance(fql_query, QueryExpression)
 
 

--- a/tipping/sqlalchemy-fauna/tests/unit/fql/test_common.py
+++ b/tipping/sqlalchemy-fauna/tests/unit/fql/test_common.py
@@ -235,3 +235,26 @@ def test_update_documents():
     update_query = common.update_documents(sql_query)
 
     assert isinstance(update_query, QueryExpression)
+
+
+@pytest.mark.parametrize(
+    "sql_string",
+    [
+        (
+            "SELECT users.name, users.age FROM users "
+            "WHERE users.name = 'Bob' "
+            "AND users.age > 30 "
+            "OR users.job = 'cook'"
+        ),
+        "SELECT users.name, users.age FROM users",
+    ],
+)
+def test_build_document_set_union(sql_string):
+    sql_statement = sqlparse.parse(sql_string)[0]
+    sql_query = sql.SQLQuery.from_statement(sql_statement)
+
+    set_union = common.build_document_set_union(
+        sql_query.tables[0], sql_query.filter_groups
+    )
+
+    assert isinstance(set_union, QueryExpression)


### PR DESCRIPTION
With the implementation of queries that use `FilterGroup`s, we can now support unions of results across `FilterGroup`s for single- and multi-collection queries.