### PR TITLE
Maybe fix flake by including draw predictions in assertion

### DIFF
--- a/backend/server/tests/unit/models/test_match.py
+++ b/backend/server/tests/unit/models/test_match.py
@@ -238,7 +238,8 @@ class TestMatch(TestCase):
         # It updates prediction correctness
         self.assertGreaterEqual(match.prediction_set.filter(is_correct=True).count(), 1)
         # It updates match winner and margin
-        self.assertEqual(match.winner, winner)
+        winner_is_correct = match.winner == winner
+        self.assertTrue(winner_is_correct or match.is_draw)
         self.assertEqual(match.margin, max(match_scores) - min(match_scores))
 
     def test_year(self):

--- a/backend/server/tests/unit/test_schema.py
+++ b/backend/server/tests/unit/test_schema.py
@@ -384,7 +384,7 @@ class TestSchema(TestCase):
             draw_prediction = 0.5
 
         predicted_losses = [
-            pred[non_principal_prediction_label] < draw_prediction
+            pred[non_principal_prediction_label] <= draw_prediction
             for pred in data["matchPredictions"]
         ]
 


### PR DESCRIPTION
This is too rare of a flake to recreate, but since it's possible
for the non-principal model to predict draws, I think checking
for strict losses only (rather than losses & draws) is what's
causing this to occasionally fail.