### PR TITLE
Raise warnings in tests & fix warnings

### DIFF
--- a/tipping/pytest.ini
+++ b/tipping/pytest.ini
@@ -1,3 +1,9 @@
 [pytest-watch]
 clear = True
 nobeep = True
+
+[pytest]
+filterwarnings =
+  error
+  # from faunadb package, so can't do anything about it
+  ignore:Using or importing the ABCs from 'collections' instead of from 'collections.abc' is deprecated since Python 3.3, and in 3.9 it will stop working:DeprecationWarning

--- a/tipping/sqlalchemy-fauna/pytest.ini
+++ b/tipping/sqlalchemy-fauna/pytest.ini
@@ -1,0 +1,5 @@
+[pytest]
+filterwarnings =
+  error
+  # from faunadb package, so can't do anything about it
+  ignore:Using or importing the ABCs from 'collections' instead of from 'collections.abc' is deprecated since Python 3.3, and in 3.9 it will stop working:DeprecationWarning

--- a/tipping/sqlalchemy-fauna/sqlalchemy_fauna/fauna/translation/drop.py
+++ b/tipping/sqlalchemy-fauna/sqlalchemy_fauna/fauna/translation/drop.py
@@ -39,7 +39,8 @@ def translate_drop(statement: token_groups.Statement) -> typing.List[QueryExpres
                                     column_name="name_",
                                     index_type=fql.IndexType.TERM,
                                 )
-                            )
+                            ),
+                            table_name,
                         ),
                         fql.convert_to_ref_set(
                             "information_schema_columns_",

--- a/tipping/sqlalchemy-fauna/tests/fixtures/factories.py
+++ b/tipping/sqlalchemy-fauna/tests/fixtures/factories.py
@@ -1,5 +1,7 @@
 """Factories for example model classes."""
 
+from datetime import timezone
+
 import factory
 from factory.alchemy import SQLAlchemyModelFactory
 from faker import Faker
@@ -21,7 +23,7 @@ class UserFactory(SQLAlchemyModelFactory):
         sqlalchemy_session = Session
 
     name = factory.Sequence(lambda n: f"{Fake.first_name()} {n}")
-    date_joined = factory.Faker("date_this_decade")
+    date_joined = factory.Faker("date_time_this_decade", tzinfo=timezone.utc)
     age = factory.Faker("pyint")
     finger_count = factory.Faker("pyint")
     is_premium_member = factory.Faker("pybool")

--- a/tipping/sqlalchemy-fauna/tests/integration/conftest.py
+++ b/tipping/sqlalchemy-fauna/tests/integration/conftest.py
@@ -28,12 +28,12 @@ def _setup_faunadb():
 def _setup_teardown_test_db():
     os.system("npx fauna create-database test --endpoint localhost")
 
-    create_key_output = os.popen(
+    with os.popen(
         "npx fauna create-key test --endpoint=localhost"
-    ).read()
-    secret_key = (
-        re.search("secret: (.+)", create_key_output).group(CAPTURED_MATCH).strip()
-    )
+    ) as create_key_output:
+        output_text = create_key_output.read()
+
+    secret_key = re.search("secret: (.+)", output_text).group(CAPTURED_MATCH).strip()
 
     with patch.dict(os.environ, {**os.environ, "FAUNA_SECRET": secret_key}):
         try:

--- a/tipping/sqlalchemy-fauna/tests/integration/test_sqlalchemy_fauna.py
+++ b/tipping/sqlalchemy-fauna/tests/integration/test_sqlalchemy_fauna.py
@@ -35,8 +35,7 @@ def test_drop_table(fauna_engine):
     inspector = inspect(fauna_engine)
 
     # It drops the table
-    with fauna_engine.connect() as connection:
-        assert not fauna_engine.has_table(connection, "users")
+    assert not inspector.has_table("users")
     # It drops all associated indexes
     assert not any(inspector.get_indexes("users"))
     assert not any(inspector.get_columns("users"))

--- a/tipping/sqlalchemy-fauna/tests/integration/test_sqlalchemy_fauna.py
+++ b/tipping/sqlalchemy-fauna/tests/integration/test_sqlalchemy_fauna.py
@@ -1,6 +1,6 @@
 # pylint: disable=missing-docstring,redefined-outer-name
 
-from datetime import timezone
+from datetime import timezone, tzinfo
 import functools
 
 from sqlalchemy import inspect, exc as sqlalchemy_exceptions, sql
@@ -248,7 +248,9 @@ def test_unique_constraint(fauna_session):
     name = "Bob"
     factories.UserFactory(name=name)
 
-    duplicate_user = models.User(name=name, date_joined=Fake.date_this_decade())
+    duplicate_user = models.User(
+        name=name, date_joined=Fake.date_time_this_decade(tzinfo=timezone.utc)
+    )
     fauna_session.add(duplicate_user)
 
     with pytest.raises(

--- a/tipping/sqlalchemy-fauna/tests/unit/sql/test_common.py
+++ b/tipping/sqlalchemy-fauna/tests/unit/sql/test_common.py
@@ -1,6 +1,7 @@
 # pylint: disable=missing-docstring,redefined-outer-name
 
 from datetime import timezone
+import warnings
 
 from sqlparse import sql as token_groups, tokens as token_types
 import pytest
@@ -44,5 +45,8 @@ naive_datetime = Fake.date_time_this_year()
 )
 def test_extract_value(_label, token_value, expected):
     token = token_groups.Token(token_types.Literal, token_value)
-    value = common.extract_value(token)
+
+    with warnings.catch_warnings():
+        warnings.simplefilter("ignore", category=UserWarning)
+        value = common.extract_value(token)
     assert value == expected

--- a/tipping/src/tests/unit/models/test_match.py
+++ b/tipping/src/tests/unit/models/test_match.py
@@ -98,8 +98,9 @@ def test_update_result(start_date_time, expected_winner):
     home_team = models.Team(name=home_team_name)
     home_team_results = match_results.query("home_team == @home_team_name")
     random_row_idx = np.random.randint(0, len(home_team_results))
-    match_result = home_team_results.iloc[random_row_idx : (random_row_idx + 1), :]
-    match_result["home_score"] = match_result["away_score"] * 2
+    match_result = home_team_results.iloc[
+        random_row_idx : (random_row_idx + 1), :
+    ].assign(home_score=lambda df: df["away_score"] * 2)
     match = Match(
         start_date_time=start_date_time,
         venue=Fake.company(),

--- a/tipping/src/tests/unit/test_api.py
+++ b/tipping/src/tests/unit/test_api.py
@@ -3,6 +3,7 @@
 from unittest import TestCase
 from unittest.mock import patch, MagicMock
 from datetime import datetime, date
+import warnings
 import pytz
 
 import pandas as pd
@@ -262,9 +263,11 @@ class TestApi(TestCase):
         mock_submitter.submit_tips = MagicMock()
 
         with self.subTest("with no future match records available"):
-            self.api.update_match_predictions(
-                tips_submitters=[mock_submitter, mock_submitter], verbose=0
-            )
+            with warnings.catch_warnings():
+                warnings.simplefilter("ignore", category=UserWarning)
+                self.api.update_match_predictions(
+                    tips_submitters=[mock_submitter, mock_submitter], verbose=0
+                )
 
             # It doesn't fetch predictions
             mock_data_import.fetch_prediction_data.assert_not_called()

--- a/tipping/src/tests/unit/test_version.py
+++ b/tipping/src/tests/unit/test_version.py
@@ -6,6 +6,7 @@ import sys
 
 def test_lambda_version_compatibility():
     current_python_version = f"{sys.version_info.major}.{sys.version_info.minor}"
-    lambda_python_version = os.popen("npx serverless print | grep runtime:").read()
+    with os.popen("npx serverless print | grep runtime:") as version_output:
+        lambda_python_version = version_output.read()
 
     assert f"python{current_python_version}" in lambda_python_version


### PR DESCRIPTION
This is to better catch warnings and fix them whenever possible,
because they're easy to miss, then they accumulate, until they
become errors.