### PR TITLE
Use LetsEncrypt certs & port 443 for HTTPS

### DIFF
--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -3,11 +3,11 @@ services:
   app:
     image: cfranklin11/tipresias_backend:latest
     ports:
-      - "80:80"
+      - "443:443"
     stdin_open: true
     tty: true
     env_file: .env
     environment:
       - DJANGO_SETTINGS_MODULE=project.settings.production
       - DATABASE_NAME=${DATABASE_NAME}
-    command: gunicorn -b 0.0.0.0:80 -w 3 -t 1200 --access-logfile=- project.wsgi
+    command: gunicorn -b 0.0.0.0:443 -w 3 -t 1200 --certfile /certs/fullchain.pem --keyfile /certs/privkey.pem --access-logfile=- project.wsgi


### PR DESCRIPTION
Trying to deploy the frontend to Vercel didn't work, because
if the frontend is on HTTPS, it can't call a backend via HTTP,
so I'm doing a quickie HTTPS setup to get it working while I
migrate over to a fully-serverless architecture.