### PR TITLE
Fix all GQL dependencies to versions that actually work

### DIFF
--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -8,7 +8,8 @@ django-cors-headers
 graphene==3.0.0b6
 graphene-django==3.0.0b7
 gql==3.0.0a3
-graphql-core>=3.0,<4.0
+graphql-core==3.1.7
+graphql_relay==3.1.0
 psycopg2-binary
 dj-database-url
 sendgrid>=6.0,<6.99


### PR DESCRIPTION
An update in graphql_relay broke graphene-django. Since the latter
hasn't had an update in over a year, I tried installing from
GitHub, but it was still broken, so I chased down which versions
are currently running in prod and fixed requirements.txt to those.