### PR TITLE
Add factories for SQL objects

### DIFF
--- a/tipping/sqlalchemy-fauna/sqlalchemy_fauna/sql/__init__.py
+++ b/tipping/sqlalchemy-fauna/sqlalchemy_fauna/sql/__init__.py
@@ -1,5 +1,5 @@
 """Module for construction objects based on SQL query structures."""
 
 from .sql_query import OrderDirection, SQLQuery, OrderBy
-from .sql_table import Table, Column, Filter, Function, FilterGroup
+from .sql_table import Table, Column, Filter, Function, FilterGroup, Comparison
 from .common import extract_value

--- a/tipping/sqlalchemy-fauna/sqlalchemy_fauna/sql/sql_query.py
+++ b/tipping/sqlalchemy-fauna/sqlalchemy_fauna/sql/sql_query.py
@@ -462,3 +462,6 @@ class SQLQuery:
 
     def __str__(self):
         return self._query_string
+
+    def __repr__(self) -> str:
+        return self._query_string

--- a/tipping/sqlalchemy-fauna/sqlalchemy_fauna/sql/sql_query.py
+++ b/tipping/sqlalchemy-fauna/sqlalchemy_fauna/sql/sql_query.py
@@ -32,10 +32,12 @@ class OrderBy:
 
     def __init__(
         self,
-        columns: typing.List[sql_table.Column],
+        columns: typing.List[sql_table.Column] = None,
         direction: OrderDirection = OrderDirection.ASC,
     ):
+        columns = columns or []
         assert any(columns)
+
         self._columns = columns
         self._direction = direction or OrderDirection.ASC
 

--- a/tipping/sqlalchemy-fauna/sqlalchemy_fauna/sql/sql_table.py
+++ b/tipping/sqlalchemy-fauna/sqlalchemy_fauna/sql/sql_table.py
@@ -32,6 +32,21 @@ class JoinDirection(enum.Enum):
     RIGHT = "right"
 
 
+class ComparisonOperator(enum.Enum):
+    """Operators for comparing column values with filter params in WHERE clauses."""
+
+    EQUAL = "="
+    GREATER_THAN = ">"
+    LESS_THAN = "<"
+    GREATER_THAN_OR_EQUAL = ">="
+    LESS_THAN_OR_EQUAL = "<="
+
+    @classmethod
+    def values(cls) -> typing.List[str]:
+        """Returns all operator values in C."""
+        return [member.value for member in cls]
+
+
 ColumnParams = TypedDict(
     "ColumnParams",
     {
@@ -46,8 +61,6 @@ ColumnParams = TypedDict(
 
 # Probably not a complete list, but covers the basics
 FUNCTION_NAMES = {"min", "max", "count", "avg", "sum"}
-GREATER_THAN = ">"
-LESS_THAN = "<"
 
 NOT_SUPPORTED_FUNCTION_REGEX = re.compile(r"^(?:MIN|MAX|AVG|SUM)\(.+\)$", re.IGNORECASE)
 COUNT_REGEX = re.compile(r"^COUNT\(.+\)$", re.IGNORECASE)
@@ -273,26 +286,113 @@ class Column:
         return self.name
 
 
+class Comparison:
+    """Representation of the comparison between column values and filter value.
+
+    Params:
+    -------
+    operator: The ComparisonOperator that defines the requested relationship
+        between the values being compared.
+    """
+
+    OPERATOR_MAP = {
+        "=": ComparisonOperator.EQUAL,
+        ">": ComparisonOperator.GREATER_THAN,
+        "<": ComparisonOperator.LESS_THAN,
+        ">=": ComparisonOperator.GREATER_THAN_OR_EQUAL,
+        "<=": ComparisonOperator.LESS_THAN_OR_EQUAL,
+        "IS": ComparisonOperator.EQUAL,
+    }
+
+    REVERSE_MAP = {
+        ComparisonOperator.GREATER_THAN: ComparisonOperator.LESS_THAN,
+        ComparisonOperator.GREATER_THAN_OR_EQUAL: ComparisonOperator.LESS_THAN_OR_EQUAL,
+        ComparisonOperator.LESS_THAN: ComparisonOperator.GREATER_THAN,
+        ComparisonOperator.LESS_THAN_OR_EQUAL: ComparisonOperator.GREATER_THAN_OR_EQUAL,
+    }
+
+    def __init__(self, operator: ComparisonOperator):
+        self.operator = operator
+
+    @classmethod
+    def from_comparison_group(
+        cls, comparison_group: token_groups.Comparison
+    ) -> Comparison:
+        """Create a Comparison object based on an SQL Comparison token group.
+
+        Params:
+        -------
+        comparison_group: An SQL token group representing a comparison.
+        reverse: Whether to reverse a directional comparison (e.g. change '>' to '<').
+
+        Returns:
+        --------
+        A Comparison object.
+        """
+        _, comparison_token = comparison_group.token_next_by(
+            t=token_types.Comparison, m=(token_types.Keyword, "IS")
+        )
+        assert comparison_token is not None
+
+        comparison_operator = cls.OPERATOR_MAP.get(comparison_token.value)
+
+        if comparison_operator is None:
+            raise exceptions.NotSupportedError(
+                "Only the following comparisons are supported in WHERE clauses: "
+                ", ".join(cls.OPERATOR_MAP.keys())
+            )
+
+        # We're enforcing the convention of <column name> <operator> <value> for WHERE
+        # clauses here to simplify later query translation.
+        # Unfortunately, FQL generation depends on this convention without that dependency
+        # being explicit, which increases the likelihood of future bugs. However, I can't
+        # think of a good way to centralize the knowledge of this convention across all
+        # query translation, so I'm leaving this note as a warning.
+        id_idx, _ = comparison_group.token_next_by(i=token_groups.Identifier)
+        value_idx, _ = comparison_group.token_next_by(
+            t=token_types.Literal,
+            m=[
+                (token_types.Keyword, "NULL"),
+                (token_types.Keyword, "TRUE"),
+                (token_types.Keyword, "FALSE"),
+            ],
+        )
+        identifier_comes_before_value = id_idx < value_idx
+        if identifier_comes_before_value:
+            return cls(operator=comparison_operator)
+
+        return cls(
+            operator=cls.REVERSE_MAP.get(comparison_operator, comparison_operator)
+        )
+
+    def __str__(self):
+        return self.operator.value
+
+    def __eq__(self, other: typing.Any) -> bool:
+        if not isinstance(other, Comparison):
+            raise NotImplementedError()
+
+        return self.operator == other.operator
+
+
 class Filter:
     """Representation of filter applied by WHERE clause in SQL.
 
     Params:
     -------
     column: An instance of the Column used in the filter.
-    operator: The comparison operator.
+    comparison: The comparison between column values and the filter value.
     value: The raw value being compared for the filter.
     """
-
-    SUPPORTED_COMPARISON_OPERATORS = ["=", GREATER_THAN, ">=", "<", "<=", "IS"]
 
     def __init__(
         self,
         column: Column,
-        operator: str,
+        comparison: Comparison,
         value: typing.Union[str, int, float, None, bool, datetime],
     ):
         self.column = column
-        self.operator = operator
+        self.comparison = comparison
         self.value = value
         self._table: typing.Optional[Table] = None
         self._table_name = column.table_name
@@ -310,24 +410,16 @@ class Filter:
         --------
         An instance of Filter.
         """
-        id_idx, comparison_identifier = comparison_group.token_next_by(
+        _, comparison_identifier = comparison_group.token_next_by(
             i=token_groups.Identifier
         )
         columns = Column.from_identifier_group(comparison_identifier)
         assert len(columns) == 1
         column = columns[0]
 
-        _, comparison_operator = comparison_group.token_next_by(
-            t=token_types.Comparison, m=(token_types.Keyword, "IS")
-        )
+        comparison = Comparison.from_comparison_group(comparison_group)
 
-        if comparison_operator.value not in cls.SUPPORTED_COMPARISON_OPERATORS:
-            raise exceptions.NotSupportedError(
-                "Only the following comparisons are supported in WHERE clauses: "
-                ", ".join(cls.SUPPORTED_COMPARISON_OPERATORS)
-            )
-
-        value_idx, comparison_value_literal = comparison_group.token_next_by(
+        _, comparison_value_literal = comparison_group.token_next_by(
             t=token_types.Literal,
             m=[
                 (token_types.Keyword, "NULL"),
@@ -336,40 +428,12 @@ class Filter:
             ],
         )
         comparison_value = common.extract_value(comparison_value_literal)
-        operator_value = cls._extract_operator_value(
-            comparison_operator.value, id_idx, value_idx
-        )
 
         return cls(
             column=column,
-            operator=operator_value,
+            comparison=comparison,
             value=comparison_value,
         )
-
-    @classmethod
-    def _extract_operator_value(
-        cls, operator_value: str, id_idx: int, value_idx: int
-    ) -> str:
-        if operator_value == "IS":
-            return "="
-
-        # We're enforcing the convention of <column name> <operator> <value> for WHERE
-        # clauses here to simplify later query translation.
-        # Unfortunately, FQL generation depends on this convention without that dependency
-        # being explicit, which increases the likelihood of future bugs. However, I can't
-        # think of a good way to centralize the knowledge of this convention across all
-        # query translation, so I'm leaving this note as a warning.
-        identifier_comes_before_value = id_idx < value_idx
-        if identifier_comes_before_value:
-            return operator_value
-
-        if GREATER_THAN in operator_value:
-            return operator_value.replace(GREATER_THAN, LESS_THAN)
-
-        if LESS_THAN in operator_value:
-            return operator_value.replace(LESS_THAN, GREATER_THAN)
-
-        return operator_value
 
     def belongs_to_table(self, table: Table) -> bool:
         """Whether this column is associated with the given table."""
@@ -395,7 +459,32 @@ class Filter:
     @property
     def name(self) -> str:
         """Unique name of the filter based on its query parameters."""
-        return f"{self.table_name}_{self.column.name}_{self.operator}_{self.value}"
+        return f"{self.table_name}_{self.column.name}_{self.comparison}_{self.value}"
+
+    @property
+    def checks_whether_equal(self) -> bool:
+        """Check whether the filter uses '=' operator to select field values."""
+        return self.comparison.operator == ComparisonOperator.EQUAL
+
+    @property
+    def checks_whether_greater_than(self) -> bool:
+        """Check whether the filter uses '>' operator to select field values."""
+        return self.comparison.operator == ComparisonOperator.GREATER_THAN
+
+    @property
+    def checks_whether_greater_than_or_equal(self) -> bool:
+        """Check whether the filter uses '>=' operator to select field values."""
+        return self.comparison.operator == ComparisonOperator.GREATER_THAN_OR_EQUAL
+
+    @property
+    def checks_whether_less_than(self) -> bool:
+        """Check whether the filter uses '<' operator to select field values."""
+        return self.comparison.operator == ComparisonOperator.LESS_THAN
+
+    @property
+    def checks_whether_less_than_or_equal(self) -> bool:
+        """Check whether the filter uses '<=' operator to select field values."""
+        return self.comparison.operator == ComparisonOperator.LESS_THAN_OR_EQUAL
 
 
 class FilterGroup:

--- a/tipping/sqlalchemy-fauna/sqlalchemy_fauna/sql/sql_table.py
+++ b/tipping/sqlalchemy-fauna/sqlalchemy_fauna/sql/sql_table.py
@@ -635,7 +635,11 @@ class Table:
 
     @property
     def columns(self) -> typing.List[Column]:
-        """List of column objects associated with this table."""
+        """List of column objects associated with this table.
+
+        Only includes columns that are being selected or modified, not any columns
+        included in WHERE clause filters.
+        """
         return self._columns
 
     def add_column(self, column: Column):

--- a/tipping/sqlalchemy-fauna/sqlalchemy_fauna/sql/sql_table.py
+++ b/tipping/sqlalchemy-fauna/sqlalchemy_fauna/sql/sql_table.py
@@ -285,6 +285,13 @@ class Column:
     def __str__(self) -> str:
         return self.name
 
+    def __repr__(self) -> str:
+        return (
+            f"Column(name={self.name}, alias={self.alias}, position={self.position}, "
+            f"table_name={self.table_name}, value={self.value}, "
+            f"function_name={self.function_name})"
+        )
+
 
 class Comparison:
     """Representation of the comparison between column values and filter value.
@@ -485,6 +492,9 @@ class Filter:
     def checks_whether_less_than_or_equal(self) -> bool:
         """Check whether the filter uses '<=' operator to select field values."""
         return self.comparison.operator == ComparisonOperator.LESS_THAN_OR_EQUAL
+
+    def __repr__(self) -> str:
+        return f"Filter(column={self.column}, comparison={self.comparison}, value={self.value})"
 
 
 class FilterGroup:
@@ -720,3 +730,6 @@ class Table:
 
     def __str__(self) -> str:
         return self.name
+
+    def __repr__(self) -> str:
+        return f"Table(name={self.name}, alias={self.alias})"

--- a/tipping/sqlalchemy-fauna/tests/fixtures/factories/__init__.py
+++ b/tipping/sqlalchemy-fauna/tests/fixtures/factories/__init__.py
@@ -1,4 +1,10 @@
 """Factories for generating randomized objects for use in tests."""
 
 from .models import UserFactory, ChildFactory, FoodFactory
-from .sql import ColumnFactory, ComparisonFactory, FilterFactory, FilterGroupFactory
+from .sql import (
+    ColumnFactory,
+    ComparisonFactory,
+    FilterFactory,
+    FilterGroupFactory,
+    TableFactory,
+)

--- a/tipping/sqlalchemy-fauna/tests/fixtures/factories/__init__.py
+++ b/tipping/sqlalchemy-fauna/tests/fixtures/factories/__init__.py
@@ -1,0 +1,3 @@
+"""Factories for generating randomized objects for use in tests."""
+
+from .models import UserFactory, ChildFactory, FoodFactory

--- a/tipping/sqlalchemy-fauna/tests/fixtures/factories/__init__.py
+++ b/tipping/sqlalchemy-fauna/tests/fixtures/factories/__init__.py
@@ -1,3 +1,4 @@
 """Factories for generating randomized objects for use in tests."""
 
 from .models import UserFactory, ChildFactory, FoodFactory
+from .sql import ColumnFactory

--- a/tipping/sqlalchemy-fauna/tests/fixtures/factories/__init__.py
+++ b/tipping/sqlalchemy-fauna/tests/fixtures/factories/__init__.py
@@ -1,4 +1,4 @@
 """Factories for generating randomized objects for use in tests."""
 
 from .models import UserFactory, ChildFactory, FoodFactory
-from .sql import ColumnFactory
+from .sql import ColumnFactory, ComparisonFactory

--- a/tipping/sqlalchemy-fauna/tests/fixtures/factories/__init__.py
+++ b/tipping/sqlalchemy-fauna/tests/fixtures/factories/__init__.py
@@ -1,4 +1,4 @@
 """Factories for generating randomized objects for use in tests."""
 
 from .models import UserFactory, ChildFactory, FoodFactory
-from .sql import ColumnFactory, ComparisonFactory
+from .sql import ColumnFactory, ComparisonFactory, FilterFactory

--- a/tipping/sqlalchemy-fauna/tests/fixtures/factories/__init__.py
+++ b/tipping/sqlalchemy-fauna/tests/fixtures/factories/__init__.py
@@ -1,4 +1,4 @@
 """Factories for generating randomized objects for use in tests."""
 
 from .models import UserFactory, ChildFactory, FoodFactory
-from .sql import ColumnFactory, ComparisonFactory, FilterFactory
+from .sql import ColumnFactory, ComparisonFactory, FilterFactory, FilterGroupFactory

--- a/tipping/sqlalchemy-fauna/tests/fixtures/factories/__init__.py
+++ b/tipping/sqlalchemy-fauna/tests/fixtures/factories/__init__.py
@@ -7,4 +7,6 @@ from .sql import (
     FilterFactory,
     FilterGroupFactory,
     TableFactory,
+    SQLQueryFactory,
+    OrderByFactory,
 )

--- a/tipping/sqlalchemy-fauna/tests/fixtures/factories/models.py
+++ b/tipping/sqlalchemy-fauna/tests/fixtures/factories/models.py
@@ -6,8 +6,8 @@ import factory
 from factory.alchemy import SQLAlchemyModelFactory
 from faker import Faker
 
-from .session import Session
-from .models import Food, User, Child
+from ..session import Session
+from ..models import Food, User, Child
 
 
 Fake = Faker()

--- a/tipping/sqlalchemy-fauna/tests/fixtures/factories/sql.py
+++ b/tipping/sqlalchemy-fauna/tests/fixtures/factories/sql.py
@@ -6,6 +6,7 @@ from datetime import timezone
 
 import factory
 from faker import Faker
+import numpy as np
 
 from sqlalchemy_fauna import sql
 
@@ -70,3 +71,15 @@ class ColumnFactory(factory.Factory):
             return Fake.date_time(tzinfo=timezone.utc)
 
         raise Exception(f"Unknown DataType, {self.data_type}, for column value.")
+
+
+class ComparisonFactory(factory.Factory):
+    """Factory class for SQL Comparison objects."""
+
+    class Meta:
+        """Factory attributes for recreating the associated model's attributes."""
+
+        model = sql.Comparison
+        strategy = factory.BUILD_STRATEGY
+
+    operator = np.random.choice(list(sql.Comparison.OPERATOR_MAP.values()))  # type: ignore

--- a/tipping/sqlalchemy-fauna/tests/fixtures/factories/sql.py
+++ b/tipping/sqlalchemy-fauna/tests/fixtures/factories/sql.py
@@ -1,8 +1,8 @@
 """Factories for SQLQuery objects."""
 
 from __future__ import annotations
-import enum
-from datetime import timezone
+from datetime import timezone, datetime
+import typing
 
 import factory
 from faker import Faker
@@ -14,14 +14,23 @@ from sqlalchemy_fauna import sql
 Fake = Faker()
 
 
-class DataType(enum.Enum):
-    """Available data types for a column value."""
+def _define_value(data_type: type):
+    if data_type is None:
+        return None
 
-    NONE = "None"
-    STRING = "str"
-    INTEGER = "int"
-    FLOAT = "float"
-    DATETIME = "datetime"
+    if data_type == str:
+        return Fake.company()
+
+    if data_type == int:
+        return Fake.pyint()
+
+    if data_type == float:
+        return Fake.pyfloat()
+
+    if data_type == datetime:
+        return Fake.date_time(tzinfo=timezone.utc)
+
+    raise Exception(f"Unknown type, {data_type}, for column value.")
 
 
 class ColumnFactory(factory.Factory):
@@ -44,7 +53,7 @@ class ColumnFactory(factory.Factory):
             'str'.
         """
 
-        data_type: DataType = DataType.STRING
+        data_type: typing.Optional[type] = str
 
     name = factory.Faker("first_name")
     alias = factory.Faker("first_name")
@@ -55,22 +64,7 @@ class ColumnFactory(factory.Factory):
     @factory.lazy_attribute
     def value(self):
         """Generate a random value based on the column's data_type param."""
-        if self.data_type == DataType.NONE:
-            return None
-
-        if self.data_type == DataType.STRING:
-            return Fake.company()
-
-        if self.data_type == DataType.INTEGER:
-            return Fake.pyint()
-
-        if self.data_type == DataType.FLOAT:
-            return Fake.pyfloat()
-
-        if self.data_type == DataType.DATETIME:
-            return Fake.date_time(tzinfo=timezone.utc)
-
-        raise Exception(f"Unknown DataType, {self.data_type}, for column value.")
+        return _define_value(self.data_type)
 
 
 class ComparisonFactory(factory.Factory):
@@ -83,3 +77,22 @@ class ComparisonFactory(factory.Factory):
         strategy = factory.BUILD_STRATEGY
 
     operator = np.random.choice(list(sql.Comparison.OPERATOR_MAP.values()))  # type: ignore
+
+
+class FilterFactory(factory.Factory):
+    """Factory class for SQL Filter objects."""
+
+    class Meta:
+        """Factory attributes for recreating the associated model's attributes."""
+
+        model = sql.Filter
+        strategy = factory.BUILD_STRATEGY
+
+    column = factory.SubFactory(ColumnFactory)
+    comparison = factory.SubFactory(ComparisonFactory)
+
+    @factory.lazy_attribute
+    def value(self):
+        """Generate a random value based on the associated column's data_type param."""
+        data_type = None if self.column.value is None else type(self.column.value)
+        return _define_value(data_type)

--- a/tipping/sqlalchemy-fauna/tests/fixtures/factories/sql.py
+++ b/tipping/sqlalchemy-fauna/tests/fixtures/factories/sql.py
@@ -96,3 +96,18 @@ class FilterFactory(factory.Factory):
         """Generate a random value based on the associated column's data_type param."""
         data_type = None if self.column.value is None else type(self.column.value)
         return _define_value(data_type)
+
+
+class FilterGroupFactory(factory.Factory):
+    """Factory class for SQL FilterGroup objects."""
+
+    class Meta:
+        """Factory attributes for recreating the associated model's attributes."""
+
+        model = sql.FilterGroup
+        strategy = factory.BUILD_STRATEGY
+
+    # Arbitrary filter count range to keep the list reasonably small
+    filters = factory.RelatedFactoryList(
+        FilterFactory, size=lambda: np.random.randint(1, 6)
+    )

--- a/tipping/sqlalchemy-fauna/tests/fixtures/factories/sql.py
+++ b/tipping/sqlalchemy-fauna/tests/fixtures/factories/sql.py
@@ -1,0 +1,72 @@
+"""Factories for SQLQuery objects."""
+
+from __future__ import annotations
+import enum
+from datetime import timezone
+
+import factory
+from faker import Faker
+
+from sqlalchemy_fauna import sql
+
+
+Fake = Faker()
+
+
+class DataType(enum.Enum):
+    """Available data types for a column value."""
+
+    NONE = "None"
+    STRING = "str"
+    INTEGER = "int"
+    FLOAT = "float"
+    DATETIME = "datetime"
+
+
+class ColumnFactory(factory.Factory):
+    """Factory class for SQL Column objects."""
+
+    class Meta:
+        """Factory attributes for recreating the associated model's attributes."""
+
+        model = sql.Column
+        strategy = factory.BUILD_STRATEGY
+
+    class Params:
+        """
+        Params for modifying the factory's default attributes.
+
+        Params:
+        -------
+        data_type: A factory param that defines the data type of the column value. Possible
+            values are 'str', 'int', 'float', 'datetime', 'None'. The default value is
+            'str'.
+        """
+
+        data_type: DataType = DataType.STRING
+
+    name = factory.Faker("first_name")
+    alias = factory.Faker("first_name")
+    position = factory.Faker("pyint")
+    table_name = factory.Faker("word")
+    function_name = None
+
+    @factory.lazy_attribute
+    def value(self):
+        """Generate a random value based on the column's data_type param."""
+        if self.data_type == DataType.NONE:
+            return None
+
+        if self.data_type == DataType.STRING:
+            return Fake.company()
+
+        if self.data_type == DataType.INTEGER:
+            return Fake.pyint()
+
+        if self.data_type == DataType.FLOAT:
+            return Fake.pyfloat()
+
+        if self.data_type == DataType.DATETIME:
+            return Fake.date_time(tzinfo=timezone.utc)
+
+        raise Exception(f"Unknown DataType, {self.data_type}, for column value.")

--- a/tipping/sqlalchemy-fauna/tests/unit/fql/test_common.py
+++ b/tipping/sqlalchemy-fauna/tests/unit/fql/test_common.py
@@ -10,6 +10,8 @@ import sqlparse
 from sqlalchemy_fauna import exceptions, sql
 from sqlalchemy_fauna.fauna.fql import common
 
+from ...fixtures.factories import ColumnFactory
+
 
 Fake = Faker()
 
@@ -80,13 +82,7 @@ where_or = (
 )
 def test_unsupported_build_document_set_intersection(filter_params):
     table_name = Fake.word()
-    column_params = {
-        "name": Fake.word(),
-        "alias": Fake.word(),
-        "table_name": table_name,
-        "position": 0,
-    }
-    column = sql.Column(**column_params)
+    column = ColumnFactory(table_name=table_name)
 
     base_filter_params = {
         "column": column,
@@ -116,13 +112,7 @@ def test_unsupported_build_document_set_intersection(filter_params):
 )
 def test_build_document_set_intersection(filter_params, column_params):
     table_name = Fake.word()
-    base_column_params = {
-        "name": Fake.word(),
-        "alias": Fake.word(),
-        "table_name": table_name,
-        "position": 0,
-    }
-    column = sql.Column(**{**base_column_params, **column_params})
+    column = ColumnFactory(table_name=table_name, **column_params)
 
     base_filter_params = {
         "column": column,

--- a/tipping/sqlalchemy-fauna/tests/unit/fql/test_common.py
+++ b/tipping/sqlalchemy-fauna/tests/unit/fql/test_common.py
@@ -4,13 +4,14 @@ import pytest
 from faker import Faker
 from faunadb.objects import _Expr as QueryExpression
 from faunadb import query as q
-import sqlparse
 
 from tests.fixtures.factories import (
     ColumnFactory,
     FilterGroupFactory,
     FilterFactory,
     TableFactory,
+    SQLQueryFactory,
+    OrderByFactory,
 )
 from sqlalchemy_fauna import exceptions, sql
 from sqlalchemy_fauna.fauna.fql import common
@@ -123,120 +124,45 @@ def test_build_document_set_intersection(operator, column_params):
 
 
 def test_join_collections():
-    from_table = "users"
-    first_child_table = "accounts"
+    ENOUGH_TO_PROBABLY_GET_A_VARIETY_OF_JOINS = 6
+    query = SQLQueryFactory(table_count=ENOUGH_TO_PROBABLY_GET_A_VARIETY_OF_JOINS)
 
-    select_string = f"SELECT {from_table}.name, {from_table}.age "
-    from_string = f"FROM {from_table} "
-    join_string = (
-        f"JOIN {first_child_table} ON {from_table}.id = {first_child_table}.user_id "
-    )
-    where_string = f"WHERE {first_child_table}.amount > 5.0"
-    sql_string = select_string + from_string + join_string + where_string
-
-    sql_statement = sqlparse.parse(sql_string)[0]
-    sql_query = sql.SQLQuery.from_statement(sql_statement)
-
-    join_query = common.join_collections(sql_query)
-    assert isinstance(join_query, QueryExpression)
-
-    second_child_table = "transactions"
-    join_string = (
-        join_string
-        + f"JOIN {second_child_table} ON {first_child_table}.id = {second_child_table}.account_id "
-    )
-    where_string = where_string + f" AND {second_child_table}.count < 10"
-    sql_string = select_string + from_string + join_string + where_string
-
-    sql_statement = sqlparse.parse(sql_string)[0]
-    sql_query = sql.SQLQuery.from_statement(sql_statement)
-
-    join_query = common.join_collections(sql_query)
-    assert isinstance(join_query, QueryExpression)
-
-    first_parent_table = "banks"
-    join_string = (
-        join_string
-        + f"JOIN {first_parent_table} ON {first_parent_table}.id = {second_child_table}.bank_id "
-    )
-    where_string = where_string + f" OR {first_parent_table}.id = 'asdf1234'"
-    sql_string = select_string + from_string + join_string + where_string
-
-    sql_statement = sqlparse.parse(sql_string)[0]
-    sql_query = sql.SQLQuery.from_statement(sql_statement)
-
-    join_query = common.join_collections(sql_query)
-    assert isinstance(join_query, QueryExpression)
-
-    second_parent_table = "country"
-    join_string = (
-        join_string + f"JOIN {second_parent_table} "
-        f"ON {first_parent_table}.id = {second_parent_table}.country_id "
-    )
-    where_string = where_string + f" AND {second_parent_table}.code = 'AU'"
-    sql_string = select_string + from_string + join_string + where_string
-
-    sql_statement = sqlparse.parse(sql_string)[0]
-    sql_query = sql.SQLQuery.from_statement(sql_statement)
-
-    join_query = common.join_collections(sql_query)
+    join_query = common.join_collections(query)
     assert isinstance(join_query, QueryExpression)
 
 
 @pytest.mark.parametrize(
-    ["sql_string", "error_message"],
+    ["sql_query", "error_message"],
     [
         (
-            "SELECT users.name, users.age FROM users",
+            SQLQueryFactory(table_count=1, filter_groups=[]),
             "Joining tables without cross-table filters via the WHERE clause is not supported",
         ),
         (
-            "SELECT users.name, users.age FROM users JOIN transactions "
-            "ON users.id = transactions.user_id ORDER BY transactions.id",
+            SQLQueryFactory(order_by=OrderByFactory()),
             "we currently can only sort the principal table",
         ),
     ],
 )
-def test_invalid_join_collections(sql_string, error_message):
-    sql_statement = sqlparse.parse(sql_string)[0]
-    sql_query = sql.SQLQuery.from_statement(sql_statement)
-
+def test_invalid_join_collections(sql_query, error_message):
     with pytest.raises(exceptions.NotSupportedError, match=error_message):
         common.join_collections(sql_query)
 
 
 def test_update_documents():
-    table_name = Fake.first_name()
-    sql_string = (
-        f"UPDATE {table_name} "
-        f"SET {Fake.first_name()} = '{Fake.first_name()}', "
-        f"{Fake.first_name()} = '{Fake.first_name()}', "
-        f"{Fake.first_name()} = {Fake.pyint()}, "
-    )
-    sql_statement = sqlparse.parse(sql_string)[0]
-    sql_query = sql.SQLQuery.from_statement(sql_statement)
-
-    update_query = common.update_documents(sql_query)
+    update_query = common.update_documents(SQLQueryFactory(table_count=1))
 
     assert isinstance(update_query, QueryExpression)
 
 
 @pytest.mark.parametrize(
-    "sql_string",
+    "sql_query",
     [
-        (
-            "SELECT users.name, users.age FROM users "
-            "WHERE users.name = 'Bob' "
-            "AND users.age > 30 "
-            "OR users.job = 'cook'"
-        ),
-        "SELECT users.name, users.age FROM users",
+        SQLQueryFactory(table_count=1),
+        SQLQueryFactory(table_count=1, filter_groups=[]),
     ],
 )
-def test_build_document_set_union(sql_string):
-    sql_statement = sqlparse.parse(sql_string)[0]
-    sql_query = sql.SQLQuery.from_statement(sql_statement)
-
+def test_build_document_set_union(sql_query):
     set_union = common.build_document_set_union(
         sql_query.tables[0], sql_query.filter_groups
     )

--- a/tipping/sqlalchemy-fauna/tests/unit/fql/test_common.py
+++ b/tipping/sqlalchemy-fauna/tests/unit/fql/test_common.py
@@ -10,7 +10,7 @@ import sqlparse
 from sqlalchemy_fauna import exceptions, sql
 from sqlalchemy_fauna.fauna.fql import common
 
-from ...fixtures.factories import ColumnFactory
+from tests.fixtures.factories import ColumnFactory, ComparisonFactory
 
 
 Fake = Faker()
@@ -77,37 +77,61 @@ where_or = (
 
 
 @pytest.mark.parametrize(
-    "filter_params",
-    [{"operator": "LIKE"}],
-)
-def test_unsupported_build_document_set_intersection(filter_params):
-    table_name = Fake.word()
-    column = ColumnFactory(table_name=table_name)
-
-    base_filter_params = {
-        "column": column,
-        "operator": np.random.choice(sql.Filter.SUPPORTED_COMPARISON_OPERATORS),
-        "value": Fake.word(),
-    }
-    filter_params = {**base_filter_params, **filter_params}
-    query_filter = sql.Filter(**filter_params)
-
-    table = sql.Table(name=table_name, columns=[column], filters=[query_filter])
-    filter_group = sql.FilterGroup(filters=[query_filter])
-
-    with pytest.raises(exceptions.NotSupportedError, match="Unsupported operator"):
-        common.build_document_set_intersection(table, filter_group)
-
-
-@pytest.mark.parametrize(
     ["filter_params", "column_params"],
     [
-        ({"operator": "=", "value": Fake.uuid4()}, {"name": "ref", "alias": "id"}),
-        ({"operator": "="}, {}),
-        ({"operator": ">=", "value": Fake.pyint()}, {}),
-        ({"operator": ">", "value": Fake.pyint()}, {}),
-        ({"operator": "<=", "value": Fake.pyint()}, {}),
-        ({"operator": "<", "value": Fake.pyint()}, {}),
+        (
+            {
+                "comparison": ComparisonFactory(
+                    operator=sql.sql_table.ComparisonOperator.EQUAL
+                ),
+                "value": Fake.uuid4(),
+            },
+            {"name": "ref", "alias": "id"},
+        ),
+        (
+            {
+                "comparison": ComparisonFactory(
+                    operator=sql.sql_table.ComparisonOperator.EQUAL
+                )
+            },
+            {},
+        ),
+        (
+            {
+                "comparison": ComparisonFactory(
+                    operator=sql.sql_table.ComparisonOperator.GREATER_THAN_OR_EQUAL
+                ),
+                "value": Fake.pyint(),
+            },
+            {},
+        ),
+        (
+            {
+                "comparison": ComparisonFactory(
+                    operator=sql.sql_table.ComparisonOperator.GREATER_THAN
+                ),
+                "value": Fake.pyint(),
+            },
+            {},
+        ),
+        (
+            {
+                "comparison": ComparisonFactory(
+                    operator=sql.sql_table.ComparisonOperator.LESS_THAN_OR_EQUAL
+                ),
+                "value": Fake.pyint(),
+            },
+            {},
+        ),
+        (
+            {
+                "comparison": ComparisonFactory(
+                    operator=sql.sql_table.ComparisonOperator.LESS_THAN
+                ),
+                "value": Fake.pyint(),
+            },
+            {},
+        ),
     ],
 )
 def test_build_document_set_intersection(filter_params, column_params):
@@ -116,7 +140,7 @@ def test_build_document_set_intersection(filter_params, column_params):
 
     base_filter_params = {
         "column": column,
-        "operator": np.random.choice(sql.Filter.SUPPORTED_COMPARISON_OPERATORS),
+        "comparison": ComparisonFactory(),
         "value": Fake.word(),
     }
     query_filter = sql.Filter(**{**base_filter_params, **filter_params})

--- a/tipping/sqlalchemy-fauna/tests/unit/fql/test_common.py
+++ b/tipping/sqlalchemy-fauna/tests/unit/fql/test_common.py
@@ -6,7 +6,12 @@ from faunadb.objects import _Expr as QueryExpression
 from faunadb import query as q
 import sqlparse
 
-from tests.fixtures.factories import ColumnFactory, FilterFactory, FilterGroupFactory
+from tests.fixtures.factories import (
+    ColumnFactory,
+    FilterGroupFactory,
+    FilterFactory,
+    TableFactory,
+)
 from sqlalchemy_fauna import exceptions, sql
 from sqlalchemy_fauna.fauna.fql import common
 
@@ -109,7 +114,7 @@ def test_build_document_set_intersection(operator, column_params):
         filters=[FilterFactory(column=column, comparison__operator=operator)]
     )
 
-    table = sql.Table(
+    table = TableFactory(
         name=column.table_name, columns=[column], filters=filter_group.filters
     )
 

--- a/tipping/sqlalchemy-fauna/tests/unit/fql/test_common.py
+++ b/tipping/sqlalchemy-fauna/tests/unit/fql/test_common.py
@@ -10,7 +10,7 @@ import sqlparse
 from sqlalchemy_fauna import exceptions, sql
 from sqlalchemy_fauna.fauna.fql import common
 
-from tests.fixtures.factories import ColumnFactory, ComparisonFactory
+from tests.fixtures.factories import ColumnFactory, ComparisonFactory, FilterFactory
 
 
 Fake = Faker()
@@ -135,17 +135,10 @@ where_or = (
     ],
 )
 def test_build_document_set_intersection(filter_params, column_params):
-    table_name = Fake.word()
-    column = ColumnFactory(table_name=table_name, **column_params)
+    column = ColumnFactory(**column_params)
+    query_filter = FilterFactory(**{"column": column, **filter_params})
 
-    base_filter_params = {
-        "column": column,
-        "comparison": ComparisonFactory(),
-        "value": Fake.word(),
-    }
-    query_filter = sql.Filter(**{**base_filter_params, **filter_params})
-
-    table = sql.Table(name=table_name, columns=[column], filters=[query_filter])
+    table = sql.Table(name=column.table_name, columns=[column], filters=[query_filter])
     filter_group = sql.FilterGroup(filters=[query_filter])
 
     fql_query = common.build_document_set_intersection(table, filter_group)

--- a/tipping/sqlalchemy-fauna/tests/unit/fql/test_delete.py
+++ b/tipping/sqlalchemy-fauna/tests/unit/fql/test_delete.py
@@ -1,21 +1,17 @@
 # pylint: disable=missing-docstring,redefined-outer-name
 
 import pytest
-import sqlparse
 from faunadb.objects import _Expr as QueryExpression
 
-from sqlalchemy_fauna import sql
+from tests.fixtures.factories import SQLQueryFactory
 from sqlalchemy_fauna.fauna.fql import delete
 
 
-base_delete = "DELETE FROM users"
-delete_where = base_delete + " WHERE users.name = 'Bob'"
-
-
-@pytest.mark.parametrize("sql_string", [base_delete, delete_where])
-def test_translate_delete(sql_string):
-    statement = sqlparse.parse(sql_string)[0]
-    sql_query = sql.SQLQuery.from_statement(statement)
+@pytest.mark.parametrize(
+    "sql_query",
+    [SQLQueryFactory(table_count=1, filter_groups=[]), SQLQueryFactory(table_count=1)],
+)
+def test_translate_delete(sql_query):
     fql_query = delete.translate_delete(sql_query)
 
     assert isinstance(fql_query, QueryExpression)

--- a/tipping/sqlalchemy-fauna/tests/unit/fql/test_insert.py
+++ b/tipping/sqlalchemy-fauna/tests/unit/fql/test_insert.py
@@ -1,11 +1,9 @@
 # pylint: disable=missing-docstring,redefined-outer-name
 
 import pytest
-import sqlparse
 from faunadb.objects import _Expr as QueryExpression
 
 from tests.fixtures.factories import SQLQueryFactory
-from sqlalchemy_fauna import sql
 from sqlalchemy_fauna.fauna.fql import insert
 
 

--- a/tipping/sqlalchemy-fauna/tests/unit/fql/test_insert.py
+++ b/tipping/sqlalchemy-fauna/tests/unit/fql/test_insert.py
@@ -4,17 +4,13 @@ import pytest
 import sqlparse
 from faunadb.objects import _Expr as QueryExpression
 
+from tests.fixtures.factories import SQLQueryFactory
 from sqlalchemy_fauna import sql
 from sqlalchemy_fauna.fauna.fql import insert
 
 
-@pytest.mark.parametrize(
-    "sql_string", ["INSERT INTO users (name, age, finger_count) VALUES ('Bob', 30, 10)"]
-)
-def test_translate_insert(sql_string):
-    sql_statement = sqlparse.parse(sql_string)[0]
-    sql_query = sql.SQLQuery.from_statement(sql_statement)
-
+@pytest.mark.parametrize("sql_query", [SQLQueryFactory(table_count=1)])
+def test_translate_insert(sql_query):
     fql_query = insert.translate_insert(sql_query)
 
     assert isinstance(fql_query, QueryExpression)

--- a/tipping/sqlalchemy-fauna/tests/unit/fql/test_select.py
+++ b/tipping/sqlalchemy-fauna/tests/unit/fql/test_select.py
@@ -2,92 +2,78 @@
 
 import pytest
 from faunadb.objects import _Expr as QueryExpression
-import sqlparse
 
+from tests.fixtures.factories import (
+    SQLQueryFactory,
+    ColumnFactory,
+    OrderByFactory,
+    TableFactory,
+)
 from sqlalchemy_fauna.fauna.fql import select
 from sqlalchemy_fauna import exceptions, sql
 
-select_values = (
-    "SELECT users.id, users.name, users.date_joined, users.age, users.finger_count "
-    "FROM users"
-)
 
-select_sum = "SELECT sum(users.id) AS sum_1 from users"
-select_avg = "SELECT avg(users.id) AS avg_1 from users"
-select_join_order_by = (
-    "SELECT accounts.name, accounts.number FROM users "
-    "JOIN accounts ON users.id = accounts.user_id "
-    "ORDER BY users.id"
-)
-select_order_multiple = (
-    "SELECT users.name, users.age FROM users ORDER BY users.name, users.age"
-)
+table = TableFactory(columns__count=2)
+
 # These are meant to be examples of SQL queries that are not currently supported,
 # but that are valid SQL and so should be supported eventually.
 @pytest.mark.parametrize(
-    ["sql_string", "error_message"],
+    ["sql_query", "error_message"],
     [
-        (select_sum, "SUM"),
-        (select_avg, "AVG"),
         (
-            select_join_order_by,
-            "we currently can only sort the principal table",
+            SQLQueryFactory(
+                tables=[table],
+                order_by=OrderByFactory(columns=table.columns),
+            ),
+            "Ordering by multiple columns is not yet supported",
         ),
-        (select_order_multiple, "Ordering by multiple columns is not yet supported"),
     ],
 )
-def test_translating_unsupported_select(sql_string, error_message):
+def test_translating_unsupported_select(sql_query, error_message):
     with pytest.raises(exceptions.NotSupportedError, match=error_message):
-        sql_statement = sqlparse.parse(sql_string)[0]
-        sql_query = sql.SQLQuery.from_statement(sql_statement)
         select.translate_select(sql_query)
 
 
-select_aliases = (
-    "SELECT users.id AS users_id, users.name AS users_name, "
-    "users.date_joined AS users_date_joined, users.age AS users_age, "
-    "users.finger_count AS users_finger_count "
-    "FROM users"
-)
-select_where_equals = select_values + " WHERE users.name = 'Bob'"
-select_count = "SELECT count(users.id) AS count_1 FROM users"
-select_join = (
-    "SELECT users.name, users.age FROM users "
-    "JOIN accounts ON users.id = accounts.user_id "
-    "WHERE accounts.amount > 5.0"
-)
-select_order_by = "SELECT users.name, users.age FROM users ORDER BY users.name"
-select_order_by_desc = (
-    "SELECT users.name, users.age FROM users ORDER BY users.name DESC"
-)
-select_join_order_by_principal = (
-    "SELECT users.name, users.age FROM users "
-    "JOIN accounts ON users.id = accounts.user_id "
-    "WHERE accounts.amount > 5.0 "
-    "ORDER BY users.name"
-)
-
-
 @pytest.mark.parametrize(
-    "sql_string",
+    "sql_query",
     [
-        select_values,
-        select_aliases,
-        select_where_equals,
-        select_count,
-        select_join,
-        select_order_by,
-        select_order_by_desc,
-        select_join_order_by_principal,
-        (
-            "SELECT COUNT(users.id) FROM users JOIN accounts ON users.id = accounts.user_id "
-            "WHERE accounts.amount > 5.0"
+        SQLQueryFactory(table_count=1, filter_groups=[], tables__columns__alias=None),
+        SQLQueryFactory(table_count=1, filter_groups=[]),
+        SQLQueryFactory(
+            table_count=1,
+            filter_groups__filters__comparison__operator=sql.sql_table.ComparisonOperator.EQUAL,
+        ),
+        SQLQueryFactory(
+            table_count=1,
+            filter_groups=[],
+            tables__columns__function_name=sql.Function.COUNT,
+        ),
+        SQLQueryFactory(table_count=2),
+        SQLQueryFactory(table_count=1, order_by=OrderByFactory()),
+        SQLQueryFactory(
+            table_count=1,
+            order_by=OrderByFactory(direction=sql.sql_query.OrderDirection.DESC),
+        ),
+        SQLQueryFactory(
+            tables=[table, TableFactory(columns=[])],
+            order_by=OrderByFactory(columns=table.columns[:1]),
+        ),
+        SQLQueryFactory(
+            tables=[
+                TableFactory(
+                    columns=[
+                        ColumnFactory(
+                            function_name=sql.sql_table.Function.COUNT, table_name=None
+                        )
+                    ],
+                    filters=[],
+                ),
+                TableFactory(filters__count=1, columns=[]),
+            ]
         ),
     ],
 )
-def test_translate_select(sql_string):
-    sql_statement = sqlparse.parse(sql_string)[0]
-    sql_query = sql.SQLQuery.from_statement(sql_statement)
+def test_translate_select(sql_query):
     fql_query = select.translate_select(sql_query)
 
     assert isinstance(fql_query, QueryExpression)

--- a/tipping/sqlalchemy-fauna/tests/unit/sql/test_sql_query.py
+++ b/tipping/sqlalchemy-fauna/tests/unit/sql/test_sql_query.py
@@ -205,6 +205,8 @@ class TestSQLQuery:
                 "INSERT INTO users (name, age) VALUES ('Bob', 45), ('Linda', 45), ('Tina', 14)",
                 "INSERT for multiple rows is not supported yet",
             ),
+            ("SELECT SUM(users.age) FROM users", "SUM"),
+            ("SELECT AVG(users.age) FROM users", "AVG"),
         ],
     )
     def test_unsupported_statement(sql_string, error_message):

--- a/tipping/sqlalchemy-fauna/tests/unit/sql/test_sql_query.py
+++ b/tipping/sqlalchemy-fauna/tests/unit/sql/test_sql_query.py
@@ -8,7 +8,7 @@ from faker import Faker
 
 from sqlalchemy_fauna.sql import sql_query, sql_table
 from sqlalchemy_fauna import exceptions
-from tests.fixtures.factories.sql import ComparisonFactory
+from tests.fixtures.factories.sql import ComparisonFactory, FilterFactory
 
 from ...fixtures.factories import ColumnFactory
 
@@ -59,9 +59,7 @@ class TestSQLQuery:
         column = ColumnFactory()
         table = sql_table.Table(name=column.table_name, columns=[column])
         query = sql_query.SQLQuery("SELECT", tables=[table])
-        sql_filter = sql_table.Filter(
-            column=column, comparison=ComparisonFactory(), value="Bob"
-        )
+        sql_filter = FilterFactory(column=column)
 
         query.add_filter_to_table(sql_filter)
 

--- a/tipping/sqlalchemy-fauna/tests/unit/sql/test_sql_query.py
+++ b/tipping/sqlalchemy-fauna/tests/unit/sql/test_sql_query.py
@@ -6,11 +6,9 @@ import sqlparse
 import pytest
 from faker import Faker
 
+from tests.fixtures.factories.sql import FilterFactory, ColumnFactory
 from sqlalchemy_fauna.sql import sql_query, sql_table
 from sqlalchemy_fauna import exceptions
-from tests.fixtures.factories.sql import ComparisonFactory, FilterFactory
-
-from ...fixtures.factories import ColumnFactory
 
 
 Fake = Faker()

--- a/tipping/sqlalchemy-fauna/tests/unit/sql/test_sql_query.py
+++ b/tipping/sqlalchemy-fauna/tests/unit/sql/test_sql_query.py
@@ -46,7 +46,7 @@ class TestSQLQuery:
     @staticmethod
     def test_add_filter_to_table():
         query = SQLQueryFactory()
-        table = query.tables[0]
+        table = next(table for table in query.tables if table.has_columns)
         sql_filter = FilterFactory(column=np.random.choice(table.columns))
 
         query.add_filter_to_table(sql_filter)

--- a/tipping/sqlalchemy-fauna/tests/unit/sql/test_sql_query.py
+++ b/tipping/sqlalchemy-fauna/tests/unit/sql/test_sql_query.py
@@ -1,13 +1,19 @@
 # pylint: disable=missing-docstring,redefined-outer-name
 
 import functools
+from sqlalchemy_fauna.sql.sql_table import Table
 
 import sqlparse
 import pytest
 from faker import Faker
 import numpy as np
 
-from tests.fixtures.factories import FilterFactory, ColumnFactory, TableFactory
+from tests.fixtures.factories import (
+    FilterFactory,
+    ColumnFactory,
+    TableFactory,
+    SQLQueryFactory,
+)
 from sqlalchemy_fauna.sql import sql_query
 from sqlalchemy_fauna import exceptions
 
@@ -33,18 +39,14 @@ class TestSQLQuery:
 
     @staticmethod
     def test_validation():
-        table = TableFactory(columns__position=0)
-
+        table = TableFactory(columns__position=0, columns__count=2)
         with pytest.raises(AssertionError, match="must have unique position values"):
-            sql_query.SQLQuery(
-                "SELECT",
-                tables=[table],
-            )
+            sql_query.SQLQuery("SELECT", tables=[table])
 
     @staticmethod
     def test_add_filter_to_table():
-        table = TableFactory()
-        query = sql_query.SQLQuery("SELECT", tables=[table])
+        query = SQLQueryFactory()
+        table = query.tables[0]
         sql_filter = FilterFactory(column=np.random.choice(table.columns))
 
         query.add_filter_to_table(sql_filter)

--- a/tipping/sqlalchemy-fauna/tests/unit/sql/test_sql_query.py
+++ b/tipping/sqlalchemy-fauna/tests/unit/sql/test_sql_query.py
@@ -8,6 +8,7 @@ from faker import Faker
 
 from sqlalchemy_fauna.sql import sql_query, sql_table
 from sqlalchemy_fauna import exceptions
+from tests.fixtures.factories.sql import ComparisonFactory
 
 from ...fixtures.factories import ColumnFactory
 
@@ -58,7 +59,9 @@ class TestSQLQuery:
         column = ColumnFactory()
         table = sql_table.Table(name=column.table_name, columns=[column])
         query = sql_query.SQLQuery("SELECT", tables=[table])
-        sql_filter = sql_table.Filter(column=column, operator="=", value="Bob")
+        sql_filter = sql_table.Filter(
+            column=column, comparison=ComparisonFactory(), value="Bob"
+        )
 
         query.add_filter_to_table(sql_filter)
 

--- a/tipping/sqlalchemy-fauna/tests/unit/sql/test_sql_table.py
+++ b/tipping/sqlalchemy-fauna/tests/unit/sql/test_sql_table.py
@@ -5,10 +5,9 @@ from sqlparse import sql as token_groups, tokens as token_types
 import pytest
 from faker import Faker
 
+from tests.fixtures.factories import ColumnFactory, ComparisonFactory, FilterFactory
 from sqlalchemy_fauna.sql import sql_table
 from sqlalchemy_fauna import exceptions
-
-from tests.fixtures.factories import ColumnFactory, ComparisonFactory, FilterFactory
 
 
 Fake = Faker()

--- a/tipping/sqlalchemy-fauna/tests/unit/sql/test_sql_table.py
+++ b/tipping/sqlalchemy-fauna/tests/unit/sql/test_sql_table.py
@@ -8,7 +8,7 @@ from faker import Faker
 from sqlalchemy_fauna.sql import sql_table
 from sqlalchemy_fauna import exceptions
 
-from ...fixtures.factories import ColumnFactory, ComparisonFactory
+from tests.fixtures.factories import ColumnFactory, ComparisonFactory, FilterFactory
 
 
 Fake = Faker()
@@ -323,8 +323,8 @@ class TestFilter:
     @staticmethod
     def test_filter():
         column = ColumnFactory()
-        comparison = ComparisonFactory
-        value = "Bob"
+        comparison = ComparisonFactory()
+        value = Fake.word()
         where_filter = sql_table.Filter(
             column=column, comparison=comparison, value=value
         )
@@ -455,10 +455,7 @@ class TestFilter:
         "operator", list(sql_table.Comparison.OPERATOR_MAP.values())
     )
     def test_checks_whether_operator_methods(operator):
-        comparison = ComparisonFactory(operator=operator)
-        sql_filter = sql_table.Filter(
-            column=ColumnFactory(), comparison=comparison, value=Fake.word()
-        )
+        sql_filter = FilterFactory(comparison__operator=operator)
 
         for operator_to_compare in list(sql_table.Comparison.OPERATOR_MAP.values()):
             checks_operator = getattr(

--- a/tipping/sqlalchemy-fauna/tests/unit/sql/test_sql_table.py
+++ b/tipping/sqlalchemy-fauna/tests/unit/sql/test_sql_table.py
@@ -7,6 +7,7 @@ from faker import Faker
 
 from sqlalchemy_fauna.sql import sql_table
 from sqlalchemy_fauna import exceptions
+from ...fixtures.factories import ColumnFactory
 
 
 Fake = Faker()
@@ -98,7 +99,7 @@ class TestColumn:
 
     @staticmethod
     def test_column():
-        column = sql_table.Column(
+        column = ColumnFactory(
             position=0, table_name="users", name="name", alias="alias"
         )
         assert str(column) == "name"
@@ -272,9 +273,7 @@ class TestTable:
 class TestFilter:
     @staticmethod
     def test_filter():
-        column = sql_table.Column(
-            name="name", alias="name", table_name="users", position=0
-        )
+        column = ColumnFactory()
         operator = "="
         value = "Bob"
         where_filter = sql_table.Filter(column=column, operator=operator, value=value)


### PR DESCRIPTION
Writing new tests was getting burdensome for the lack of SQL object fixtures, because I was having to write out SQL strings, then use class methods to convert them into the objects that I actually wanted to use in the tests. These factories don't completely eliminate that, but they at least reduce the need to set up tests in such a manual way.

I also added a `Comparison` class for use in `Filter`, because depending on raw strings of comparison operators was clunky, and that clunkiness was becoming increasingly apparent as I was updating tests.