### PR TITLE
Fix missing win probability predictions

### DIFF
--- a/backend/server/schema.graphql
+++ b/backend/server/schema.graphql
@@ -11,7 +11,7 @@ type Query {
   fetchSeasonYears: [Int!]!
   fetchSeasonModelMetrics(
     """Filter metrics by season."""
-    season: Int = 2021
+    season: Int = 2022
   ): SeasonType!
 
   """
@@ -196,7 +196,7 @@ type MatchPredictionType {
   startDateTime: DateTime!
   predictedWinner: String!
   predictedMargin: Float!
-  predictedWinProbability: Float!
+  predictedWinProbability: Float
   isCorrect: Boolean
 }
 

--- a/backend/server/tests/unit/test_schema.py
+++ b/backend/server/tests/unit/test_schema.py
@@ -422,6 +422,14 @@ class TestSchema(TestCase):
                 # It returns predictions from the last round that has them
                 self.assertEqual(data["roundNumber"], max_round_number)
 
+        with self.subTest("without predictions from a non-principal model"):
+            Prediction.objects.filter(ml_model__is_principal=False).delete()
+
+            executed = self.client.execute(query_string)
+            data = executed["data"]["fetchLatestRoundPredictions"]
+
+            self.assertGreater(len(data["matchPredictions"]), 0)
+
     # Keeping this in a separate test, because it requires special setup
     # to properly test metric calculations
     def test_fetch_season_model_metrics_cumulative_metrics(self):


### PR DESCRIPTION
Removing the win-probability model broke more things than I had anticipated, since there were a few places where I assumed at least two models and both prediction types. This fix allows for there to only be predictions from the principal model.