### PR TITLE
Remove models that are no longer used

### DIFF
--- a/tipping/serverless.yml
+++ b/tipping/serverless.yml
@@ -60,13 +60,7 @@ functions:
           rate: cron(0 0 ? * 1-7 *)
           enabled: true
           input:
-            ml_model_names: tipresias_margin_2021,tipresias_proba_2021
-      - schedule:
-          # Everyday, 1am UTC
-          rate: cron(0 1 ? * 1-7 *)
-          enabled: true
-          input:
-            ml_model_names: tipresias_margin_2020,tipresias_proba_2020
+            ml_model_names: tipresias_margin_2021
   update_matches:
     handler: handler.update_matches
     events:


### PR DESCRIPTION
We're no longer making predictions with these models, so no
reason to request them.