### PR TITLE
Enable flaky join test

### DIFF
--- a/tipping/sqlalchemy-fauna/tests/unit/fql/test_common.py
+++ b/tipping/sqlalchemy-fauna/tests/unit/fql/test_common.py
@@ -123,7 +123,6 @@ def test_build_document_set_intersection(operator, column_params):
     assert isinstance(fql_query, QueryExpression)
 
 
-@pytest.mark.skip("Passes on local, but fails in CI")
 def test_join_collections():
     ENOUGH_TO_PROBABLY_GET_A_VARIETY_OF_JOINS = 6
     query = SQLQueryFactory(table_count=ENOUGH_TO_PROBABLY_GET_A_VARIETY_OF_JOINS)


### PR DESCRIPTION
Well, the test that was consistently failing in CI isn't anymore, so I'll just enable it and see if it starts failing again.