### PR TITLE
Maybe fix flaky equality check

### DIFF
--- a/backend/server/tests/unit/test_views.py
+++ b/backend/server/tests/unit/test_views.py
@@ -116,7 +116,9 @@ class TestViews(TestCase):
                 Prediction.objects.all().values_list("predicted_margin", flat=True)
             )
 
-            self.assertNotEqual(original_predicted_margins, new_predicted_margins)
+            self.assertNotEqual(
+                set(original_predicted_margins), set(new_predicted_margins)
+            )
 
             response = views.predictions(request)
 
@@ -126,7 +128,9 @@ class TestViews(TestCase):
             posted_predicted_margins = list(
                 Prediction.objects.all().values_list("predicted_margin", flat=True)
             )
-            self.assertEqual(original_predicted_margins, posted_predicted_margins)
+            self.assertEqual(
+                set(original_predicted_margins), set(posted_predicted_margins)
+            )
             # It returns a success response
             self.assertEqual(response.status_code, 200)
             # It returns the updated predictions


### PR DESCRIPTION
Based on the error message, it seems that the issue might be
that the lists are being reordered, so they contain the same
elements, but just in a different order, and so aren't equal.
I'm hoping that making them sets instead of lists will fix this.