### PR TITLE
Use real data for UI tables

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -9,8 +9,8 @@ jobs:
       - uses: actions/checkout@v2
       - uses: actions/setup-node@v2
         with:
-          node-version: "21"
+          node-version: "20"
       - name: Install dependencies
-        run: yarn
+        run: npm install
       - name: Run unit tests
         run: npx jest

--- a/app/.server/db.ts
+++ b/app/.server/db.ts
@@ -1,0 +1,6 @@
+import { Prisma, PrismaClient } from "@prisma/client";
+
+export const db = new PrismaClient();
+
+export const buildSql = Prisma.sql;
+export const sqlQuery = <T>(sql: Prisma.Sql) => db.$queryRaw<T>(sql);

--- a/app/.server/db.ts
+++ b/app/.server/db.ts
@@ -1,6 +1,5 @@
 import { Prisma, PrismaClient } from "@prisma/client";
 
-export const db = new PrismaClient();
+const db = new PrismaClient();
 
-export const buildSql = Prisma.sql;
-export const sqlQuery = <T>(sql: Prisma.Sql) => db.$queryRaw<T>(sql);
+export const sqlQuery = <T>(sql: string) => db.$queryRaw<T>(Prisma.sql([sql]));

--- a/app/.server/predictionService.ts
+++ b/app/.server/predictionService.ts
@@ -1,0 +1,65 @@
+import * as R from "ramda";
+
+import { buildSql, sqlQuery } from "./db";
+
+interface RoundPredictionRecord {
+  predicted_winner_name: string;
+  predicted_margin: number | null;
+  predicted_win_probability: number | null;
+  is_correct: boolean | null;
+}
+
+export interface Prediction {
+  predictedWinnerName: string;
+  predictedMargin: number | null;
+  predictedWinProbability: number | null;
+  isCorrect: boolean | null;
+}
+
+const roundPredictionsSql = buildSql`
+  WITH latest_predicted_match AS (
+    SELECT server_match.id, server_match.round_number, EXTRACT(YEAR FROM server_match.start_date_time) AS year
+    FROM server_match
+    INNER JOIN server_prediction ON server_prediction.match_id = server_match.id
+    ORDER BY server_match.start_date_time DESC
+    LIMIT 1
+  ),
+  principal_predictions AS (
+    SELECT server_prediction.match_id, server_team.name AS predicted_winner_name, server_prediction.is_correct FROM server_prediction
+    INNER JOIN server_team ON server_team.id = server_prediction.predicted_winner_id
+    INNER JOIN server_mlmodel ON server_mlmodel.id = server_prediction.ml_model_id
+    WHERE server_mlmodel.is_principal IS TRUE
+  )
+  SELECT
+    principal_predictions.predicted_winner_name,
+    MAX(server_prediction.predicted_margin) AS predicted_margin,
+    MAX(server_prediction.predicted_win_probability) AS predicted_win_probability,
+    principal_predictions.is_correct
+  FROM server_prediction
+  INNER JOIN server_match ON server_match.id = server_prediction.match_id
+  INNER JOIN server_mlmodel ON server_mlmodel.id = server_prediction.ml_model_id
+  INNER JOIN principal_predictions ON principal_predictions.match_id = server_prediction.match_id
+  WHERE server_match.round_number = (SELECT latest_predicted_match.round_number FROM latest_predicted_match)
+  AND EXTRACT(YEAR FROM server_match.start_date_time) = (SELECT latest_predicted_match.year FROM latest_predicted_match)
+  AND server_mlmodel.used_in_competitions IS TRUE
+  GROUP BY principal_predictions.predicted_winner_name, principal_predictions.is_correct, server_match.start_date_time
+  ORDER BY server_match.start_date_time DESC
+`;
+const queryRoundPredictions = () =>
+  sqlQuery<RoundPredictionRecord[]>(roundPredictionsSql);
+const convertKeysToCamelCase = ({
+  predicted_winner_name,
+  predicted_margin,
+  predicted_win_probability,
+  is_correct,
+}: RoundPredictionRecord): Prediction => ({
+  predictedWinnerName: predicted_winner_name,
+  predictedMargin: predicted_margin,
+  predictedWinProbability: predicted_win_probability,
+  isCorrect: is_correct,
+});
+
+export const fetchRoundPredictions = R.pipe(
+  queryRoundPredictions,
+  R.andThen(R.map(convertKeysToCamelCase))
+);

--- a/app/.server/predictionService.ts
+++ b/app/.server/predictionService.ts
@@ -2,7 +2,7 @@ import * as R from "ramda";
 
 import { buildSql, sqlQuery } from "./db";
 
-interface RoundPredictionRecord {
+export interface RoundPredictionRecord {
   predicted_winner_name: string;
   predicted_margin: number | null;
   predicted_win_probability: number | null;
@@ -15,6 +15,27 @@ export interface Prediction {
   predictedWinProbability: number | null;
   isCorrect: boolean | null;
 }
+
+export interface MetricsRecord {
+  total_tips: number | null;
+  accuracy: number | null;
+  mae: number | null;
+  bits: number | null;
+}
+
+export interface Metrics {
+  totalTips: number | null;
+  accuracy: number | null;
+  mae: number | null;
+  bits: number | null;
+}
+
+const BLANK_METRICS: Metrics = {
+  totalTips: null,
+  accuracy: null,
+  mae: null,
+  bits: null,
+};
 
 const roundPredictionsSql = buildSql`
   WITH latest_predicted_match AS (
@@ -45,9 +66,7 @@ const roundPredictionsSql = buildSql`
   GROUP BY principal_predictions.predicted_winner_name, principal_predictions.is_correct, server_match.start_date_time
   ORDER BY server_match.start_date_time DESC
 `;
-const queryRoundPredictions = () =>
-  sqlQuery<RoundPredictionRecord[]>(roundPredictionsSql);
-const convertKeysToCamelCase = ({
+const convertPredictionKeysToCamelCase = ({
   predicted_winner_name,
   predicted_margin,
   predicted_win_probability,
@@ -59,7 +78,58 @@ const convertKeysToCamelCase = ({
   isCorrect: is_correct,
 });
 
-export const fetchRoundPredictions = R.pipe(
-  queryRoundPredictions,
-  R.andThen(R.map(convertKeysToCamelCase))
-);
+export const fetchRoundPredictions = () =>
+  R.pipe(
+    sqlQuery<RoundPredictionRecord[]>,
+    R.andThen(R.map(convertPredictionKeysToCamelCase))
+  )(roundPredictionsSql);
+
+const metricsSql = buildSql`
+  WITH latest_predicted_match AS (
+    SELECT server_match.id, server_match.round_number, EXTRACT(YEAR FROM server_match.start_date_time) AS year
+    FROM server_match
+    INNER JOIN server_prediction ON server_prediction.match_id = server_match.id
+    ORDER BY server_match.start_date_time DESC
+    LIMIT 1
+  )
+  SELECT
+    SUM(server_prediction.is_correct::int) FILTER(WHERE server_mlmodel.is_principal IS TRUE)::int AS total_tips,
+    AVG(server_prediction.is_correct::int) FILTER(WHERE server_mlmodel.is_principal IS TRUE) AS accuracy,
+    AVG(ABS(server_match.margin + (server_prediction.predicted_margin * server_prediction.is_correct::int + server_prediction.predicted_margin * (server_prediction.is_correct::int - 1)) * -1))
+      FILTER(WHERE server_prediction.predicted_margin IS NOT NULL) AS mae,
+    SUM(
+      CASE
+        WHEN server_match.margin = 0
+          THEN 1 + (0.5 * LOG(2, (server_prediction.predicted_win_probability * (1 - server_prediction.predicted_win_probability))::numeric))
+        WHEN server_prediction.is_correct IS TRUE
+          THEN 1 + LOG(2, server_prediction.predicted_win_probability::numeric)
+        WHEN server_prediction.is_correct IS FALSE
+          THEN 1 + LOG(2, (1 - server_prediction.predicted_win_probability)::numeric)
+        END
+    ) FILTER(WHERE server_prediction.predicted_win_probability IS NOT NULL) AS bits
+
+  FROM server_prediction
+  INNER JOIN server_mlmodel ON server_mlmodel.id = server_prediction.ml_model_id
+  INNER JOIN server_match ON server_match.id = server_prediction.match_id
+  WHERE server_mlmodel.used_in_competitions IS TRUE
+  AND server_prediction.is_correct IS NOT NULL
+  AND EXTRACT(YEAR FROM server_match.start_date_time) = (SELECT latest_predicted_match.year FROM latest_predicted_match)
+`;
+const convertMetricKeysToCamelCase = ({
+  total_tips,
+  accuracy,
+  mae,
+  bits,
+}: MetricsRecord) => ({
+  totalTips: total_tips,
+  accuracy,
+  mae,
+  bits,
+});
+export const fetchRoundMetrics = () =>
+  R.pipe(
+    sqlQuery<MetricsRecord[]>,
+    R.andThen(R.map<MetricsRecord, Metrics>(convertMetricKeysToCamelCase)),
+    R.andThen(R.head<Metrics>),
+    R.andThen(R.defaultTo(BLANK_METRICS))
+  )(metricsSql);

--- a/app/components/MetricsTable.tsx
+++ b/app/components/MetricsTable.tsx
@@ -7,21 +7,42 @@ import {
   Th,
   Tr,
 } from "@chakra-ui/react";
+import round from "lodash/round";
+
+export interface Metrics {
+  totalTips: number | null;
+  accuracy: number | null;
+  mae: number | null;
+  bits: number | null;
+}
 
 interface Metric {
-  name: string;
-  value: string;
+  name: keyof Metrics;
+  value: number | null;
 }
 
 interface MetricsTableProps {
-  metrics: Metric[];
+  metrics: Metrics;
   season: number;
 }
 
+const ROW_ORDER: Array<keyof Metrics> = [
+  "totalTips",
+  "accuracy",
+  "mae",
+  "bits",
+];
+export const METRIC_LABEL_MAP: Record<keyof Metrics, string> = {
+  totalTips: "Total Tips",
+  accuracy: "Accuracy",
+  mae: "MAE",
+  bits: "Bits",
+};
+
 const MetricRow = ({ name, value }: Metric) => (
-  <Tr key={name}>
-    <Th>{name}</Th>
-    <Td isNumeric>{value}</Td>
+  <Tr>
+    <Th>{METRIC_LABEL_MAP[name]}</Th>
+    <Td isNumeric>{round(value || NaN, 2) || "NA"}</Td>
   </Tr>
 );
 
@@ -31,7 +52,15 @@ const MetricsTable = ({ metrics, season }: MetricsTableProps) => (
       Model performance for {season}
     </Heading>
     <Table variant="simple">
-      <Tbody>{metrics.map(MetricRow)}</Tbody>
+      <Tbody>
+        {ROW_ORDER.map((metricKey) => (
+          <MetricRow
+            key={metricKey}
+            name={metricKey}
+            value={metrics[metricKey]}
+          />
+        ))}
+      </Tbody>
     </Table>
   </TableContainer>
 );

--- a/app/components/MetricsTable.tsx
+++ b/app/components/MetricsTable.tsx
@@ -8,13 +8,7 @@ import {
   Tr,
 } from "@chakra-ui/react";
 import round from "lodash/round";
-
-export interface Metrics {
-  totalTips: number | null;
-  accuracy: number | null;
-  mae: number | null;
-  bits: number | null;
-}
+import { Metrics } from "../.server/predictionService";
 
 interface Metric {
   name: keyof Metrics;

--- a/app/components/PredictionsTable.tsx
+++ b/app/components/PredictionsTable.tsx
@@ -14,6 +14,7 @@ import { Prediction } from "~/.server/predictionService";
 
 interface PredictionsTableProps {
   currentRound: number;
+  currentSeason: number;
   predictions: Prediction[];
 }
 
@@ -44,11 +45,12 @@ const PredictionRow = ({
 
 const PredictionsTable = ({
   currentRound,
+  currentSeason,
   predictions,
 }: PredictionsTableProps) => (
   <TableContainer textAlign="center">
     <Heading as="h2" size="l" margin="0.5rem" whiteSpace="nowrap">
-      Predictions for round {currentRound}
+      Predictions for round {currentRound}, {currentSeason}
     </Heading>
     <Table variant="striped" maxWidth="fit-content">
       <Thead>

--- a/app/components/PredictionsTable.tsx
+++ b/app/components/PredictionsTable.tsx
@@ -8,12 +8,13 @@ import {
   Thead,
   Tr,
 } from "@chakra-ui/react";
+import round from "lodash/round";
 
-interface Prediction {
-  winner: string;
-  loser: string;
-  margin: number;
-  wasCorrect: boolean | null;
+export interface Prediction {
+  predictedWinnerName: string;
+  predictedMargin: number | null;
+  predictedWinProbability: number | null;
+  isCorrect: boolean | null;
 }
 
 interface PredictionsTableProps {
@@ -24,20 +25,25 @@ interface PredictionsTableProps {
 export const displayCorrectness = (wasCorrect: boolean | null) => {
   switch (wasCorrect) {
     case true:
-      return "yup";
+      return "yeah";
     case false:
-      return "nope";
+      return "nah";
     case null:
       return "dunno";
   }
 };
 
-const PredictionRow = ({ winner, loser, margin, wasCorrect }: Prediction) => (
-  <Tr key={winner}>
-    <Td>{winner}</Td>
-    <Td>{loser}</Td>
-    <Td isNumeric>{margin}</Td>
-    <Td>{displayCorrectness(wasCorrect)}</Td>
+const PredictionRow = ({
+  predictedWinnerName,
+  predictedMargin,
+  predictedWinProbability,
+  isCorrect,
+}: Prediction) => (
+  <Tr key={predictedWinnerName}>
+    <Td>{predictedWinnerName}</Td>
+    <Td isNumeric>{round(predictedMargin || NaN, 2) || "NA"}</Td>
+    <Td isNumeric>{round(predictedWinProbability || NaN, 2) || "NA"}</Td>
+    <Td>{displayCorrectness(isCorrect)}</Td>
   </Tr>
 );
 
@@ -52,9 +58,9 @@ const PredictionsTable = ({
     <Table variant="striped" maxWidth="fit-content">
       <Thead>
         <Tr>
-          <Th>Winner</Th>
-          <Th>Loser</Th>
-          <Th isNumeric>Margin</Th>
+          <Th>Predicted Winner</Th>
+          <Th isNumeric>Predicted Margin</Th>
+          <Th isNumeric>Predicted Win Probability (%)</Th>
           <Th>Correct?</Th>
         </Tr>
       </Thead>

--- a/app/components/PredictionsTable.tsx
+++ b/app/components/PredictionsTable.tsx
@@ -10,12 +10,7 @@ import {
 } from "@chakra-ui/react";
 import round from "lodash/round";
 
-export interface Prediction {
-  predictedWinnerName: string;
-  predictedMargin: number | null;
-  predictedWinProbability: number | null;
-  isCorrect: boolean | null;
-}
+import { Prediction } from "~/.server/predictionService";
 
 interface PredictionsTableProps {
   currentRound: number;

--- a/app/routes/_index.tsx
+++ b/app/routes/_index.tsx
@@ -18,7 +18,7 @@ import {
   Metrics,
   fetchRoundMetrics,
 } from "../.server/predictionService";
-import { buildSql, sqlQuery } from "../.server/db";
+import { sqlQuery } from "../.server/db";
 
 interface Round {
   round_number: number;
@@ -36,14 +36,14 @@ export const meta: MetaFunction = () => {
 };
 
 export const loader = async () => {
-  const predictedRoundSql = buildSql`
+  const PREDICTED_ROUND_SQL = `
     SELECT server_match.round_number, EXTRACT(YEAR FROM server_match.start_date_time) AS season
     FROM server_match
     INNER JOIN server_prediction ON server_prediction.match_id = server_match.id
     ORDER BY server_match.start_date_time DESC
     LIMIT 1
   `;
-  const predictedRound = (await sqlQuery<Round[]>(predictedRoundSql))[0];
+  const predictedRound = (await sqlQuery<Round[]>(PREDICTED_ROUND_SQL))[0];
   const predictions: Prediction[] = await fetchRoundPredictions();
   const metrics: Metrics = await fetchRoundMetrics();
 

--- a/app/routes/_index.tsx
+++ b/app/routes/_index.tsx
@@ -9,23 +9,20 @@ import {
 } from "@chakra-ui/react";
 import { json, MetaFunction } from "@remix-run/node";
 import { useLoaderData } from "@remix-run/react";
-import * as R from "ramda";
 
-import MetricsTable, { Metrics } from "../components/MetricsTable";
+import MetricsTable from "../components/MetricsTable";
 import PredictionsTable from "../components/PredictionsTable";
-import { Prediction, fetchRoundPredictions } from "~/.server/predictionService";
-import { buildSql, sqlQuery } from "~/.server/db";
+import {
+  Prediction,
+  fetchRoundPredictions,
+  Metrics,
+  fetchRoundMetrics,
+} from "../.server/predictionService";
+import { buildSql, sqlQuery } from "../.server/db";
 
 interface Round {
   round_number: number;
   season: number;
-}
-
-interface MetricsRecord {
-  total_tips: number | null;
-  accuracy: number | null;
-  mae: number | null;
-  bits: number | null;
 }
 
 export const meta: MetaFunction = () => {
@@ -48,54 +45,7 @@ export const loader = async () => {
   `;
   const predictedRound = (await sqlQuery<Round[]>(predictedRoundSql))[0];
   const predictions: Prediction[] = await fetchRoundPredictions();
-  const metricsSql = buildSql`
-    WITH latest_predicted_match AS (
-      SELECT server_match.id, server_match.round_number, EXTRACT(YEAR FROM server_match.start_date_time) AS year
-      FROM server_match
-      INNER JOIN server_prediction ON server_prediction.match_id = server_match.id
-      ORDER BY server_match.start_date_time DESC
-      LIMIT 1
-    )
-    SELECT
-      SUM(server_prediction.is_correct::int) FILTER(WHERE server_mlmodel.is_principal IS TRUE)::int AS total_tips,
-      AVG(server_prediction.is_correct::int) FILTER(WHERE server_mlmodel.is_principal IS TRUE) AS accuracy,
-      AVG(ABS(server_match.margin + (server_prediction.predicted_margin * server_prediction.is_correct::int + server_prediction.predicted_margin * (server_prediction.is_correct::int - 1)) * -1))
-        FILTER(WHERE server_prediction.predicted_margin IS NOT NULL) AS mae,
-      SUM(
-        CASE
-          WHEN server_match.margin = 0
-            THEN 1 + (0.5 * LOG(2, (server_prediction.predicted_win_probability * (1 - server_prediction.predicted_win_probability))::numeric))
-          WHEN server_prediction.is_correct IS TRUE
-            THEN 1 + LOG(2, server_prediction.predicted_win_probability::numeric)
-          WHEN server_prediction.is_correct IS FALSE
-            THEN 1 + LOG(2, (1 - server_prediction.predicted_win_probability)::numeric)
-          END
-      ) FILTER(WHERE server_prediction.predicted_win_probability IS NOT NULL) AS bits
-
-    FROM server_prediction
-    INNER JOIN server_mlmodel ON server_mlmodel.id = server_prediction.ml_model_id
-    INNER JOIN server_match ON server_match.id = server_prediction.match_id
-    WHERE server_mlmodel.used_in_competitions IS TRUE
-    AND server_prediction.is_correct IS NOT NULL
-    AND EXTRACT(YEAR FROM server_match.start_date_time) = (SELECT latest_predicted_match.year FROM latest_predicted_match)
-  `;
-  const metrics = (await R.pipe(
-    sqlQuery<MetricsRecord[]>,
-    R.andThen(
-      R.map<MetricsRecord, Metrics>(({ total_tips, accuracy, mae, bits }) => ({
-        totalTips: total_tips,
-        accuracy,
-        mae,
-        bits,
-      }))
-    ),
-    R.andThen(R.head<Metrics>)
-  )(metricsSql)) || {
-    totalTips: null,
-    accuracy: null,
-    mae: null,
-    bits: null,
-  };
+  const metrics: Metrics = await fetchRoundMetrics();
 
   return json({
     currentRound: predictedRound.round_number,

--- a/app/routes/_index.tsx
+++ b/app/routes/_index.tsx
@@ -9,8 +9,9 @@ import {
 } from "@chakra-ui/react";
 import { json, MetaFunction } from "@remix-run/node";
 import { useLoaderData } from "@remix-run/react";
+import * as R from "ramda";
 
-import MetricsTable from "../components/MetricsTable";
+import MetricsTable, { Metrics } from "../components/MetricsTable";
 import PredictionsTable from "../components/PredictionsTable";
 import { Prediction, fetchRoundPredictions } from "~/.server/predictionService";
 import { buildSql, sqlQuery } from "~/.server/db";
@@ -18,6 +19,13 @@ import { buildSql, sqlQuery } from "~/.server/db";
 interface Round {
   round_number: number;
   season: number;
+}
+
+interface MetricsRecord {
+  total_tips: number | null;
+  accuracy: number | null;
+  mae: number | null;
+  bits: number | null;
 }
 
 export const meta: MetaFunction = () => {
@@ -40,15 +48,59 @@ export const loader = async () => {
   `;
   const predictedRound = (await sqlQuery<Round[]>(predictedRoundSql))[0];
   const predictions: Prediction[] = await fetchRoundPredictions();
+  const metricsSql = buildSql`
+    WITH latest_predicted_match AS (
+      SELECT server_match.id, server_match.round_number, EXTRACT(YEAR FROM server_match.start_date_time) AS year
+      FROM server_match
+      INNER JOIN server_prediction ON server_prediction.match_id = server_match.id
+      ORDER BY server_match.start_date_time DESC
+      LIMIT 1
+    )
+    SELECT
+      SUM(server_prediction.is_correct::int) FILTER(WHERE server_mlmodel.is_principal IS TRUE)::int AS total_tips,
+      AVG(server_prediction.is_correct::int) FILTER(WHERE server_mlmodel.is_principal IS TRUE) AS accuracy,
+      AVG(ABS(server_match.margin + (server_prediction.predicted_margin * server_prediction.is_correct::int + server_prediction.predicted_margin * (server_prediction.is_correct::int - 1)) * -1))
+        FILTER(WHERE server_prediction.predicted_margin IS NOT NULL) AS mae,
+      SUM(
+        CASE
+          WHEN server_match.margin = 0
+            THEN 1 + (0.5 * LOG(2, (server_prediction.predicted_win_probability * (1 - server_prediction.predicted_win_probability))::numeric))
+          WHEN server_prediction.is_correct IS TRUE
+            THEN 1 + LOG(2, server_prediction.predicted_win_probability::numeric)
+          WHEN server_prediction.is_correct IS FALSE
+            THEN 1 + LOG(2, (1 - server_prediction.predicted_win_probability)::numeric)
+          END
+      ) FILTER(WHERE server_prediction.predicted_win_probability IS NOT NULL) AS bits
+
+    FROM server_prediction
+    INNER JOIN server_mlmodel ON server_mlmodel.id = server_prediction.ml_model_id
+    INNER JOIN server_match ON server_match.id = server_prediction.match_id
+    WHERE server_mlmodel.used_in_competitions IS TRUE
+    AND server_prediction.is_correct IS NOT NULL
+    AND EXTRACT(YEAR FROM server_match.start_date_time) = (SELECT latest_predicted_match.year FROM latest_predicted_match)
+  `;
+  const metrics = (await R.pipe(
+    sqlQuery<MetricsRecord[]>,
+    R.andThen(
+      R.map<MetricsRecord, Metrics>(({ total_tips, accuracy, mae, bits }) => ({
+        totalTips: total_tips,
+        accuracy,
+        mae,
+        bits,
+      }))
+    ),
+    R.andThen(R.head<Metrics>)
+  )(metricsSql)) || {
+    totalTips: null,
+    accuracy: null,
+    mae: null,
+    bits: null,
+  };
 
   return json({
     currentRound: predictedRound.round_number,
     predictions,
-    metrics: [
-      { name: "Total Tips", value: "42" },
-      { name: "MAE", value: "21.2" },
-      { name: "Accuracy", value: "84.8%" },
-    ],
+    metrics,
     currentSeason: predictedRound.season,
   });
 };
@@ -71,7 +123,7 @@ export default function Index() {
       </Container>
       <Box margin="auto" width="fit-content">
         <Flex alignItems="center" flexWrap="wrap" direction="column">
-          {predictions.length && (
+          {predictions?.length && (
             <Card marginTop="1rem" marginBottom="1rem">
               <CardBody>
                 <PredictionsTable
@@ -84,7 +136,7 @@ export default function Index() {
           )}
           <Card marginTop="1rem" marginBottom="1rem" width="100%">
             <CardBody>
-              {metrics.length && (
+              {metrics && (
                 <MetricsTable metrics={metrics} season={currentSeason} />
               )}
             </CardBody>

--- a/app/routes/_index.tsx
+++ b/app/routes/_index.tsx
@@ -9,18 +9,10 @@ import {
 } from "@chakra-ui/react";
 import { json, MetaFunction } from "@remix-run/node";
 import { useLoaderData } from "@remix-run/react";
-import { PrismaClient } from "@prisma/client";
-import * as R from "ramda";
 
 import MetricsTable from "../components/MetricsTable";
-import PredictionsTable, { Prediction } from "../components/PredictionsTable";
-
-interface RoundPredictionRecord {
-  predicted_winner_name: string;
-  predicted_margin: number | null;
-  predicted_win_probability: number | null;
-  is_correct: boolean | null;
-}
+import PredictionsTable from "../components/PredictionsTable";
+import { Prediction, fetchRoundPredictions } from "~/.server/predictionService";
 
 export const meta: MetaFunction = () => {
   return [
@@ -33,52 +25,7 @@ export const meta: MetaFunction = () => {
 };
 
 export const loader = async () => {
-  const prisma = new PrismaClient();
-  const predictions: Prediction[] = await R.pipe(
-    () => prisma.$queryRaw<RoundPredictionRecord[]>`
-    WITH latest_predicted_match AS (
-      SELECT server_match.id, server_match.round_number, EXTRACT(YEAR FROM server_match.start_date_time) AS year
-      FROM server_match
-      INNER JOIN server_prediction ON server_prediction.match_id = server_match.id
-      ORDER BY server_match.start_date_time DESC
-      LIMIT 1
-    ),
-    principal_predictions AS (
-      SELECT server_prediction.match_id, server_team.name AS predicted_winner_name, server_prediction.is_correct FROM server_prediction
-      INNER JOIN server_team ON server_team.id = server_prediction.predicted_winner_id
-      INNER JOIN server_mlmodel ON server_mlmodel.id = server_prediction.ml_model_id
-      WHERE server_mlmodel.is_principal IS TRUE
-    )
-    SELECT
-      principal_predictions.predicted_winner_name,
-      MAX(server_prediction.predicted_margin) AS predicted_margin,
-      MAX(server_prediction.predicted_win_probability) AS predicted_win_probability,
-      principal_predictions.is_correct
-    FROM server_prediction
-    INNER JOIN server_match ON server_match.id = server_prediction.match_id
-    INNER JOIN server_mlmodel ON server_mlmodel.id = server_prediction.ml_model_id
-    INNER JOIN principal_predictions ON principal_predictions.match_id = server_prediction.match_id
-    WHERE server_match.round_number = (SELECT latest_predicted_match.round_number FROM latest_predicted_match)
-    AND EXTRACT(YEAR FROM server_match.start_date_time) = (SELECT latest_predicted_match.year FROM latest_predicted_match)
-    AND server_mlmodel.used_in_competitions IS TRUE
-    GROUP BY principal_predictions.predicted_winner_name, principal_predictions.is_correct;
-  `,
-    R.andThen(
-      R.map<RoundPredictionRecord, Prediction>(
-        ({
-          predicted_winner_name,
-          predicted_margin,
-          predicted_win_probability,
-          is_correct,
-        }) => ({
-          predictedWinnerName: predicted_winner_name,
-          predictedMargin: predicted_margin,
-          predictedWinProbability: predicted_win_probability,
-          isCorrect: is_correct,
-        })
-      )
-    )
-  )();
+  const predictions: Prediction[] = await fetchRoundPredictions();
 
   return json({
     currentRound: 42,

--- a/app/routes/_index.tsx
+++ b/app/routes/_index.tsx
@@ -9,9 +9,18 @@ import {
 } from "@chakra-ui/react";
 import { json, MetaFunction } from "@remix-run/node";
 import { useLoaderData } from "@remix-run/react";
-import MetricsTable from "../components/MetricsTable";
+import { PrismaClient } from "@prisma/client";
+import * as R from "ramda";
 
-import PredictionsTable from "../components/PredictionsTable";
+import MetricsTable from "../components/MetricsTable";
+import PredictionsTable, { Prediction } from "../components/PredictionsTable";
+
+interface RoundPredictionRecord {
+  predicted_winner_name: string;
+  predicted_margin: number | null;
+  predicted_win_probability: number | null;
+  is_correct: boolean | null;
+}
 
 export const meta: MetaFunction = () => {
   return [
@@ -24,14 +33,56 @@ export const meta: MetaFunction = () => {
 };
 
 export const loader = async () => {
+  const prisma = new PrismaClient();
+  const predictions: Prediction[] = await R.pipe(
+    () => prisma.$queryRaw<RoundPredictionRecord[]>`
+    WITH latest_predicted_match AS (
+      SELECT server_match.id, server_match.round_number, EXTRACT(YEAR FROM server_match.start_date_time) AS year
+      FROM server_match
+      INNER JOIN server_prediction ON server_prediction.match_id = server_match.id
+      ORDER BY server_match.start_date_time DESC
+      LIMIT 1
+    ),
+    principal_predictions AS (
+      SELECT server_prediction.match_id, server_team.name AS predicted_winner_name, server_prediction.is_correct FROM server_prediction
+      INNER JOIN server_team ON server_team.id = server_prediction.predicted_winner_id
+      INNER JOIN server_mlmodel ON server_mlmodel.id = server_prediction.ml_model_id
+      WHERE server_mlmodel.is_principal IS TRUE
+    )
+    SELECT
+      principal_predictions.predicted_winner_name,
+      MAX(server_prediction.predicted_margin) AS predicted_margin,
+      MAX(server_prediction.predicted_win_probability) AS predicted_win_probability,
+      principal_predictions.is_correct
+    FROM server_prediction
+    INNER JOIN server_match ON server_match.id = server_prediction.match_id
+    INNER JOIN server_mlmodel ON server_mlmodel.id = server_prediction.ml_model_id
+    INNER JOIN principal_predictions ON principal_predictions.match_id = server_prediction.match_id
+    WHERE server_match.round_number = (SELECT latest_predicted_match.round_number FROM latest_predicted_match)
+    AND EXTRACT(YEAR FROM server_match.start_date_time) = (SELECT latest_predicted_match.year FROM latest_predicted_match)
+    AND server_mlmodel.used_in_competitions IS TRUE
+    GROUP BY principal_predictions.predicted_winner_name, principal_predictions.is_correct;
+  `,
+    R.andThen(
+      R.map<RoundPredictionRecord, Prediction>(
+        ({
+          predicted_winner_name,
+          predicted_margin,
+          predicted_win_probability,
+          is_correct,
+        }) => ({
+          predictedWinnerName: predicted_winner_name,
+          predictedMargin: predicted_margin,
+          predictedWinProbability: predicted_win_probability,
+          isCorrect: is_correct,
+        })
+      )
+    )
+  )();
+
   return json({
     currentRound: 42,
-    predictions: new Array(9).fill(null).map((_, i) => ({
-      winner: `Team ${i + 1}`,
-      loser: `Team ${-i - 1}`,
-      margin: i ** 2,
-      wasCorrect: i === 0 ? null : Boolean(i % 2),
-    })),
+    predictions,
     metrics: [
       { name: "Total Tips", value: "42" },
       { name: "MAE", value: "21.2" },

--- a/package-lock.json
+++ b/package-lock.json
@@ -17,6 +17,7 @@
         "@remix-run/serve": "^2.9.2",
         "framer-motion": "^10.12.16",
         "isbot": "^4.1.0",
+        "lodash": "^4.17.21",
         "ramda": "^0.29.1",
         "react": "^18.2.0",
         "react-dom": "^18.2.0"
@@ -10659,8 +10660,7 @@
     "node_modules/lodash": {
       "version": "4.17.21",
       "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
-      "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==",
-      "dev": true
+      "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg=="
     },
     "node_modules/lodash.camelcase": {
       "version": "4.3.0",

--- a/package.json
+++ b/package.json
@@ -57,6 +57,6 @@
     "vite-tsconfig-paths": "^4.2.1"
   },
   "engines": {
-    "node": ">=20"
+    "node": "20"
   }
 }

--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
     "@remix-run/serve": "^2.9.2",
     "framer-motion": "^10.12.16",
     "isbot": "^4.1.0",
+    "lodash": "^4.17.21",
     "ramda": "^0.29.1",
     "react": "^18.2.0",
     "react-dom": "^18.2.0"

--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
     "build": "remix vite:build",
     "dev": "remix vite:dev",
     "lint": "eslint --ignore-path .gitignore --cache --cache-location ./node_modules/.cache/eslint .",
+    "postinstall": "prisma generate",
     "start": "remix-serve ./build/server/index.js",
     "test": "jest",
     "typecheck": "tsc"

--- a/tests/.server/predictionService.test.ts
+++ b/tests/.server/predictionService.test.ts
@@ -1,0 +1,40 @@
+/**
+ * @jest-environment node
+ */
+import { faker } from "@faker-js/faker";
+import { fetchRoundPredictions } from "../../app/.server/predictionService";
+
+jest.mock("../../app/.server/db", () => {
+  return {
+    sqlQuery: jest.fn(async () =>
+      new Array(9).fill(null).map(() => ({
+        predictedWinnerName: faker.company.name(),
+        predictedMargin: faker.number.float(),
+        predictedWinProbability: faker.number.float(),
+        isCorrect:
+          faker.helpers.maybe(faker.datatype.boolean, {
+            probability: faker.number.float(),
+          }) ?? null,
+      }))
+    ),
+  };
+});
+
+describe("fetchRoundPredictions", () => {
+  it("fetches prediction records from the DB", async () => {
+    const predictions = await fetchRoundPredictions();
+    expect(predictions.length).toEqual(9);
+  });
+
+  it("converts record keys to camelCase", async () => {
+    const predictions = await fetchRoundPredictions();
+    const predictionKeys = new Set(predictions.flatMap(Object.keys));
+    const expectedPredictionKeys = new Set([
+      "predictedWinnerName",
+      "predictedMargin",
+      "predictedWinProbability",
+      "isCorrect",
+    ]);
+    expect(predictionKeys).toEqual(expectedPredictionKeys);
+  });
+});

--- a/tests/.server/predictionService.test.ts
+++ b/tests/.server/predictionService.test.ts
@@ -2,39 +2,97 @@
  * @jest-environment node
  */
 import { faker } from "@faker-js/faker";
-import { fetchRoundPredictions } from "../../app/.server/predictionService";
+import {
+  Metrics,
+  MetricsRecord,
+  RoundPredictionRecord,
+  fetchRoundMetrics,
+  fetchRoundPredictions,
+} from "../../app/.server/predictionService";
+import * as db from "../../app/.server/db";
 
-jest.mock("../../app/.server/db", () => {
-  return {
-    sqlQuery: jest.fn(async () =>
-      new Array(9).fill(null).map(() => ({
-        predictedWinnerName: faker.company.name(),
-        predictedMargin: faker.number.float(),
-        predictedWinProbability: faker.number.float(),
-        isCorrect:
-          faker.helpers.maybe(faker.datatype.boolean, {
-            probability: faker.number.float(),
-          }) ?? null,
-      }))
-    ),
-  };
-});
+const mockSqlQuery = jest.spyOn(db, "sqlQuery");
 
 describe("fetchRoundPredictions", () => {
-  it("fetches prediction records from the DB", async () => {
-    const predictions = await fetchRoundPredictions();
-    expect(predictions.length).toEqual(9);
+  beforeAll(() => {
+    const fakePredictions = new Array(9).fill(null).map(() => ({
+      predicted_winner_name: faker.company.name(),
+      predicted_margin: faker.number.float(),
+      predicted_win_probability: faker.number.float(),
+      is_correct:
+        faker.helpers.maybe(faker.datatype.boolean, {
+          probability: faker.number.float(),
+        }) ?? null,
+    }));
+    const mockSqlQueryImplementation = (async () =>
+      fakePredictions) as typeof db.sqlQuery<RoundPredictionRecord[]>;
+    mockSqlQuery.mockImplementation(mockSqlQueryImplementation);
   });
 
-  it("converts record keys to camelCase", async () => {
+  it("fetches predictions from the DB", async () => {
     const predictions = await fetchRoundPredictions();
-    const predictionKeys = new Set(predictions.flatMap(Object.keys));
-    const expectedPredictionKeys = new Set([
-      "predictedWinnerName",
-      "predictedMargin",
-      "predictedWinProbability",
-      "isCorrect",
-    ]);
-    expect(predictionKeys).toEqual(expectedPredictionKeys);
+    expect(predictions).toHaveLength(9);
+    predictions.forEach((prediction) => {
+      expect(prediction).toMatchObject({
+        predictedWinnerName: expect.any(String),
+        predictedMargin: expect.any(Number),
+        predictedWinProbability: expect.any(Number),
+      });
+      expect([true, false, null]).toContain(prediction.isCorrect);
+    });
+  });
+});
+
+describe("fetchRoundMetrics", () => {
+  describe("when prediction are available", () => {
+    beforeAll(() => {
+      const fakeMetrics = [
+        {
+          total_tips: faker.number.int(),
+          accuracy: faker.number.float(),
+          mae: faker.number.float(),
+          bits: faker.number.float(),
+        },
+      ];
+      const mockSqlQueryImplementation = (async () =>
+        fakeMetrics) as typeof db.sqlQuery<MetricsRecord[]>;
+      mockSqlQuery.mockImplementation(mockSqlQueryImplementation);
+    });
+
+    it("returns a metrics object", async () => {
+      const metrics = await fetchRoundMetrics();
+      expect(metrics).toMatchObject<Metrics>({
+        totalTips: expect.any(Number),
+        accuracy: expect.any(Number),
+        mae: expect.any(Number),
+        bits: expect.any(Number),
+      });
+    });
+  });
+
+  describe("when no predictions are available", () => {
+    beforeAll(() => {
+      const fakeMetrics = [
+        {
+          total_tips: null,
+          accuracy: null,
+          mae: null,
+          bits: null,
+        },
+      ];
+      const mockSqlQueryImplementation = (async () =>
+        fakeMetrics) as typeof db.sqlQuery<MetricsRecord[]>;
+      mockSqlQuery.mockImplementation(mockSqlQueryImplementation);
+    });
+
+    it("returns a blank metrics object", async () => {
+      const metrics = await fetchRoundMetrics();
+      expect(metrics).toMatchObject<Metrics>({
+        totalTips: null,
+        accuracy: null,
+        mae: null,
+        bits: null,
+      });
+    });
   });
 });

--- a/tests/components/MetricsTable.test.tsx
+++ b/tests/components/MetricsTable.test.tsx
@@ -1,13 +1,19 @@
 import { faker } from "@faker-js/faker";
 import { render, screen } from "@testing-library/react";
+import round from "lodash/round";
 
-import MetricsTable from "../../app/components/MetricsTable";
+import MetricsTable, {
+  METRIC_LABEL_MAP,
+  Metrics,
+} from "../../app/components/MetricsTable";
 
 describe("MetricsTable", () => {
-  const metrics = new Array(4).fill(null).map((_, idx) => ({
-    name: `${faker.company.buzzNoun()}${idx}`,
-    value: faker.number.float().toString(),
-  }));
+  const metrics = {
+    totalTips: faker.number.float(),
+    accuracy: faker.number.float(),
+    mae: faker.number.float(),
+    bits: faker.number.float(),
+  };
   const season = faker.number.int();
 
   it("displays the table title", () => {
@@ -19,9 +25,9 @@ describe("MetricsTable", () => {
   it("displays metrics", () => {
     render(<MetricsTable metrics={metrics} season={season} />);
 
-    const { name, value } = faker.helpers.arrayElement(metrics);
-
-    screen.getByText(name);
-    screen.getByText(value);
+    Object.entries(metrics).forEach(([name, value]) => {
+      screen.getByText(METRIC_LABEL_MAP[name as keyof Metrics]);
+      screen.getByText(round(value, 2));
+    });
   });
 });

--- a/tests/components/MetricsTable.test.tsx
+++ b/tests/components/MetricsTable.test.tsx
@@ -4,8 +4,8 @@ import round from "lodash/round";
 
 import MetricsTable, {
   METRIC_LABEL_MAP,
-  Metrics,
 } from "../../app/components/MetricsTable";
+import { Metrics } from "../../app/.server/predictionService";
 
 describe("MetricsTable", () => {
   const metrics = {

--- a/tests/components/MetricsTable.test.tsx
+++ b/tests/components/MetricsTable.test.tsx
@@ -8,26 +8,45 @@ import MetricsTable, {
 import { Metrics } from "../../app/.server/predictionService";
 
 describe("MetricsTable", () => {
-  const metrics = {
-    totalTips: faker.number.float(),
-    accuracy: faker.number.float(),
-    mae: faker.number.float(),
-    bits: faker.number.float(),
-  };
   const season = faker.number.int();
 
-  it("displays the table title", () => {
-    render(<MetricsTable metrics={metrics} season={season} />);
+  describe("when all values are present", () => {
+    const metrics = {
+      totalTips: faker.number.float(),
+      accuracy: faker.number.float(),
+      mae: faker.number.float(),
+      bits: faker.number.float(),
+    };
 
-    screen.getByText(`Model performance for ${season}`);
+    it("displays the table title", () => {
+      render(<MetricsTable metrics={metrics} season={season} />);
+
+      screen.getByText(`Model performance for ${season}`);
+    });
+
+    it("displays metrics", () => {
+      render(<MetricsTable metrics={metrics} season={season} />);
+
+      Object.entries(metrics).forEach(([name, value]) => {
+        screen.getByText(METRIC_LABEL_MAP[name as keyof Metrics]);
+        screen.getByText(round(value, 2));
+      });
+    });
   });
 
-  it("displays metrics", () => {
-    render(<MetricsTable metrics={metrics} season={season} />);
+  describe("when some values are null", () => {
+    const metrics = {
+      totalTips: null,
+      accuracy: null,
+      mae: null,
+      bits: null,
+    };
 
-    Object.entries(metrics).forEach(([name, value]) => {
-      screen.getByText(METRIC_LABEL_MAP[name as keyof Metrics]);
-      screen.getByText(round(value, 2));
+    it("displays NA for missing values", () => {
+      render(<MetricsTable metrics={metrics} season={season} />);
+
+      const naElements = screen.getAllByText("NA");
+      expect(naElements).toHaveLength(4);
     });
   });
 });

--- a/tests/components/PredictionsTable.test.tsx
+++ b/tests/components/PredictionsTable.test.tsx
@@ -9,46 +9,77 @@ import PredictionsTable, {
 describe("PredictionsTable", () => {
   const currentRound = faker.number.int();
   const currentSeason = faker.number.int();
-  const predictions = new Array(9).fill(null).map(() => ({
-    predictedWinnerName: faker.company.name(),
-    predictedMargin: faker.number.float(),
-    predictedWinProbability: faker.number.float(),
-    isCorrect:
-      faker.helpers.maybe(faker.datatype.boolean, { probability: 0.67 }) ??
-      null,
-  }));
 
-  it("displays the table title", () => {
-    render(
-      <PredictionsTable
-        currentRound={currentRound}
-        currentSeason={currentSeason}
-        predictions={predictions}
-      />
-    );
+  describe("when all values are present", () => {
+    const predictions = new Array(9).fill(null).map(() => ({
+      predictedWinnerName: faker.company.name(),
+      predictedMargin: faker.number.float(),
+      predictedWinProbability: faker.number.float(),
+      isCorrect:
+        faker.helpers.maybe(faker.datatype.boolean, { probability: 0.67 }) ??
+        null,
+    }));
 
-    screen.getByText(`Predictions for round ${currentRound}, ${currentSeason}`);
+    it("displays the table title", () => {
+      render(
+        <PredictionsTable
+          currentRound={currentRound}
+          currentSeason={currentSeason}
+          predictions={predictions}
+        />
+      );
+
+      screen.getByText(
+        `Predictions for round ${currentRound}, ${currentSeason}`
+      );
+    });
+
+    it("displays predictions", () => {
+      render(
+        <PredictionsTable
+          currentRound={currentRound}
+          currentSeason={currentSeason}
+          predictions={predictions}
+        />
+      );
+
+      const {
+        predictedWinnerName,
+        predictedMargin,
+        predictedWinProbability,
+        isCorrect,
+      } = faker.helpers.arrayElement(predictions);
+
+      screen.getByText(predictedWinnerName);
+      screen.getByText(String(round(predictedMargin, 2)));
+      screen.getByText(String(round(predictedWinProbability, 2)));
+      screen.getAllByText(displayCorrectness(isCorrect));
+    });
   });
 
-  it("displays predictions", () => {
-    render(
-      <PredictionsTable
-        currentRound={currentRound}
-        currentSeason={currentSeason}
-        predictions={predictions}
-      />
-    );
+  describe("when some values are null", () => {
+    const predictions = [
+      {
+        predictedWinnerName: faker.company.name(),
+        predictedMargin: null,
+        predictedWinProbability: null,
+        isCorrect:
+          faker.helpers.maybe(faker.datatype.boolean, { probability: 0.67 }) ??
+          null,
+      },
+    ];
 
-    const {
-      predictedWinnerName,
-      predictedMargin,
-      predictedWinProbability,
-      isCorrect,
-    } = faker.helpers.arrayElement(predictions);
+    it("displays NA for missing values", () => {
+      render(
+        <PredictionsTable
+          currentRound={currentRound}
+          currentSeason={currentSeason}
+          predictions={predictions}
+        />
+      );
 
-    screen.getByText(predictedWinnerName);
-    screen.getByText(String(round(predictedMargin, 2)));
-    screen.getByText(String(round(predictedWinProbability, 2)));
-    screen.getAllByText(displayCorrectness(isCorrect));
+      const naElements = screen.getAllByText("NA");
+      expect(naElements).toHaveLength(2);
+    });
   });
 });

--- a/tests/components/PredictionsTable.test.tsx
+++ b/tests/components/PredictionsTable.test.tsx
@@ -1,5 +1,6 @@
 import { faker } from "@faker-js/faker";
 import { render, screen } from "@testing-library/react";
+import round from "lodash/round";
 
 import PredictionsTable, {
   displayCorrectness,
@@ -8,10 +9,10 @@ import PredictionsTable, {
 describe("PredictionsTable", () => {
   const currentRound = faker.number.int();
   const predictions = new Array(9).fill(null).map(() => ({
-    winner: faker.company.name(),
-    loser: faker.company.name(),
-    margin: faker.number.float(),
-    wasCorrect:
+    predictedWinnerName: faker.company.name(),
+    predictedMargin: faker.number.float(),
+    predictedWinProbability: faker.number.float(),
+    isCorrect:
       faker.helpers.maybe(faker.datatype.boolean, { probability: 0.67 }) ??
       null,
   }));
@@ -29,12 +30,16 @@ describe("PredictionsTable", () => {
       <PredictionsTable currentRound={currentRound} predictions={predictions} />
     );
 
-    const { winner, loser, margin, wasCorrect } =
-      faker.helpers.arrayElement(predictions);
+    const {
+      predictedWinnerName,
+      predictedMargin,
+      predictedWinProbability,
+      isCorrect,
+    } = faker.helpers.arrayElement(predictions);
 
-    screen.getByText(winner);
-    screen.getByText(loser);
-    screen.getByText(String(margin));
-    screen.getAllByText(displayCorrectness(wasCorrect));
+    screen.getByText(predictedWinnerName);
+    screen.getByText(String(round(predictedMargin, 2)));
+    screen.getByText(String(round(predictedWinProbability, 2)));
+    screen.getAllByText(displayCorrectness(isCorrect));
   });
 });

--- a/tests/components/PredictionsTable.test.tsx
+++ b/tests/components/PredictionsTable.test.tsx
@@ -8,6 +8,7 @@ import PredictionsTable, {
 
 describe("PredictionsTable", () => {
   const currentRound = faker.number.int();
+  const currentSeason = faker.number.int();
   const predictions = new Array(9).fill(null).map(() => ({
     predictedWinnerName: faker.company.name(),
     predictedMargin: faker.number.float(),
@@ -19,15 +20,23 @@ describe("PredictionsTable", () => {
 
   it("displays the table title", () => {
     render(
-      <PredictionsTable currentRound={currentRound} predictions={predictions} />
+      <PredictionsTable
+        currentRound={currentRound}
+        currentSeason={currentSeason}
+        predictions={predictions}
+      />
     );
 
-    screen.getByText(`Predictions for round ${currentRound}`);
+    screen.getByText(`Predictions for round ${currentRound}, ${currentSeason}`);
   });
 
   it("displays predictions", () => {
     render(
-      <PredictionsTable currentRound={currentRound} predictions={predictions} />
+      <PredictionsTable
+        currentRound={currentRound}
+        currentSeason={currentSeason}
+        predictions={predictions}
+      />
     );
 
     const {


### PR DESCRIPTION
Added DB queries to fetch the required data to populate the tables in the UI. I used raw SQL instead of Prisma's query interface, because the former allowed me to do all the calculations and data processing in the database instead of the application code, which is a bit cleaner, and probably faster.