### PR TITLE
Fix definition of query result attributes

### DIFF
--- a/app/.server/predictionService.ts
+++ b/app/.server/predictionService.ts
@@ -2,25 +2,11 @@ import * as R from "ramda";
 
 import { sqlQuery } from "./db";
 
-export interface RoundPredictionRecord {
-  predicted_winner_name: string;
-  predicted_margin: number | null;
-  predicted_win_probability: number | null;
-  is_correct: boolean | null;
-}
-
-export interface Prediction {
+export interface RoundPrediction {
   predictedWinnerName: string;
   predictedMargin: number | null;
   predictedWinProbability: number | null;
   isCorrect: boolean | null;
-}
-
-export interface MetricsRecord {
-  total_tips: number | null;
-  accuracy: number | null;
-  mae: number | null;
-  bits: number | null;
 }
 
 export interface Metrics {
@@ -59,23 +45,9 @@ const ROUND_PREDICTIONS_SQL = `
   GROUP BY "principalPrediction"."predictedWinnerName", "principalPrediction"."isCorrect", "Match"."startDateTime"
   ORDER BY "Match"."startDateTime" DESC
 `;
-const convertPredictionKeysToCamelCase = ({
-  predicted_winner_name,
-  predicted_margin,
-  predicted_win_probability,
-  is_correct,
-}: RoundPredictionRecord): Prediction => ({
-  predictedWinnerName: predicted_winner_name,
-  predictedMargin: predicted_margin,
-  predictedWinProbability: predicted_win_probability,
-  isCorrect: is_correct,
-});
 
 export const fetchRoundPredictions = () =>
-  R.pipe(
-    sqlQuery<RoundPredictionRecord[]>,
-    R.andThen(R.map(convertPredictionKeysToCamelCase))
-  )(ROUND_PREDICTIONS_SQL);
+  sqlQuery<RoundPrediction[]>(ROUND_PREDICTIONS_SQL);
 
 const SEASON_METRICS_SQL = `
   WITH "latestPredictedMatch" AS (
@@ -114,21 +86,9 @@ const BLANK_METRICS: Metrics = {
   mae: null,
   bits: null,
 };
-const convertMetricKeysToCamelCase = ({
-  total_tips,
-  accuracy,
-  mae,
-  bits,
-}: MetricsRecord) => ({
-  totalTips: total_tips,
-  accuracy,
-  mae,
-  bits,
-});
 export const fetchRoundMetrics = () =>
   R.pipe(
-    sqlQuery<MetricsRecord[]>,
-    R.andThen(R.map<MetricsRecord, Metrics>(convertMetricKeysToCamelCase)),
+    sqlQuery<Metrics[]>,
     R.andThen(R.head<Metrics>),
     R.andThen(R.defaultTo(BLANK_METRICS))
   )(SEASON_METRICS_SQL);

--- a/app/components/PredictionsTable.tsx
+++ b/app/components/PredictionsTable.tsx
@@ -10,12 +10,12 @@ import {
 } from "@chakra-ui/react";
 import round from "lodash/round";
 
-import { Prediction } from "~/.server/predictionService";
+import { RoundPrediction } from "~/.server/predictionService";
 
 interface PredictionsTableProps {
   currentRound: number;
   currentSeason: number;
-  predictions: Prediction[];
+  predictions: RoundPrediction[];
 }
 
 export const displayCorrectness = (wasCorrect: boolean | null) => {
@@ -34,7 +34,7 @@ const PredictionRow = ({
   predictedMargin,
   predictedWinProbability,
   isCorrect,
-}: Prediction) => (
+}: RoundPrediction) => (
   <Tr key={predictedWinnerName}>
     <Td>{predictedWinnerName}</Td>
     <Td isNumeric>

--- a/app/routes/_index.tsx
+++ b/app/routes/_index.tsx
@@ -13,7 +13,7 @@ import { useLoaderData } from "@remix-run/react";
 import MetricsTable from "../components/MetricsTable";
 import PredictionsTable from "../components/PredictionsTable";
 import {
-  Prediction,
+  RoundPrediction,
   fetchRoundPredictions,
   Metrics,
   fetchRoundMetrics,
@@ -21,7 +21,7 @@ import {
 import { sqlQuery } from "../.server/db";
 
 interface Round {
-  round_number: number;
+  roundNumber: number;
   season: number;
 }
 
@@ -44,11 +44,11 @@ export const loader = async () => {
     LIMIT 1
   `;
   const predictedRound = (await sqlQuery<Round[]>(PREDICTED_ROUND_SQL))[0];
-  const predictions: Prediction[] = await fetchRoundPredictions();
+  const predictions: RoundPrediction[] = await fetchRoundPredictions();
   const metrics: Metrics = await fetchRoundMetrics();
 
   return json({
-    currentRound: predictedRound.round_number,
+    currentRound: predictedRound.roundNumber,
     predictions,
     metrics,
     currentSeason: predictedRound.season,

--- a/tests/.server/predictionService.test.ts
+++ b/tests/.server/predictionService.test.ts
@@ -4,8 +4,7 @@
 import { faker } from "@faker-js/faker";
 import {
   Metrics,
-  MetricsRecord,
-  RoundPredictionRecord,
+  RoundPrediction,
   fetchRoundMetrics,
   fetchRoundPredictions,
 } from "../../app/.server/predictionService";
@@ -16,16 +15,16 @@ const mockSqlQuery = jest.spyOn(db, "sqlQuery");
 describe("fetchRoundPredictions", () => {
   beforeAll(() => {
     const fakePredictions = new Array(9).fill(null).map(() => ({
-      predicted_winner_name: faker.company.name(),
-      predicted_margin: faker.number.float(),
-      predicted_win_probability: faker.number.float(),
-      is_correct:
+      predictedWinnerName: faker.company.name(),
+      predictedMargin: faker.number.float(),
+      predictedWinProbability: faker.number.float(),
+      isCorrect:
         faker.helpers.maybe(faker.datatype.boolean, {
           probability: faker.number.float(),
         }) ?? null,
     }));
     const mockSqlQueryImplementation = (async () =>
-      fakePredictions) as typeof db.sqlQuery<RoundPredictionRecord[]>;
+      fakePredictions) as typeof db.sqlQuery<RoundPrediction[]>;
     mockSqlQuery.mockImplementation(mockSqlQueryImplementation);
   });
 
@@ -48,14 +47,14 @@ describe("fetchRoundMetrics", () => {
     beforeAll(() => {
       const fakeMetrics = [
         {
-          total_tips: faker.number.int(),
+          totalTips: faker.number.int(),
           accuracy: faker.number.float(),
           mae: faker.number.float(),
           bits: faker.number.float(),
         },
       ];
       const mockSqlQueryImplementation = (async () =>
-        fakeMetrics) as typeof db.sqlQuery<MetricsRecord[]>;
+        fakeMetrics) as typeof db.sqlQuery<Metrics[]>;
       mockSqlQuery.mockImplementation(mockSqlQueryImplementation);
     });
 
@@ -74,14 +73,14 @@ describe("fetchRoundMetrics", () => {
     beforeAll(() => {
       const fakeMetrics = [
         {
-          total_tips: null,
+          totalTips: null,
           accuracy: null,
           mae: null,
           bits: null,
         },
       ];
       const mockSqlQueryImplementation = (async () =>
-        fakeMetrics) as typeof db.sqlQuery<MetricsRecord[]>;
+        fakeMetrics) as typeof db.sqlQuery<Metrics[]>;
       mockSqlQuery.mockImplementation(mockSqlQueryImplementation);
     });
 


### PR DESCRIPTION
With the latest migration, the SQL queries are now returning column names in camelCase, so the type definitions and key transformation functions were all wrong.