### PR TITLE
Fetch season data & allow selecting of current season

### DIFF
--- a/app/.server/db.ts
+++ b/app/.server/db.ts
@@ -3,3 +3,4 @@ import { Prisma, PrismaClient } from "@prisma/client";
 const db = new PrismaClient();
 
 export const sqlQuery = <T>(sql: string) => db.$queryRaw<T>(Prisma.sql([sql]));
+export const season = db.season;

--- a/app/.server/seasonService.ts
+++ b/app/.server/seasonService.ts
@@ -1,13 +1,35 @@
 import * as R from "ramda";
 
-import { season } from "./db";
+import { season, sqlQuery } from "./db";
 
 export interface Season {
   id: number;
   year: number;
 }
 
-export const fetchSeasons = R.pipe(
-  season.findMany,
-  R.andThen(R.map(R.prop("year")))
-);
+export interface Round {
+  number: number | null;
+}
+
+const BLANK_ROUND: Round = {
+  number: null,
+};
+
+export const fetchSeasons = () =>
+  R.pipe(season.findMany, R.andThen(R.map(R.prop("year"))))();
+
+const buildLatestPredictedRoundQuery = (season: number) => `
+  SELECT MAX("Match"."roundNumber") AS number FROM "Match"
+  INNER JOIN "Season" ON "Season".id = "Match"."seasonId"
+  INNER JOIN "Prediction" ON "Prediction"."matchId" = "Match".id
+  WHERE "Season".year = ${season}
+`;
+
+export const fetchLatestPredictedRound = (seasonYear: number) =>
+  R.pipe(
+    buildLatestPredictedRoundQuery,
+    sqlQuery<Round[]>,
+    R.andThen(R.head<Round>),
+    R.andThen(R.defaultTo(BLANK_ROUND)),
+    R.andThen(R.prop("number"))
+  )(seasonYear);

--- a/app/.server/seasonService.ts
+++ b/app/.server/seasonService.ts
@@ -1,0 +1,13 @@
+import * as R from "ramda";
+
+import { season } from "./db";
+
+export interface Season {
+  id: number;
+  year: number;
+}
+
+export const fetchSeasons = R.pipe(
+  season.findMany,
+  R.andThen(R.map(R.prop("year")))
+);

--- a/app/components/SeasonSelect.tsx
+++ b/app/components/SeasonSelect.tsx
@@ -1,0 +1,42 @@
+import { Flex, FormControl, FormLabel, Select } from "@chakra-ui/react";
+
+interface SeasonSelectProps {
+  submit: (form: HTMLFormElement | null) => void;
+  seasonYears: number[];
+  currentSeasonYear: number;
+}
+
+interface SeasonOptionProps {
+  seasonYear: number;
+}
+
+export const CURRENT_SEASON_PARAM = "current-season";
+
+const SeasonOption = ({ seasonYear }: SeasonOptionProps) => (
+  <option value={seasonYear}>{seasonYear}</option>
+);
+
+const SeasonSelect = ({
+  submit,
+  seasonYears,
+  currentSeasonYear,
+}: SeasonSelectProps) => (
+  <FormControl>
+    <Flex alignItems="center">
+      <FormLabel margin="0.5rem" size="xl">
+        Season
+      </FormLabel>
+      <Select
+        name={CURRENT_SEASON_PARAM}
+        defaultValue={currentSeasonYear}
+        onChange={(event) => submit(event.currentTarget.form)}
+      >
+        {seasonYears.map((seasonYear) => (
+          <SeasonOption seasonYear={seasonYear} key={seasonYear} />
+        ))}
+      </Select>
+    </Flex>
+  </FormControl>
+);
+
+export default SeasonSelect;

--- a/app/routes/_index.tsx
+++ b/app/routes/_index.tsx
@@ -47,7 +47,9 @@ export const loader = async ({ request }: LoaderFunctionArgs) => {
   if (!currentSeason) throw Error("No season data found");
 
   const currentRound = await fetchLatestPredictedRound(currentSeason);
-  const predictions: RoundPrediction[] = await fetchRoundPredictions();
+  const predictions: RoundPrediction[] = await fetchRoundPredictions(
+    currentSeason
+  );
   const metrics: Metrics = await fetchRoundMetrics();
 
   return json({

--- a/app/routes/_index.tsx
+++ b/app/routes/_index.tsx
@@ -4,11 +4,15 @@ import {
   CardBody,
   Container,
   Flex,
+  FormControl,
+  FormLabel,
   Heading,
   Text,
+  Select,
 } from "@chakra-ui/react";
-import { json, MetaFunction } from "@remix-run/node";
-import { useLoaderData } from "@remix-run/react";
+import { json, LoaderFunctionArgs, MetaFunction } from "@remix-run/node";
+import { useLoaderData, Form, useSubmit } from "@remix-run/react";
+import max from "lodash/max";
 
 import MetricsTable from "../components/MetricsTable";
 import PredictionsTable from "../components/PredictionsTable";
@@ -19,11 +23,14 @@ import {
   fetchRoundMetrics,
 } from "../.server/predictionService";
 import { sqlQuery } from "../.server/db";
+import { fetchSeasons } from "~/.server/seasonService";
 
 interface Round {
   roundNumber: number;
   season: number;
 }
+
+const CURRENT_SEASON_PARAM = "current-season";
 
 export const meta: MetaFunction = () => {
   return [
@@ -35,7 +42,7 @@ export const meta: MetaFunction = () => {
   ];
 };
 
-export const loader = async () => {
+export const loader = async ({ request }: LoaderFunctionArgs) => {
   const PREDICTED_ROUND_SQL = `
     SELECT "Match"."roundNumber", EXTRACT(YEAR FROM "Match"."startDateTime") AS season
     FROM "Match"
@@ -43,6 +50,10 @@ export const loader = async () => {
     ORDER BY "Match"."startDateTime" DESC
     LIMIT 1
   `;
+  const seasons = await fetchSeasons();
+  const url = new URL(request.url);
+  const currentSeason =
+    parseInt(url.searchParams.get(CURRENT_SEASON_PARAM) || "") || max(seasons);
   const predictedRound = (await sqlQuery<Round[]>(PREDICTED_ROUND_SQL))[0];
   const predictions: RoundPrediction[] = await fetchRoundPredictions();
   const metrics: Metrics = await fetchRoundMetrics();
@@ -51,13 +62,15 @@ export const loader = async () => {
     currentRound: predictedRound.roundNumber,
     predictions,
     metrics,
-    currentSeason: predictedRound.season,
+    currentSeason,
+    seasons,
   });
 };
 
 export default function Index() {
-  const { currentRound, predictions, metrics, currentSeason } =
+  const { currentRound, predictions, metrics, seasons, currentSeason } =
     useLoaderData<typeof loader>();
+  const submit = useSubmit();
 
   return (
     <div
@@ -73,7 +86,24 @@ export default function Index() {
       </Container>
       <Box margin="auto" width="fit-content">
         <Flex alignItems="center" flexWrap="wrap" direction="column">
-          {predictions?.length && (
+          <Form>
+            <FormControl>
+              <FormLabel>Season</FormLabel>
+              <Select name={CURRENT_SEASON_PARAM}>
+                {seasons.map((season) => (
+                  <option
+                    key={season}
+                    value={season}
+                    selected={season === currentSeason}
+                    onClick={(event) => submit(event.currentTarget.form)}
+                  >
+                    {season}
+                  </option>
+                ))}
+              </Select>
+            </FormControl>
+          </Form>
+          {predictions?.length && currentSeason && (
             <Card marginTop="1rem" marginBottom="1rem">
               <CardBody>
                 <PredictionsTable
@@ -86,7 +116,7 @@ export default function Index() {
           )}
           <Card marginTop="1rem" marginBottom="1rem" width="100%">
             <CardBody>
-              {metrics && (
+              {metrics && currentSeason && (
                 <MetricsTable metrics={metrics} season={currentSeason} />
               )}
             </CardBody>

--- a/app/routes/_index.tsx
+++ b/app/routes/_index.tsx
@@ -50,7 +50,7 @@ export const loader = async ({ request }: LoaderFunctionArgs) => {
   const predictions: RoundPrediction[] = await fetchRoundPredictions(
     currentSeason
   );
-  const metrics: Metrics = await fetchRoundMetrics();
+  const metrics: Metrics = await fetchRoundMetrics(currentSeason);
 
   return json({
     currentRound,

--- a/package-lock.json
+++ b/package-lock.json
@@ -27,6 +27,7 @@
         "@faker-js/faker": "^8.0.2",
         "@remix-run/dev": "^2.9.2",
         "@testing-library/react": "^14.0.0",
+        "@testing-library/user-event": "^14.5.2",
         "@types/jest": "^29.5.2",
         "@types/ramda": "^0.29.11",
         "@types/react": "^18.2.20",
@@ -4016,6 +4017,19 @@
       "peerDependencies": {
         "react": "^18.0.0",
         "react-dom": "^18.0.0"
+      }
+    },
+    "node_modules/@testing-library/user-event": {
+      "version": "14.5.2",
+      "resolved": "https://registry.npmjs.org/@testing-library/user-event/-/user-event-14.5.2.tgz",
+      "integrity": "sha512-YAh82Wh4TIrxYLmfGcixwD18oIjyC1pFQC2Y01F2lzV2HTMiYrI0nze0FD0ocB//CKS/7jIUgae+adPqxK5yCQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=12",
+        "npm": ">=6"
+      },
+      "peerDependencies": {
+        "@testing-library/dom": ">=7.21.4"
       }
     },
     "node_modules/@tootallnate/once": {

--- a/package.json
+++ b/package.json
@@ -36,6 +36,7 @@
     "@faker-js/faker": "^8.0.2",
     "@remix-run/dev": "^2.9.2",
     "@testing-library/react": "^14.0.0",
+    "@testing-library/user-event": "^14.5.2",
     "@types/jest": "^29.5.2",
     "@types/ramda": "^0.29.11",
     "@types/react": "^18.2.20",

--- a/tests/.server/predictionService.test.ts
+++ b/tests/.server/predictionService.test.ts
@@ -13,6 +13,8 @@ import * as db from "../../app/.server/db";
 const mockSqlQuery = jest.spyOn(db, "sqlQuery");
 
 describe("fetchRoundPredictions", () => {
+  const seasonYear = 2020;
+
   beforeAll(() => {
     const fakePredictions = new Array(9).fill(null).map(() => ({
       predictedWinnerName: faker.company.name(),
@@ -29,7 +31,7 @@ describe("fetchRoundPredictions", () => {
   });
 
   it("fetches predictions from the DB", async () => {
-    const predictions = await fetchRoundPredictions();
+    const predictions = await fetchRoundPredictions(seasonYear);
     expect(predictions).toHaveLength(9);
     predictions.forEach((prediction) => {
       expect(prediction).toMatchObject({

--- a/tests/.server/predictionService.test.ts
+++ b/tests/.server/predictionService.test.ts
@@ -45,6 +45,8 @@ describe("fetchRoundPredictions", () => {
 });
 
 describe("fetchRoundMetrics", () => {
+  const seasonYear = 2020;
+
   describe("when prediction are available", () => {
     beforeAll(() => {
       const fakeMetrics = [
@@ -61,7 +63,7 @@ describe("fetchRoundMetrics", () => {
     });
 
     it("returns a metrics object", async () => {
-      const metrics = await fetchRoundMetrics();
+      const metrics = await fetchRoundMetrics(2020);
       expect(metrics).toMatchObject<Metrics>({
         totalTips: expect.any(Number),
         accuracy: expect.any(Number),
@@ -87,7 +89,7 @@ describe("fetchRoundMetrics", () => {
     });
 
     it("returns a blank metrics object", async () => {
-      const metrics = await fetchRoundMetrics();
+      const metrics = await fetchRoundMetrics(seasonYear);
       expect(metrics).toMatchObject<Metrics>({
         totalTips: null,
         accuracy: null,

--- a/tests/.server/seasonService.test.ts
+++ b/tests/.server/seasonService.test.ts
@@ -1,0 +1,38 @@
+/**
+ * @jest-environment node
+ */
+
+import { fetchSeasons } from "../../app/.server/seasonService";
+
+const fakeSeasons = Array(5)
+  .fill(null)
+  .map((_, idx) => ({ id: idx, year: 2000 + idx }));
+
+jest.mock<typeof import("../../app/.server/db")>("../../app/.server/db", () => {
+  const originalDb = jest.requireActual<typeof import("../../app/.server/db")>(
+    "../../app/.server/db"
+  );
+
+  return {
+    ...originalDb,
+    season: {
+      ...originalDb.season,
+      findMany: (async () => {
+        return fakeSeasons;
+      }) as typeof originalDb.season.findMany,
+    },
+  };
+});
+
+afterAll(() => {
+  jest.restoreAllMocks();
+});
+
+describe("fetchSeasons", () => {
+  const expectedYears = fakeSeasons.map(({ year }) => year);
+
+  it("fetches seasons from the DB", async () => {
+    const seasons = await fetchSeasons();
+    expect(seasons).toEqual(expectedYears);
+  });
+});

--- a/tests/.server/seasonService.test.ts
+++ b/tests/.server/seasonService.test.ts
@@ -2,37 +2,65 @@
  * @jest-environment node
  */
 
-import { fetchSeasons } from "../../app/.server/seasonService";
+import {
+  Round,
+  fetchLatestPredictedRound,
+  fetchSeasons,
+} from "../../app/.server/seasonService";
+import * as db from "../../app/.server/db";
 
 const fakeSeasons = Array(5)
   .fill(null)
   .map((_, idx) => ({ id: idx, year: 2000 + idx }));
 
-jest.mock<typeof import("../../app/.server/db")>("../../app/.server/db", () => {
-  const originalDb = jest.requireActual<typeof import("../../app/.server/db")>(
-    "../../app/.server/db"
-  );
-
-  return {
-    ...originalDb,
-    season: {
-      ...originalDb.season,
-      findMany: (async () => {
-        return fakeSeasons;
-      }) as typeof originalDb.season.findMany,
-    },
-  };
-});
-
-afterAll(() => {
-  jest.restoreAllMocks();
-});
+const mockSqlQuery = jest.spyOn(db, "sqlQuery");
+const mockFindMany = jest.spyOn(db.season, "findMany");
 
 describe("fetchSeasons", () => {
   const expectedYears = fakeSeasons.map(({ year }) => year);
 
+  beforeAll(() => {
+    const mockFindManyImplementation = (async () =>
+      fakeSeasons) as typeof db.season.findMany;
+    mockFindMany.mockImplementation(mockFindManyImplementation);
+  });
+
   it("fetches seasons from the DB", async () => {
     const seasons = await fetchSeasons();
     expect(seasons).toEqual(expectedYears);
+  });
+});
+
+describe("fetchLatestPredictedRound", () => {
+  const season = 2020;
+
+  describe("when a round number is available", () => {
+    const roundNumber = 5;
+
+    beforeAll(() => {
+      const mockSqlQueryImplementation = (async () => [
+        { number: roundNumber },
+      ]) as typeof db.sqlQuery<Round[]>;
+      mockSqlQuery.mockImplementation(mockSqlQueryImplementation);
+    });
+
+    it("fetches a round number", async () => {
+      const latestPredictedRound = await fetchLatestPredictedRound(season);
+      expect(latestPredictedRound).toEqual(roundNumber);
+    });
+  });
+
+  describe("when a round number is not available", () => {
+    beforeAll(() => {
+      const mockSqlQueryImplementation = (async () => []) as typeof db.sqlQuery<
+        number[]
+      >;
+      mockSqlQuery.mockImplementation(mockSqlQueryImplementation);
+    });
+
+    it("fetches a round number", async () => {
+      const latestPredictedRound = await fetchLatestPredictedRound(season);
+      expect(latestPredictedRound).toBeNull();
+    });
   });
 });

--- a/tests/components/SeasonSelect.test.tsx
+++ b/tests/components/SeasonSelect.test.tsx
@@ -1,0 +1,26 @@
+import { render, screen } from "@testing-library/react";
+import { userEvent } from "@testing-library/user-event";
+
+import SeasonSelect from "../../app/components/SeasonSelect";
+
+const mockSubmit = jest.fn();
+const seasonYears = [2020, 2021, 2022, 2023, 2024];
+const currentSeasonYear = 2024;
+
+describe("SeasonSelect", () => {
+  it("submits the form on option select", async () => {
+    const user = userEvent.setup();
+
+    render(
+      <SeasonSelect
+        submit={mockSubmit}
+        seasonYears={seasonYears}
+        currentSeasonYear={currentSeasonYear}
+      />
+    );
+
+    const select = screen.getByLabelText<HTMLSelectElement>("Season");
+    await user.selectOptions(select, "2020");
+    expect(mockSubmit).toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
Since I'm not running the model anymore, the prediction data isn't getting updated, so it doesn't make much sense to only show the latest predicted season/round. So, I'm adding the ability to select past seasons to see historical data. A round select will be added in a follow-up PR.