### PR TITLE
Add round selector to be able to show different round predictions

### DIFF
--- a/app/components/PredictionsTable.tsx
+++ b/app/components/PredictionsTable.tsx
@@ -66,7 +66,7 @@ const PredictionsTable = ({
 }: PredictionsTableProps) => (
   <TableContainer textAlign="center">
     <Heading as="h2" size="l" margin="0.5rem" whiteSpace="nowrap">
-      Predictions for round {currentRound}, {currentSeason}{" "}
+      Predictions for Round {currentRound}, {currentSeason}{" "}
       <PredictionInfoTooltip />
     </Heading>
     <Table variant="striped" maxWidth="fit-content">

--- a/app/components/PredictionsTable.tsx
+++ b/app/components/PredictionsTable.tsx
@@ -6,11 +6,13 @@ import {
   Td,
   Th,
   Thead,
+  Tooltip,
   Tr,
 } from "@chakra-ui/react";
 
 import { RoundPrediction } from "../.server/predictionService";
 import { presentNumber, presentPercentage } from "../helpers/number";
+import { InfoOutlineIcon } from "@chakra-ui/icons";
 
 interface PredictionsTableProps {
   currentRound: number;
@@ -28,6 +30,20 @@ export const displayCorrectness = (wasCorrect: boolean | null) => {
       return "dunno";
   }
 };
+
+const PREDICTION_INFO = `Margin and win probability are generated
+  by different models that sometimes disagree. In those cases,
+  the secondary prediction will be for a loss for the given team,
+  resulting in negative margins or win probabilities of less than 0.5.`;
+const PredictionInfoTooltip = () => (
+  <Tooltip
+    label={PREDICTION_INFO}
+    aria-label="Prediction info tooltip"
+    placement="top-start"
+  >
+    <InfoOutlineIcon />
+  </Tooltip>
+);
 
 const PredictionRow = ({
   predictedWinnerName,
@@ -50,7 +66,8 @@ const PredictionsTable = ({
 }: PredictionsTableProps) => (
   <TableContainer textAlign="center">
     <Heading as="h2" size="l" margin="0.5rem" whiteSpace="nowrap">
-      Predictions for round {currentRound}, {currentSeason}
+      Predictions for round {currentRound}, {currentSeason}{" "}
+      <PredictionInfoTooltip />
     </Heading>
     <Table variant="striped" maxWidth="fit-content">
       <Thead>

--- a/app/components/RoundSelect.tsx
+++ b/app/components/RoundSelect.tsx
@@ -1,0 +1,43 @@
+import { Flex, FormControl, FormLabel, Select } from "@chakra-ui/react";
+
+interface RoundSelectProps {
+  submit: (form: HTMLFormElement | null) => void;
+  roundNumbers: number[];
+  currentRoundNumber: number;
+}
+
+interface RoundOptionProps {
+  roundNumber: number;
+}
+
+export const CURRENT_ROUND_PARAM = "current-round";
+
+const RoundOption = ({ roundNumber }: RoundOptionProps) => (
+  <option value={roundNumber}>{roundNumber}</option>
+);
+
+const RoundSelect = ({
+  submit,
+  roundNumbers,
+  currentRoundNumber,
+}: RoundSelectProps) => (
+  <FormControl margin="0.5rem">
+    <Flex alignItems="center" justifyContent="space-between">
+      <FormLabel margin="0.5rem" size="xl">
+        Round
+      </FormLabel>
+      <Select
+        name={CURRENT_ROUND_PARAM}
+        defaultValue={currentRoundNumber}
+        onChange={(event) => submit(event.currentTarget.form)}
+        maxWidth="60%"
+      >
+        {roundNumbers.map((roundNumber) => (
+          <RoundOption roundNumber={roundNumber} key={roundNumber} />
+        ))}
+      </Select>
+    </Flex>
+  </FormControl>
+);
+
+export default RoundSelect;

--- a/app/components/RoundSelect.tsx
+++ b/app/components/RoundSelect.tsx
@@ -10,7 +10,7 @@ interface RoundOptionProps {
   roundNumber: number;
 }
 
-export const CURRENT_ROUND_PARAM = "current-round";
+export const CURRENT_ROUND_PARAM = "round";
 
 const RoundOption = ({ roundNumber }: RoundOptionProps) => (
   <option value={roundNumber}>{roundNumber}</option>
@@ -28,7 +28,7 @@ const RoundSelect = ({
       </FormLabel>
       <Select
         name={CURRENT_ROUND_PARAM}
-        defaultValue={currentRoundNumber}
+        value={currentRoundNumber}
         onChange={(event) => submit(event.currentTarget.form)}
         maxWidth="60%"
       >

--- a/app/components/SeasonSelect.tsx
+++ b/app/components/SeasonSelect.tsx
@@ -21,8 +21,8 @@ const SeasonSelect = ({
   seasonYears,
   currentSeasonYear,
 }: SeasonSelectProps) => (
-  <FormControl>
-    <Flex alignItems="center">
+  <FormControl margin="0.5rem">
+    <Flex alignItems="center" justifyContent="space-between">
       <FormLabel margin="0.5rem" size="xl">
         Season
       </FormLabel>
@@ -30,6 +30,7 @@ const SeasonSelect = ({
         name={CURRENT_SEASON_PARAM}
         defaultValue={currentSeasonYear}
         onChange={(event) => submit(event.currentTarget.form)}
+        maxWidth="60%"
       >
         {seasonYears.map((seasonYear) => (
           <SeasonOption seasonYear={seasonYear} key={seasonYear} />

--- a/app/components/SeasonSelect.tsx
+++ b/app/components/SeasonSelect.tsx
@@ -10,7 +10,7 @@ interface SeasonOptionProps {
   seasonYear: number;
 }
 
-export const CURRENT_SEASON_PARAM = "current-season";
+export const CURRENT_SEASON_PARAM = "season";
 
 const SeasonOption = ({ seasonYear }: SeasonOptionProps) => (
   <option value={seasonYear}>{seasonYear}</option>

--- a/app/routes/_index.tsx
+++ b/app/routes/_index.tsx
@@ -15,9 +15,7 @@ import * as R from "ramda";
 import MetricsTable from "../components/MetricsTable";
 import PredictionsTable from "../components/PredictionsTable";
 import {
-  RoundPrediction,
   fetchRoundPredictions,
-  Metrics,
   fetchRoundMetrics,
 } from "../.server/predictionService";
 import {
@@ -61,11 +59,10 @@ export const loader = async ({ request }: LoaderFunctionArgs) => {
     roundNumbers
   );
 
-  const predictions: RoundPrediction[] = await fetchRoundPredictions(
-    currentSeasonYear,
-    currentRoundNumber
-  );
-  const metrics: Metrics = await fetchRoundMetrics(currentSeasonYear);
+  const [predictions, metrics] = await Promise.all([
+    fetchRoundPredictions(currentSeasonYear, currentRoundNumber),
+    fetchRoundMetrics(currentSeasonYear),
+  ]);
 
   return json({
     currentRoundNumber,

--- a/app/routes/_index.tsx
+++ b/app/routes/_index.tsx
@@ -66,7 +66,8 @@ export const loader = async ({ request }: LoaderFunctionArgs) => {
   if (!currentRoundNumber) throw Error("No round prediction data found");
 
   const predictions: RoundPrediction[] = await fetchRoundPredictions(
-    currentSeasonYear
+    currentSeasonYear,
+    currentRoundNumber
   );
   const metrics: Metrics = await fetchRoundMetrics(currentSeasonYear);
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -7,6 +7,7 @@
       "name": "tipresias",
       "hasInstallScript": true,
       "dependencies": {
+        "@chakra-ui/icons": "^2.1.1",
         "@chakra-ui/react": "^2.6.1",
         "@emotion/cache": "^11.11.0",
         "@emotion/react": "^11.11.0",
@@ -1099,6 +1100,18 @@
       "integrity": "sha512-xxjGLvlX2Ys4H0iHrI16t74rG9EBcpFvJ3Y3B7KMQTrnW34Kf7Da/UC8J67Gtx85mTHW020ml85SVPKORWNNKQ==",
       "dependencies": {
         "@chakra-ui/shared-utils": "2.0.5"
+      },
+      "peerDependencies": {
+        "@chakra-ui/system": ">=2.0.0",
+        "react": ">=18"
+      }
+    },
+    "node_modules/@chakra-ui/icons": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/@chakra-ui/icons/-/icons-2.1.1.tgz",
+      "integrity": "sha512-3p30hdo4LlRZTT5CwoAJq3G9fHI0wDc0pBaMHj4SUn0yomO+RcDRlzhdXqdr5cVnzax44sqXJVnf3oQG0eI+4g==",
+      "dependencies": {
+        "@chakra-ui/icon": "3.2.0"
       },
       "peerDependencies": {
         "@chakra-ui/system": ">=2.0.0",

--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
     "seed": "ts-node prisma/seed.ts"
   },
   "dependencies": {
+    "@chakra-ui/icons": "^2.1.1",
     "@chakra-ui/react": "^2.6.1",
     "@emotion/cache": "^11.11.0",
     "@emotion/react": "^11.11.0",

--- a/tests/.server/predictionService.test.ts
+++ b/tests/.server/predictionService.test.ts
@@ -14,6 +14,7 @@ const mockSqlQuery = jest.spyOn(db, "sqlQuery");
 
 describe("fetchRoundPredictions", () => {
   const seasonYear = 2020;
+  const roundNumber = 5;
 
   beforeAll(() => {
     const fakePredictions = new Array(9).fill(null).map(() => ({
@@ -31,7 +32,7 @@ describe("fetchRoundPredictions", () => {
   });
 
   it("fetches predictions from the DB", async () => {
-    const predictions = await fetchRoundPredictions(seasonYear);
+    const predictions = await fetchRoundPredictions(seasonYear, roundNumber);
     expect(predictions).toHaveLength(9);
     predictions.forEach((prediction) => {
       expect(prediction).toMatchObject({

--- a/tests/.server/seasonService.test.ts
+++ b/tests/.server/seasonService.test.ts
@@ -4,7 +4,7 @@
 
 import {
   Round,
-  fetchLatestPredictedRound,
+  fetchPredictedRoundNumbers,
   fetchSeasons,
 } from "../../app/.server/seasonService";
 import * as db from "../../app/.server/db";
@@ -31,22 +31,27 @@ describe("fetchSeasons", () => {
   });
 });
 
-describe("fetchLatestPredictedRound", () => {
+describe("fetchPredictedRoundNumbers", () => {
   const season = 2020;
 
-  describe("when a round number is available", () => {
-    const roundNumber = 5;
+  describe("when round numbers are available", () => {
+    const roundNumbers = Array(5)
+      .fill(null)
+      .map((_, idx) => ({
+        roundNumber: idx + 1,
+      }));
 
     beforeAll(() => {
-      const mockSqlQueryImplementation = (async () => [
-        { number: roundNumber },
-      ]) as typeof db.sqlQuery<Round[]>;
+      const mockSqlQueryImplementation = (async () =>
+        roundNumbers) as typeof db.sqlQuery<Round[]>;
       mockSqlQuery.mockImplementation(mockSqlQueryImplementation);
     });
 
-    it("fetches a round number", async () => {
-      const latestPredictedRound = await fetchLatestPredictedRound(season);
-      expect(latestPredictedRound).toEqual(roundNumber);
+    it("fetches round numbers", async () => {
+      const predictedRoundNumbers = await fetchPredictedRoundNumbers(season);
+      expect(predictedRoundNumbers).toEqual(
+        roundNumbers.map(({ roundNumber }) => roundNumber)
+      );
     });
   });
 
@@ -58,9 +63,9 @@ describe("fetchLatestPredictedRound", () => {
       mockSqlQuery.mockImplementation(mockSqlQueryImplementation);
     });
 
-    it("fetches a round number", async () => {
-      const latestPredictedRound = await fetchLatestPredictedRound(season);
-      expect(latestPredictedRound).toBeNull();
+    it("is empty", async () => {
+      const predictedRoundNumbers = await fetchPredictedRoundNumbers(season);
+      expect(predictedRoundNumbers).toEqual([]);
     });
   });
 });

--- a/tests/components/PredictionsTable.test.tsx
+++ b/tests/components/PredictionsTable.test.tsx
@@ -29,7 +29,7 @@ describe("PredictionsTable", () => {
       );
 
       screen.getByText(
-        `Predictions for round ${currentRound}, ${currentSeason}`
+        `Predictions for Round ${currentRound}, ${currentSeason}`
       );
     });
 

--- a/tests/components/RoundSelect.test.tsx
+++ b/tests/components/RoundSelect.test.tsx
@@ -1,0 +1,26 @@
+import { render, screen } from "@testing-library/react";
+import { userEvent } from "@testing-library/user-event";
+
+import RoundSelect from "../../app/components/RoundSelect";
+
+const mockSubmit = jest.fn();
+const roundNumbers = [1, 2, 3, 4, 5];
+const currentRoundNumber = 5;
+
+describe("SeasonSelect", () => {
+  it("submits the form on option select", async () => {
+    const user = userEvent.setup();
+
+    render(
+      <RoundSelect
+        submit={mockSubmit}
+        roundNumbers={roundNumbers}
+        currentRoundNumber={currentRoundNumber}
+      />
+    );
+
+    const select = screen.getByLabelText<HTMLSelectElement>("Round");
+    await user.selectOptions(select, "1");
+    expect(mockSubmit).toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
Since I'm not planning on running the tipping model again anytime
soon, it would be kind of boring to only display the prediction
for the final round of each season. So, the user can select
different rounds to see more historical predictions.