### PR TITLE
Fetch round metrics data in format that Recharts understands

### DIFF
--- a/.eslintrc.cjs
+++ b/.eslintrc.cjs
@@ -85,6 +85,7 @@ module.exports = {
   rules: {
     // There are plenty of times when you want to make sure a hook just runs once,
     // so I don't find this rule particularly helpful
-    'react-hooks/exhaustive-deps': "off"
+    "react-hooks/exhaustive-deps": "off",
+    "@typescript-eslint/no-unused-vars": ["error", { "argsIgnorePattern": "^_" }]
   }
 };

--- a/app/.server/predictionService.ts
+++ b/app/.server/predictionService.ts
@@ -136,10 +136,10 @@ const buildRoundMetricsQuery = (seasonYear: number) => `
     json_agg("RoundMetrics".bits) AS bits
   FROM (
     SELECT
-      (json_build_object('roundNumber', "Metrics"."roundNumber")::jsonb || json_object_agg("Metrics".name, "Metrics"."totalTips")::jsonb)::json AS "totalTips",
-      (json_build_object('roundNumber', "Metrics"."roundNumber")::jsonb || json_object_agg("Metrics".name, "Metrics".accuracy)::jsonb)::json AS accuracy,
-      (json_build_object('roundNumber', "Metrics"."roundNumber")::jsonb || json_object_agg("Metrics".name, "Metrics".mae)::jsonb)::json AS mae,
-      (json_build_object('roundNumber', "Metrics"."roundNumber")::jsonb || json_object_agg("Metrics".name, "Metrics".bits)::jsonb)::json AS bits
+      (json_build_object('roundNumber', "Metrics"."roundNumber")::jsonb || json_object_agg_strict("Metrics".name, "Metrics"."totalTips")::jsonb)::json AS "totalTips",
+      (json_build_object('roundNumber', "Metrics"."roundNumber")::jsonb || json_object_agg_strict("Metrics".name, "Metrics".accuracy)::jsonb)::json AS accuracy,
+      (json_build_object('roundNumber', "Metrics"."roundNumber")::jsonb || json_object_agg_strict("Metrics".name, "Metrics".mae)::jsonb)::json AS mae,
+      (json_build_object('roundNumber', "Metrics"."roundNumber")::jsonb || json_object_agg_strict("Metrics".name, "Metrics".bits)::jsonb)::json AS bits
     FROM (
       SELECT DISTINCT
         "Match"."roundNumber",

--- a/app/.server/predictionService.ts
+++ b/app/.server/predictionService.ts
@@ -9,7 +9,7 @@ export interface RoundPrediction {
   isCorrect: boolean | null;
 }
 
-export interface Metrics {
+export interface SeasonMetrics {
   totalTips: number | null;
   accuracy: number | null;
   mae: number | null;
@@ -104,16 +104,16 @@ const buildSeasonMetricsQuery = (seasonYear: number) => `
   AND "Prediction"."isCorrect" IS NOT NULL
   AND "Season".year = ${seasonYear}
 `;
-const BLANK_METRICS: Metrics = {
+const BLANK_SEASON_METRICS: SeasonMetrics = {
   totalTips: null,
   accuracy: null,
   mae: null,
   bits: null,
 };
-export const fetchRoundMetrics = (seasonYear: number) =>
+export const fetchSeasonMetrics = (seasonYear: number) =>
   R.pipe(
     buildSeasonMetricsQuery,
-    sqlQuery<Metrics[]>,
-    R.andThen(R.head<Metrics>),
-    R.andThen(R.defaultTo(BLANK_METRICS))
+    sqlQuery<SeasonMetrics[]>,
+    R.andThen(R.head<SeasonMetrics>),
+    R.andThen(R.defaultTo(BLANK_SEASON_METRICS))
   )(seasonYear);

--- a/app/.server/predictionService.ts
+++ b/app/.server/predictionService.ts
@@ -15,6 +15,16 @@ export interface SeasonMetrics {
   mae: number | null;
   bits: number | null;
 }
+interface MlModelRoundMetrics {
+  roundNumber: number;
+  [mlModelName: string]: number;
+}
+export interface RoundMetrics {
+  totalTips: MlModelRoundMetrics[];
+  accuracy: MlModelRoundMetrics[];
+  mae: MlModelRoundMetrics[];
+  bits: MlModelRoundMetrics[];
+}
 
 const buildRoundPredictionQuery = (seasonYear: number, roundNumber: number) => `
   WITH "PrincipalPrediction" AS (
@@ -116,4 +126,69 @@ export const fetchSeasonMetrics = (seasonYear: number) =>
     sqlQuery<SeasonMetrics[]>,
     R.andThen(R.head<SeasonMetrics>),
     R.andThen(R.defaultTo(BLANK_SEASON_METRICS))
+  )(seasonYear);
+
+const buildRoundMetricsQuery = (seasonYear: number) => `
+  SELECT
+    json_agg("RoundMetrics"."totalTips") AS "totalTips",
+    json_agg("RoundMetrics".accuracy) AS accuracy,
+    json_agg("RoundMetrics".mae) AS mae,
+    json_agg("RoundMetrics".bits) AS bits
+  FROM (
+    SELECT
+      (json_build_object('roundNumber', "Metrics"."roundNumber")::jsonb || json_object_agg("Metrics".name, "Metrics"."totalTips")::jsonb)::json AS "totalTips",
+      (json_build_object('roundNumber', "Metrics"."roundNumber")::jsonb || json_object_agg("Metrics".name, "Metrics".accuracy)::jsonb)::json AS accuracy,
+      (json_build_object('roundNumber', "Metrics"."roundNumber")::jsonb || json_object_agg("Metrics".name, "Metrics".mae)::jsonb)::json AS mae,
+      (json_build_object('roundNumber', "Metrics"."roundNumber")::jsonb || json_object_agg("Metrics".name, "Metrics".bits)::jsonb)::json AS bits
+    FROM (
+      SELECT DISTINCT
+        "Match"."roundNumber",
+        "MlModel".name,
+        SUM("Prediction"."isCorrect"::int) OVER "PerModelRound"::int AS "totalTips",
+        AVG("Prediction"."isCorrect"::int) OVER "PerModelRound"::float AS accuracy,
+        AVG(
+          CASE
+          WHEN "Prediction"."isCorrect" IS TRUE
+            THEN ABS("Match".margin - "Prediction"."predictedMargin")
+          ELSE
+            "Match".margin + "Prediction"."predictedMargin"
+          END
+        ) FILTER(WHERE "Prediction"."predictedMargin" IS NOT NULL) OVER "PerModelRound"::float AS mae,
+        SUM(
+          (
+          CASE
+            WHEN "Match".margin = 0
+            THEN 1 + (0.5 * LOG(2, ("Prediction"."predictedWinProbability" * (1 - "Prediction"."predictedWinProbability"))::numeric))
+            WHEN "Match".margin <> 0 AND "Prediction"."isCorrect" IS TRUE
+            THEN 1 + LOG(2, "Prediction"."predictedWinProbability"::numeric)
+            WHEN "Prediction"."isCorrect" IS FALSE
+            THEN 1 + LOG(2, (1 - "Prediction"."predictedWinProbability")::numeric)
+            END
+          )::float
+        ) FILTER(WHERE "Prediction"."predictedWinProbability" IS NOT NULL) OVER "PerModelRound"::float AS bits
+      FROM "Prediction"
+      INNER JOIN "MlModel" ON "MlModel".id = "Prediction"."mlModelId"
+      INNER JOIN "Match" ON "Match".id = "Prediction"."matchId"
+      INNER JOIN "Season" ON "Season".id = "Match"."seasonId"
+      INNER JOIN "MlModelSeason" ON "MlModelSeason"."mlModelId" = "MlModel".id AND "MlModelSeason"."seasonId" = "Season".id
+      WHERE "Prediction"."isCorrect" IS NOT NULL
+      AND "Season".year = ${seasonYear}
+      WINDOW "PerModelRound" AS (PARTITION BY "MlModel".name ORDER BY "Match"."roundNumber" ASC)
+      ORDER BY "Match"."roundNumber" ASC, "MlModel".name
+    ) AS "Metrics"
+    GROUP BY "Metrics"."roundNumber"
+  ) AS "RoundMetrics"
+`;
+const BLANK_ROUND_METRICS: RoundMetrics = {
+  totalTips: [],
+  accuracy: [],
+  mae: [],
+  bits: [],
+};
+export const fetchRoundMetrics = (seasonYear: number) =>
+  R.pipe(
+    buildRoundMetricsQuery,
+    sqlQuery<RoundMetrics[]>,
+    R.andThen(R.head<RoundMetrics>),
+    R.andThen(R.defaultTo(BLANK_ROUND_METRICS))
   )(seasonYear);

--- a/app/.server/predictionService.ts
+++ b/app/.server/predictionService.ts
@@ -15,7 +15,7 @@ export interface SeasonMetrics {
   mae: number | null;
   bits: number | null;
 }
-interface MlModelRoundMetrics {
+export interface MlModelRoundMetrics {
   roundNumber: number;
   [mlModelName: string]: number;
 }

--- a/app/components/MetricsChart.tsx
+++ b/app/components/MetricsChart.tsx
@@ -1,0 +1,65 @@
+import {
+  CartesianGrid,
+  Legend,
+  Line,
+  LineChart,
+  ResponsiveContainer,
+  Tooltip,
+  XAxis,
+  YAxis,
+} from "recharts";
+import { RoundMetrics } from "../.server/predictionService";
+
+interface MetricsChartProps {
+  roundMetrics: RoundMetrics;
+}
+
+const CHART_PALETTE = [
+  "#E69F00",
+  "#56B4E9",
+  "#CC79A7",
+  "#009E73",
+  "#0072B2",
+  "#D55E00",
+  "#F0E442",
+];
+
+const MetricsChart = ({ roundMetrics }: MetricsChartProps) => (
+  <ResponsiveContainer width="100%" height={600}>
+    <LineChart data={roundMetrics.totalTips}>
+      <CartesianGrid />
+      <XAxis
+        dataKey="roundNumber"
+        label={{
+          value: "Rounds",
+          position: "insideBottom",
+          offset: 25,
+        }}
+        height={70}
+      />
+      <YAxis
+        label={{
+          value: "Total Tips",
+          angle: -90,
+          position: "insideLeft",
+          offset: 15,
+        }}
+      />
+      <Tooltip itemSorter={({ value }) => -(value ?? 0)} />
+      <Legend />
+      {Object.keys(roundMetrics.totalTips[0])
+        .filter((key) => key !== "roundNumber")
+        .sort()
+        .map((mlModelName, idx) => (
+          <Line
+            key={mlModelName}
+            dataKey={mlModelName}
+            stroke={CHART_PALETTE[idx]}
+            fill={CHART_PALETTE[idx]}
+          />
+        ))}
+    </LineChart>
+  </ResponsiveContainer>
+);
+
+export default MetricsChart;

--- a/app/components/MetricsChart.tsx
+++ b/app/components/MetricsChart.tsx
@@ -11,12 +11,20 @@ import {
 import { Flex, FormControl, FormLabel, Select } from "@chakra-ui/react";
 import { useState } from "react";
 
-import { RoundMetrics } from "../.server/predictionService";
+import {
+  MlModelRoundMetrics,
+  RoundMetrics,
+} from "../.server/predictionService";
 
 interface MetricsChartProps {
   roundMetrics: RoundMetrics;
 }
 type MetricName = keyof RoundMetrics;
+interface MetricSelectProps {
+  roundMetrics: RoundMetrics;
+  currentMetric: MetricName;
+  setCurrentMetric: (metric: MetricName) => void;
+}
 
 const CHART_PALETTE = [
   "#E69F00",
@@ -37,37 +45,56 @@ const METRIC_LABELS = {
 const isMetricName = (maybeMetricName: string): maybeMetricName is MetricName =>
   Object.keys(METRIC_LABELS).includes(maybeMetricName);
 
+const getModelNames = (mlModelRoundMetrics: MlModelRoundMetrics[]) =>
+  Object.keys(mlModelRoundMetrics[0])
+    .filter((key) => key !== "roundNumber")
+    .sort();
+
+const MetricSelect = ({
+  roundMetrics,
+  currentMetric,
+  setCurrentMetric,
+}: MetricSelectProps) => (
+  <FormControl
+    margin="0.5rem"
+    maxWidth="30%"
+    marginLeft="auto"
+    marginRight="auto"
+  >
+    <Flex alignItems="center" justifyContent="space-between">
+      <FormLabel margin="0.5rem" size="xl">
+        Metric
+      </FormLabel>
+      <Select
+        name={"metric"}
+        value={currentMetric}
+        onChange={(event) => {
+          const metricName = event.currentTarget.value;
+          if (isMetricName(metricName)) setCurrentMetric(metricName);
+        }}
+      >
+        {Object.entries(roundMetrics)
+          .filter(([_, metricValues]) => getModelNames(metricValues).length)
+          .map(([metric]) => (
+            <option value={metric} key={metric}>
+              {METRIC_LABELS[metric as MetricName]}
+            </option>
+          ))}
+      </Select>
+    </Flex>
+  </FormControl>
+);
+
 const MetricsChart = ({ roundMetrics }: MetricsChartProps) => {
   const [currentMetric, setCurrentMetric] = useState<MetricName>("totalTips");
 
   return (
     <>
-      <FormControl
-        margin="0.5rem"
-        maxWidth="30%"
-        marginLeft="auto"
-        marginRight="auto"
-      >
-        <Flex alignItems="center" justifyContent="space-between">
-          <FormLabel margin="0.5rem" size="xl">
-            Metric
-          </FormLabel>
-          <Select
-            name={"metric"}
-            value={currentMetric}
-            onChange={(event) => {
-              const metricName = event.currentTarget.value;
-              if (isMetricName(metricName)) setCurrentMetric(metricName);
-            }}
-          >
-            {Object.keys(roundMetrics).map((metric) => (
-              <option value={metric} key={metric}>
-                {METRIC_LABELS[metric as MetricName]}
-              </option>
-            ))}
-          </Select>
-        </Flex>
-      </FormControl>
+      <MetricSelect
+        roundMetrics={roundMetrics}
+        currentMetric={currentMetric}
+        setCurrentMetric={setCurrentMetric}
+      />
       <ResponsiveContainer width="100%" height={600}>
         <LineChart data={roundMetrics[currentMetric]}>
           <CartesianGrid />
@@ -90,17 +117,16 @@ const MetricsChart = ({ roundMetrics }: MetricsChartProps) => {
           />
           <Tooltip itemSorter={({ value }) => -(value ?? 0)} />
           <Legend />
-          {Object.keys(roundMetrics[currentMetric][0])
-            .filter((key) => key !== "roundNumber")
-            .sort()
-            .map((mlModelName, idx) => (
+          {getModelNames(roundMetrics[currentMetric]).map(
+            (mlModelName, idx) => (
               <Line
                 key={mlModelName}
                 dataKey={mlModelName}
                 stroke={CHART_PALETTE[idx]}
                 fill={CHART_PALETTE[idx]}
               />
-            ))}
+            )
+          )}
         </LineChart>
       </ResponsiveContainer>
     </>

--- a/app/components/MetricsTable.tsx
+++ b/app/components/MetricsTable.tsx
@@ -8,11 +8,11 @@ import {
   Tr,
 } from "@chakra-ui/react";
 
-import { Metrics } from "../.server/predictionService";
+import { SeasonMetrics } from "../.server/predictionService";
 import { presentNumber, presentPercentage } from "../helpers/number";
 
 interface MetricsTableProps {
-  metrics: Metrics;
+  metrics: SeasonMetrics;
   season: number;
 }
 

--- a/app/routes/_index.tsx
+++ b/app/routes/_index.tsx
@@ -25,26 +25,7 @@ import {
 } from "~/.server/seasonService";
 import SeasonSelect, { CURRENT_SEASON_PARAM } from "~/components/SeasonSelect";
 import RoundSelect, { CURRENT_ROUND_PARAM } from "~/components/RoundSelect";
-import {
-  CartesianGrid,
-  Legend,
-  Line,
-  LineChart,
-  ResponsiveContainer,
-  Tooltip,
-  XAxis,
-  YAxis,
-} from "recharts";
-
-const CHART_PALETTE = [
-  "#E69F00",
-  "#56B4E9",
-  "#CC79A7",
-  "#009E73",
-  "#0072B2",
-  "#D55E00",
-  "#F0E442",
-];
+import MetricsChart from "~/components/MetricsChart";
 
 export const meta: MetaFunction = () => {
   return [
@@ -123,58 +104,27 @@ export default function Index() {
       </Container>
       <Box margin="auto" width="fit-content">
         <Flex alignItems="center" flexWrap="wrap" direction="column">
-          {seasonYears && roundNumbers && currentRoundNumber && (
-            <Form style={{ padding: "1rem" }}>
-              <SeasonSelect
-                submit={submit}
-                seasonYears={seasonYears}
-                currentSeasonYear={currentSeasonYear}
-              />
-              <RoundSelect
-                submit={submit}
-                roundNumbers={roundNumbers}
-                currentRoundNumber={currentRoundNumber}
-              />
-            </Form>
-          )}
-          {currentSeasonYear && (
+          {seasonYears &&
+            roundNumbers &&
+            currentRoundNumber &&
+            currentSeasonYear && (
+              <Form style={{ padding: "1rem" }}>
+                <SeasonSelect
+                  submit={submit}
+                  seasonYears={seasonYears}
+                  currentSeasonYear={currentSeasonYear}
+                />
+                <RoundSelect
+                  submit={submit}
+                  roundNumbers={roundNumbers}
+                  currentRoundNumber={currentRoundNumber}
+                />
+              </Form>
+            )}
+          {roundMetrics && (
             <Card marginTop="1rem" marginBottom="1rem" width="100%">
               <CardBody>
-                <ResponsiveContainer width="100%" height={600}>
-                  <LineChart data={roundMetrics.totalTips}>
-                    <CartesianGrid />
-                    <XAxis
-                      dataKey="roundNumber"
-                      label={{
-                        value: "Rounds",
-                        position: "insideBottom",
-                        offset: 25,
-                      }}
-                      height={70}
-                    />
-                    <YAxis
-                      label={{
-                        value: "Total Tips",
-                        angle: -90,
-                        position: "insideLeft",
-                        offset: 15,
-                      }}
-                    />
-                    <Tooltip itemSorter={({ value }) => -(value ?? 0)} />
-                    <Legend />
-                    {Object.keys(roundMetrics.totalTips[0])
-                      .filter((key) => key !== "roundNumber")
-                      .sort()
-                      .map((mlModelName, idx) => (
-                        <Line
-                          key={mlModelName}
-                          dataKey={mlModelName}
-                          stroke={CHART_PALETTE[idx]}
-                          fill={CHART_PALETTE[idx]}
-                        />
-                      ))}
-                  </LineChart>
-                </ResponsiveContainer>
+                <MetricsChart roundMetrics={roundMetrics} />
               </CardBody>
             </Card>
           )}

--- a/app/routes/_index.tsx
+++ b/app/routes/_index.tsx
@@ -24,6 +24,15 @@ import {
 } from "~/.server/seasonService";
 import SeasonSelect, { CURRENT_SEASON_PARAM } from "~/components/SeasonSelect";
 import RoundSelect, { CURRENT_ROUND_PARAM } from "~/components/RoundSelect";
+import {
+  CartesianGrid,
+  Legend,
+  LineChart,
+  ResponsiveContainer,
+  Tooltip,
+  XAxis,
+  YAxis,
+} from "recharts";
 
 export const meta: MetaFunction = () => {
   return [
@@ -112,6 +121,17 @@ export default function Index() {
                 currentRoundNumber={currentRoundNumber}
               />
             </Form>
+          )}
+          {currentSeasonYear && (
+            <ResponsiveContainer>
+              <LineChart>
+                <CartesianGrid />
+                <XAxis />
+                <YAxis />
+                <Tooltip />
+                <Legend />
+              </LineChart>
+            </ResponsiveContainer>
           )}
           {predictions && currentSeasonYear && currentRoundNumber && (
             <Card marginTop="1rem" marginBottom="1rem">

--- a/app/routes/_index.tsx
+++ b/app/routes/_index.tsx
@@ -16,7 +16,7 @@ import MetricsTable from "../components/MetricsTable";
 import PredictionsTable from "../components/PredictionsTable";
 import {
   fetchRoundPredictions,
-  fetchRoundMetrics,
+  fetchSeasonMetrics,
 } from "../.server/predictionService";
 import {
   fetchPredictedRoundNumbers,
@@ -70,7 +70,7 @@ export const loader = async ({ request }: LoaderFunctionArgs) => {
 
   const [predictions, metrics] = await Promise.all([
     fetchRoundPredictions(currentSeasonYear, currentRoundNumber),
-    fetchRoundMetrics(currentSeasonYear),
+    fetchSeasonMetrics(currentSeasonYear),
   ]);
 
   return json({

--- a/package-lock.json
+++ b/package-lock.json
@@ -22,7 +22,8 @@
         "lodash": "^4.17.21",
         "ramda": "^0.29.1",
         "react": "^18.2.0",
-        "react-dom": "^18.2.0"
+        "react-dom": "^18.2.0",
+        "recharts": "^2.12.7"
       },
       "devDependencies": {
         "@faker-js/faker": "^8.0.2",
@@ -4147,6 +4148,60 @@
       "resolved": "https://registry.npmjs.org/@types/cookie/-/cookie-0.6.0.tgz",
       "integrity": "sha512-4Kh9a6B2bQciAhf7FSuMRRkUWecJgJu9nPnx3yzpsfXX/c50REIqpHY4C82bXP90qrLtXtkDxTZosYO3UpOwlA=="
     },
+    "node_modules/@types/d3-array": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/@types/d3-array/-/d3-array-3.2.1.tgz",
+      "integrity": "sha512-Y2Jn2idRrLzUfAKV2LyRImR+y4oa2AntrgID95SHJxuMUrkNXmanDSed71sRNZysveJVt1hLLemQZIady0FpEg=="
+    },
+    "node_modules/@types/d3-color": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/@types/d3-color/-/d3-color-3.1.3.tgz",
+      "integrity": "sha512-iO90scth9WAbmgv7ogoq57O9YpKmFBbmoEoCHDB2xMBY0+/KVrqAaCDyCE16dUspeOvIxFFRI+0sEtqDqy2b4A=="
+    },
+    "node_modules/@types/d3-ease": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/@types/d3-ease/-/d3-ease-3.0.2.tgz",
+      "integrity": "sha512-NcV1JjO5oDzoK26oMzbILE6HW7uVXOHLQvHshBUW4UMdZGfiY6v5BeQwh9a9tCzv+CeefZQHJt5SRgK154RtiA=="
+    },
+    "node_modules/@types/d3-interpolate": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@types/d3-interpolate/-/d3-interpolate-3.0.4.tgz",
+      "integrity": "sha512-mgLPETlrpVV1YRJIglr4Ez47g7Yxjl1lj7YKsiMCb27VJH9W8NVM6Bb9d8kkpG/uAQS5AmbA48q2IAolKKo1MA==",
+      "dependencies": {
+        "@types/d3-color": "*"
+      }
+    },
+    "node_modules/@types/d3-path": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/@types/d3-path/-/d3-path-3.1.0.tgz",
+      "integrity": "sha512-P2dlU/q51fkOc/Gfl3Ul9kicV7l+ra934qBFXCFhrZMOL6du1TM0pm1ThYvENukyOn5h9v+yMJ9Fn5JK4QozrQ=="
+    },
+    "node_modules/@types/d3-scale": {
+      "version": "4.0.8",
+      "resolved": "https://registry.npmjs.org/@types/d3-scale/-/d3-scale-4.0.8.tgz",
+      "integrity": "sha512-gkK1VVTr5iNiYJ7vWDI+yUFFlszhNMtVeneJ6lUTKPjprsvLLI9/tgEGiXJOnlINJA8FyA88gfnQsHbybVZrYQ==",
+      "dependencies": {
+        "@types/d3-time": "*"
+      }
+    },
+    "node_modules/@types/d3-shape": {
+      "version": "3.1.6",
+      "resolved": "https://registry.npmjs.org/@types/d3-shape/-/d3-shape-3.1.6.tgz",
+      "integrity": "sha512-5KKk5aKGu2I+O6SONMYSNflgiP0WfZIQvVUMan50wHsLG1G94JlxEVnCpQARfTtzytuY0p/9PXXZb3I7giofIA==",
+      "dependencies": {
+        "@types/d3-path": "*"
+      }
+    },
+    "node_modules/@types/d3-time": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/@types/d3-time/-/d3-time-3.0.3.tgz",
+      "integrity": "sha512-2p6olUZ4w3s+07q3Tm2dbiMZy5pCDfYwtLXXHUnVzXgQlZ/OyPtUz6OL382BkOuGlLXqfT+wqv8Fw2v8/0geBw=="
+    },
+    "node_modules/@types/d3-timer": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/@types/d3-timer/-/d3-timer-3.0.2.tgz",
+      "integrity": "sha512-Ps3T8E8dZDam6fUyNiMkekK3XUsaUEik+idO9/YjPtfj2qruF8tFBXS7XhtE4iIXBLxhmLjP3SXpLhVf21I9Lw=="
+    },
     "node_modules/@types/debug": {
       "version": "4.1.12",
       "resolved": "https://registry.npmjs.org/@types/debug/-/debug-4.1.12.tgz",
@@ -5836,6 +5891,14 @@
         "node": ">=0.8"
       }
     },
+    "node_modules/clsx": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/clsx/-/clsx-2.1.1.tgz",
+      "integrity": "sha512-eYm0QWBtUrBWZWG0d386OGAw16Z995PiOVo2B7bjWSbHedGl5e0ZWaq65kOGgUSNesEIDkB9ISbTg/JK9dhCZA==",
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/co": {
       "version": "4.6.0",
       "resolved": "https://registry.npmjs.org/co/-/co-4.6.0.tgz",
@@ -6161,6 +6224,116 @@
       "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.1.3.tgz",
       "integrity": "sha512-M1uQkMl8rQK/szD0LNhtqxIPLpimGm8sOBwU7lLnCpSbTyY3yeU1Vc7l4KT5zT4s/yOxHH5O7tIuuLOCnLADRw=="
     },
+    "node_modules/d3-array": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/d3-array/-/d3-array-3.2.4.tgz",
+      "integrity": "sha512-tdQAmyA18i4J7wprpYq8ClcxZy3SC31QMeByyCFyRt7BVHdREQZ5lpzoe5mFEYZUWe+oq8HBvk9JjpibyEV4Jg==",
+      "dependencies": {
+        "internmap": "1 - 2"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-color": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/d3-color/-/d3-color-3.1.0.tgz",
+      "integrity": "sha512-zg/chbXyeBtMQ1LbD/WSoW2DpC3I0mpmPdW+ynRTj/x2DAWYrIY7qeZIHidozwV24m4iavr15lNwIwLxRmOxhA==",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-ease": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-ease/-/d3-ease-3.0.1.tgz",
+      "integrity": "sha512-wR/XK3D3XcLIZwpbvQwQ5fK+8Ykds1ip7A2Txe0yxncXSdq1L9skcG7blcedkOX+ZcgxGAmLX1FrRGbADwzi0w==",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-format": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/d3-format/-/d3-format-3.1.0.tgz",
+      "integrity": "sha512-YyUI6AEuY/Wpt8KWLgZHsIU86atmikuoOmCfommt0LYHiQSPjvX2AcFc38PX0CBpr2RCyZhjex+NS/LPOv6YqA==",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-interpolate": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-interpolate/-/d3-interpolate-3.0.1.tgz",
+      "integrity": "sha512-3bYs1rOD33uo8aqJfKP3JWPAibgw8Zm2+L9vBKEHJ2Rg+viTR7o5Mmv5mZcieN+FRYaAOWX5SJATX6k1PWz72g==",
+      "dependencies": {
+        "d3-color": "1 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-path": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/d3-path/-/d3-path-3.1.0.tgz",
+      "integrity": "sha512-p3KP5HCf/bvjBSSKuXid6Zqijx7wIfNW+J/maPs+iwR35at5JCbLUT0LzF1cnjbCHWhqzQTIN2Jpe8pRebIEFQ==",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-scale": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/d3-scale/-/d3-scale-4.0.2.tgz",
+      "integrity": "sha512-GZW464g1SH7ag3Y7hXjf8RoUuAFIqklOAq3MRl4OaWabTFJY9PN/E1YklhXLh+OQ3fM9yS2nOkCoS+WLZ6kvxQ==",
+      "dependencies": {
+        "d3-array": "2.10.0 - 3",
+        "d3-format": "1 - 3",
+        "d3-interpolate": "1.2.0 - 3",
+        "d3-time": "2.1.1 - 3",
+        "d3-time-format": "2 - 4"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-shape": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/d3-shape/-/d3-shape-3.2.0.tgz",
+      "integrity": "sha512-SaLBuwGm3MOViRq2ABk3eLoxwZELpH6zhl3FbAoJ7Vm1gofKx6El1Ib5z23NUEhF9AsGl7y+dzLe5Cw2AArGTA==",
+      "dependencies": {
+        "d3-path": "^3.1.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-time": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/d3-time/-/d3-time-3.1.0.tgz",
+      "integrity": "sha512-VqKjzBLejbSMT4IgbmVgDjpkYrNWUYJnbCGo874u7MMKIWsILRX+OpX/gTk8MqjpT1A/c6HY2dCA77ZN0lkQ2Q==",
+      "dependencies": {
+        "d3-array": "2 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-time-format": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/d3-time-format/-/d3-time-format-4.1.0.tgz",
+      "integrity": "sha512-dJxPBlzC7NugB2PDLwo9Q8JiTR3M3e4/XANkreKSUxF8vvXKqm1Yfq4Q5dl8budlunRVlUUaDUgFt7eA8D6NLg==",
+      "dependencies": {
+        "d3-time": "1 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-timer": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-timer/-/d3-timer-3.0.1.tgz",
+      "integrity": "sha512-ndfJ/JxxMd3nw31uyKoY2naivF+r29V+Lc0svZxe1JvvIRmi8hUsrMvdOwgS1o6uBHmiz91geQ0ylPP0aj1VUA==",
+      "engines": {
+        "node": ">=12"
+      }
+    },
     "node_modules/damerau-levenshtein": {
       "version": "1.0.8",
       "resolved": "https://registry.npmjs.org/damerau-levenshtein/-/damerau-levenshtein-1.0.8.tgz",
@@ -6262,6 +6435,11 @@
       "resolved": "https://registry.npmjs.org/decimal.js/-/decimal.js-10.4.3.tgz",
       "integrity": "sha512-VBBaLc1MgL5XpzgIP7ny5Z6Nx3UrRkIViUkPUdtl9aya5amy3De1gsUUSB1g3+3sExYNjCAsAznmukyxCb1GRA==",
       "dev": true
+    },
+    "node_modules/decimal.js-light": {
+      "version": "2.5.1",
+      "resolved": "https://registry.npmjs.org/decimal.js-light/-/decimal.js-light-2.5.1.tgz",
+      "integrity": "sha512-qIMFpTMZmny+MMIitAB6D7iVPEorVw6YQRWkvarTkT4tBeSLLiHzcwj6q0MmYSFCiVpiqPJTJEYIrpcPzVEIvg=="
     },
     "node_modules/decode-named-character-reference": {
       "version": "1.0.2",
@@ -6484,6 +6662,15 @@
       "resolved": "https://registry.npmjs.org/dom-accessibility-api/-/dom-accessibility-api-0.5.16.tgz",
       "integrity": "sha512-X7BJ2yElsnOJ30pZF4uIIDfBEVgF4XEBxL9Bxhy6dnrm5hkzqmsWHGTiHqRiITNhMyFLyAiWndIJP7Z1NTteDg==",
       "dev": true
+    },
+    "node_modules/dom-helpers": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/dom-helpers/-/dom-helpers-5.2.1.tgz",
+      "integrity": "sha512-nRCa7CK3VTrM2NmGkIy4cbK7IZlgBE/PYMn55rrXefr5xXDP0LdtfPnblFDoVdcAfslJ7or6iqAUnx0CCGIWQA==",
+      "dependencies": {
+        "@babel/runtime": "^7.8.7",
+        "csstype": "^3.0.2"
+      }
     },
     "node_modules/domexception": {
       "version": "4.0.0",
@@ -7664,6 +7851,11 @@
         "node": ">=6"
       }
     },
+    "node_modules/eventemitter3": {
+      "version": "4.0.7",
+      "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-4.0.7.tgz",
+      "integrity": "sha512-8guHBZCwKnFhYdHr2ysuRWErTwhoN2X8XELRlrRwpmfeY2jjuUN4taQMsULKUVo1K4DvZl+0pgfyoysHxvmvEw=="
+    },
     "node_modules/execa": {
       "version": "5.1.1",
       "resolved": "https://registry.npmjs.org/execa/-/execa-5.1.1.tgz",
@@ -7813,6 +8005,14 @@
       "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
       "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
       "dev": true
+    },
+    "node_modules/fast-equals": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/fast-equals/-/fast-equals-5.0.1.tgz",
+      "integrity": "sha512-WF1Wi8PwwSY7/6Kx0vKXtw8RwuSGoM1bvDaJbu7MxDlR1vovZjIAKrnzyrThgAjm6JDTu0fVgWXDlMGspodfoQ==",
+      "engines": {
+        "node": ">=6.0.0"
+      }
     },
     "node_modules/fast-glob": {
       "version": "3.3.2",
@@ -8817,6 +9017,14 @@
       },
       "engines": {
         "node": ">= 0.4"
+      }
+    },
+    "node_modules/internmap": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/internmap/-/internmap-2.0.3.tgz",
+      "integrity": "sha512-5Hh7Y1wQbvY5ooGgPbDaL5iYLAPzMTUrjMulskHLH6wnv/A+1q5rgEaiuqEjB+oxGXIVZs1FF+R/KPN3ZSQYYg==",
+      "engines": {
+        "node": ">=12"
       }
     },
     "node_modules/invariant": {
@@ -13405,6 +13613,20 @@
         "react-dom": ">=16.8"
       }
     },
+    "node_modules/react-smooth": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/react-smooth/-/react-smooth-4.0.1.tgz",
+      "integrity": "sha512-OE4hm7XqR0jNOq3Qmk9mFLyd6p2+j6bvbPJ7qlB7+oo0eNcL2l7WQzG6MBnT3EXY6xzkLMUBec3AfewJdA0J8w==",
+      "dependencies": {
+        "fast-equals": "^5.0.1",
+        "prop-types": "^15.8.1",
+        "react-transition-group": "^4.4.5"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0",
+        "react-dom": "^16.8.0 || ^17.0.0 || ^18.0.0"
+      }
+    },
     "node_modules/react-style-singleton": {
       "version": "2.2.1",
       "resolved": "https://registry.npmjs.org/react-style-singleton/-/react-style-singleton-2.2.1.tgz",
@@ -13425,6 +13647,21 @@
         "@types/react": {
           "optional": true
         }
+      }
+    },
+    "node_modules/react-transition-group": {
+      "version": "4.4.5",
+      "resolved": "https://registry.npmjs.org/react-transition-group/-/react-transition-group-4.4.5.tgz",
+      "integrity": "sha512-pZcd1MCJoiKiBR2NRxeCRg13uCXbydPnmB4EOeRrY7480qNWO8IIgQG6zlDkm6uRMsURXPuKq0GWtiM59a5Q6g==",
+      "dependencies": {
+        "@babel/runtime": "^7.5.5",
+        "dom-helpers": "^5.0.1",
+        "loose-envify": "^1.4.0",
+        "prop-types": "^15.6.2"
+      },
+      "peerDependencies": {
+        "react": ">=16.6.0",
+        "react-dom": ">=16.6.0"
       }
     },
     "node_modules/readable-stream": {
@@ -13452,6 +13689,36 @@
       },
       "engines": {
         "node": ">=8.10.0"
+      }
+    },
+    "node_modules/recharts": {
+      "version": "2.12.7",
+      "resolved": "https://registry.npmjs.org/recharts/-/recharts-2.12.7.tgz",
+      "integrity": "sha512-hlLJMhPQfv4/3NBSAyq3gzGg4h2v69RJh6KU7b3pXYNNAELs9kEoXOjbkxdXpALqKBoVmVptGfLpxdaVYqjmXQ==",
+      "dependencies": {
+        "clsx": "^2.0.0",
+        "eventemitter3": "^4.0.1",
+        "lodash": "^4.17.21",
+        "react-is": "^16.10.2",
+        "react-smooth": "^4.0.0",
+        "recharts-scale": "^0.4.4",
+        "tiny-invariant": "^1.3.1",
+        "victory-vendor": "^36.6.8"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "peerDependencies": {
+        "react": "^16.0.0 || ^17.0.0 || ^18.0.0",
+        "react-dom": "^16.0.0 || ^17.0.0 || ^18.0.0"
+      }
+    },
+    "node_modules/recharts-scale": {
+      "version": "0.4.5",
+      "resolved": "https://registry.npmjs.org/recharts-scale/-/recharts-scale-0.4.5.tgz",
+      "integrity": "sha512-kivNFO+0OcUNu7jQquLXAxz1FIwZj8nrj+YkOKc5694NbjCvcT6aSZiIzNzd2Kul4o4rTto8QVR9lMNtxD4G1w==",
+      "dependencies": {
+        "decimal.js-light": "^2.4.1"
       }
     },
     "node_modules/reflect.getprototypeof": {
@@ -16021,6 +16288,27 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/victory-vendor": {
+      "version": "36.9.2",
+      "resolved": "https://registry.npmjs.org/victory-vendor/-/victory-vendor-36.9.2.tgz",
+      "integrity": "sha512-PnpQQMuxlwYdocC8fIJqVXvkeViHYzotI+NJrCuav0ZYFoq912ZHBk3mCeuj+5/VpodOjPe1z0Fk2ihgzlXqjQ==",
+      "dependencies": {
+        "@types/d3-array": "^3.0.3",
+        "@types/d3-ease": "^3.0.0",
+        "@types/d3-interpolate": "^3.0.1",
+        "@types/d3-scale": "^4.0.2",
+        "@types/d3-shape": "^3.1.0",
+        "@types/d3-time": "^3.0.0",
+        "@types/d3-timer": "^3.0.0",
+        "d3-array": "^3.1.6",
+        "d3-ease": "^3.0.1",
+        "d3-interpolate": "^3.0.1",
+        "d3-scale": "^4.0.2",
+        "d3-shape": "^3.1.0",
+        "d3-time": "^3.0.0",
+        "d3-timer": "^3.0.1"
       }
     },
     "node_modules/vite": {

--- a/package.json
+++ b/package.json
@@ -31,7 +31,8 @@
     "lodash": "^4.17.21",
     "ramda": "^0.29.1",
     "react": "^18.2.0",
-    "react-dom": "^18.2.0"
+    "react-dom": "^18.2.0",
+    "recharts": "^2.12.7"
   },
   "devDependencies": {
     "@faker-js/faker": "^8.0.2",

--- a/tests/.server/predictionService.test.ts
+++ b/tests/.server/predictionService.test.ts
@@ -3,9 +3,9 @@
  */
 import { faker } from "@faker-js/faker";
 import {
-  Metrics,
+  SeasonMetrics,
   RoundPrediction,
-  fetchRoundMetrics,
+  fetchSeasonMetrics,
   fetchRoundPredictions,
 } from "../../app/.server/predictionService";
 import * as db from "../../app/.server/db";
@@ -45,7 +45,7 @@ describe("fetchRoundPredictions", () => {
   });
 });
 
-describe("fetchRoundMetrics", () => {
+describe("fetchSeasonMetrics", () => {
   const seasonYear = 2020;
 
   describe("when prediction are available", () => {
@@ -59,13 +59,13 @@ describe("fetchRoundMetrics", () => {
         },
       ];
       const mockSqlQueryImplementation = (async () =>
-        fakeMetrics) as typeof db.sqlQuery<Metrics[]>;
+        fakeMetrics) as typeof db.sqlQuery<SeasonMetrics[]>;
       mockSqlQuery.mockImplementation(mockSqlQueryImplementation);
     });
 
     it("returns a metrics object", async () => {
-      const metrics = await fetchRoundMetrics(2020);
-      expect(metrics).toMatchObject<Metrics>({
+      const metrics = await fetchSeasonMetrics(2020);
+      expect(metrics).toMatchObject<SeasonMetrics>({
         totalTips: expect.any(Number),
         accuracy: expect.any(Number),
         mae: expect.any(Number),
@@ -85,13 +85,13 @@ describe("fetchRoundMetrics", () => {
         },
       ];
       const mockSqlQueryImplementation = (async () =>
-        fakeMetrics) as typeof db.sqlQuery<Metrics[]>;
+        fakeMetrics) as typeof db.sqlQuery<SeasonMetrics[]>;
       mockSqlQuery.mockImplementation(mockSqlQueryImplementation);
     });
 
     it("returns a blank metrics object", async () => {
-      const metrics = await fetchRoundMetrics(seasonYear);
-      expect(metrics).toMatchObject<Metrics>({
+      const metrics = await fetchSeasonMetrics(seasonYear);
+      expect(metrics).toMatchObject<SeasonMetrics>({
         totalTips: null,
         accuracy: null,
         mae: null,

--- a/tests/.server/predictionService.test.ts
+++ b/tests/.server/predictionService.test.ts
@@ -7,6 +7,8 @@ import {
   RoundPrediction,
   fetchSeasonMetrics,
   fetchRoundPredictions,
+  RoundMetrics,
+  fetchRoundMetrics,
 } from "../../app/.server/predictionService";
 import * as db from "../../app/.server/db";
 
@@ -96,6 +98,57 @@ describe("fetchSeasonMetrics", () => {
         accuracy: null,
         mae: null,
         bits: null,
+      });
+    });
+  });
+});
+
+describe("fetchRoundMetrics", () => {
+  const seasonYear = 2020;
+
+  describe("when prediction are available", () => {
+    const fakeRoundModelMetrics = [
+      {
+        roundNumber: faker.number.int(),
+        modelA: faker.number.float(),
+        modelB: faker.number.float(),
+      },
+    ];
+    const fakeRoundMetrics = {
+      totalTips: fakeRoundModelMetrics,
+      accuracy: fakeRoundModelMetrics,
+      mae: fakeRoundModelMetrics,
+      bits: fakeRoundModelMetrics,
+    };
+
+    beforeAll(() => {
+      const mockSqlQueryImplementation = (async () => [
+        fakeRoundMetrics,
+      ]) as typeof db.sqlQuery<RoundMetrics[]>;
+      mockSqlQuery.mockImplementation(mockSqlQueryImplementation);
+    });
+
+    it("returns a metrics object", async () => {
+      const metrics = await fetchRoundMetrics(2020);
+      expect(metrics).toMatchObject<RoundMetrics>(fakeRoundMetrics);
+    });
+  });
+
+  describe("when no predictions are available", () => {
+    beforeAll(() => {
+      const fakeRoundMetrics: RoundMetrics[] = [];
+      const mockSqlQueryImplementation = (async () =>
+        fakeRoundMetrics) as typeof db.sqlQuery<RoundMetrics[]>;
+      mockSqlQuery.mockImplementation(mockSqlQueryImplementation);
+    });
+
+    it("returns a blank metrics object", async () => {
+      const metrics = await fetchRoundMetrics(seasonYear);
+      expect(metrics).toMatchObject<RoundMetrics>({
+        totalTips: [],
+        accuracy: [],
+        mae: [],
+        bits: [],
       });
     });
   });

--- a/tests/components/MetricsChart.test.tsx
+++ b/tests/components/MetricsChart.test.tsx
@@ -1,0 +1,38 @@
+import { render, screen } from "@testing-library/react";
+import MetricsChart from "../../app/components/MetricsChart";
+import { faker } from "@faker-js/faker";
+import { userEvent } from "@testing-library/user-event";
+
+// ResponsiveContainer uses ResizeObeserver under the hood,
+// so we need to mock it in order to avoid errors.
+window.ResizeObserver =
+  window.ResizeObserver ||
+  jest.fn().mockImplementation(() => ({
+    disconnect: jest.fn(),
+    observe: jest.fn(),
+    unobserve: jest.fn(),
+  }));
+
+describe("MetricsChart", () => {
+  const fakeRoundModelMetrics = [
+    {
+      roundNumber: faker.number.int(),
+      modelA: faker.number.float(),
+      modelB: faker.number.float(),
+    },
+  ];
+  const fakeRoundMetrics = {
+    totalTips: fakeRoundModelMetrics,
+    accuracy: fakeRoundModelMetrics,
+    mae: fakeRoundModelMetrics,
+    bits: fakeRoundModelMetrics,
+  };
+
+  it("renders the chart", async () => {
+    const user = userEvent.setup();
+    render(<MetricsChart roundMetrics={fakeRoundMetrics} />);
+    const select = screen.getByLabelText<HTMLSelectElement>("Metric");
+    await user.selectOptions(select, "Accuracy");
+    expect(select.value).toEqual("accuracy");
+  });
+});


### PR DESCRIPTION
I'm not sure that manipulating JSON data in an SQL query instead
of building the object with reduce, but it was an interesting
exercise.

I decided to send all metrics data per season and switch between them
on the frontend, because triggering a page reload just to view a different
metric seemed like overkill.