### PR TITLE
Use fetcher for non-season data

### DIFF
--- a/app/components/PredictionsTable.tsx
+++ b/app/components/PredictionsTable.tsx
@@ -9,15 +9,19 @@ import {
   Tooltip,
   Tr,
 } from "@chakra-ui/react";
+import { InfoOutlineIcon } from "@chakra-ui/icons";
+import { useCallback, useEffect, useState } from "react";
+import max from "lodash/max";
 
+import RoundSelect from "./RoundSelect";
 import { RoundPrediction } from "../.server/predictionService";
 import { presentNumber, presentPercentage } from "../helpers/number";
-import { InfoOutlineIcon } from "@chakra-ui/icons";
 
 interface PredictionsTableProps {
-  currentRound: number;
-  currentSeason: number;
   predictions: RoundPrediction[];
+  roundNumbers: number[];
+  seasonYear: number;
+  loadData: (href: string) => void;
 }
 
 export const displayCorrectness = (wasCorrect: boolean | null) => {
@@ -60,27 +64,58 @@ const PredictionRow = ({
 );
 
 const PredictionsTable = ({
-  currentRound,
-  currentSeason,
+  loadData,
   predictions,
-}: PredictionsTableProps) => (
-  <TableContainer textAlign="center">
-    <Heading as="h2" size="l" margin="0.5rem" whiteSpace="nowrap">
-      Predictions for Round {currentRound}, {currentSeason}{" "}
-      <PredictionInfoTooltip />
-    </Heading>
-    <Table variant="striped" maxWidth="fit-content">
-      <Thead>
-        <Tr>
-          <Th>Predicted Winner</Th>
-          <Th isNumeric>Predicted Margin</Th>
-          <Th isNumeric>Predicted Win Probability</Th>
-          <Th>Correct?</Th>
-        </Tr>
-      </Thead>
-      <Tbody>{predictions.map(PredictionRow)}</Tbody>
-    </Table>
-  </TableContainer>
-);
+  seasonYear,
+  roundNumbers,
+}: PredictionsTableProps) => {
+  const [roundNumber, setRoundNumber] = useState<number | undefined>(
+    max(roundNumbers)
+  );
+
+  const loadPredictions = useCallback(
+    (newRoundNumber: number) => {
+      loadData(`seasons/${seasonYear}/rounds/${newRoundNumber}/predictions`);
+      setRoundNumber(newRoundNumber);
+    },
+    [seasonYear]
+  );
+
+  useEffect(() => {
+    const newRoundNumber = max(roundNumbers);
+    if (!newRoundNumber) return;
+    setRoundNumber(newRoundNumber);
+    loadPredictions(newRoundNumber);
+  }, [roundNumbers]);
+
+  if (roundNumber === undefined) return null;
+
+  return (
+    <>
+      <RoundSelect
+        loadPredictions={loadPredictions}
+        roundNumbers={roundNumbers}
+        currentRoundNumber={roundNumber}
+      />
+      <TableContainer textAlign="center">
+        <Heading as="h2" size="l" margin="0.5rem" whiteSpace="nowrap">
+          Predictions for Round {roundNumber}, {seasonYear}{" "}
+          <PredictionInfoTooltip />
+        </Heading>
+        <Table variant="striped" maxWidth="fit-content">
+          <Thead>
+            <Tr>
+              <Th>Predicted Winner</Th>
+              <Th isNumeric>Predicted Margin</Th>
+              <Th isNumeric>Predicted Win Probability</Th>
+              <Th>Correct?</Th>
+            </Tr>
+          </Thead>
+          <Tbody>{predictions.map(PredictionRow)}</Tbody>
+        </Table>
+      </TableContainer>
+    </>
+  );
+};
 
 export default PredictionsTable;

--- a/app/components/RoundSelect.tsx
+++ b/app/components/RoundSelect.tsx
@@ -1,7 +1,8 @@
 import { Flex, FormControl, FormLabel, Select } from "@chakra-ui/react";
+import { ChangeEvent } from "react";
 
 interface RoundSelectProps {
-  submit: (form: HTMLFormElement | null) => void;
+  loadPredictions: (roundNumber: number) => void;
   roundNumbers: number[];
   currentRoundNumber: number;
 }
@@ -17,27 +18,34 @@ const RoundOption = ({ roundNumber }: RoundOptionProps) => (
 );
 
 const RoundSelect = ({
-  submit,
+  loadPredictions,
   roundNumbers,
   currentRoundNumber,
-}: RoundSelectProps) => (
-  <FormControl margin="0.5rem">
-    <Flex alignItems="center" justifyContent="space-between">
-      <FormLabel margin="0.5rem" size="xl">
-        Round
-      </FormLabel>
-      <Select
-        name={CURRENT_ROUND_PARAM}
-        value={currentRoundNumber}
-        onChange={(event) => submit(event.currentTarget.form)}
-        maxWidth="60%"
-      >
-        {roundNumbers.map((roundNumber) => (
-          <RoundOption roundNumber={roundNumber} key={roundNumber} />
-        ))}
-      </Select>
-    </Flex>
-  </FormControl>
-);
+}: RoundSelectProps) => {
+  const onRoundChange = (event: ChangeEvent<HTMLSelectElement>) => {
+    const roundNumber = parseInt(event.currentTarget.value);
+    loadPredictions(roundNumber);
+  };
+
+  return (
+    <FormControl margin="0.5rem">
+      <Flex alignItems="center" justifyContent="center">
+        <FormLabel margin="0.5rem" size="xl">
+          Round
+        </FormLabel>
+        <Select
+          name={CURRENT_ROUND_PARAM}
+          value={currentRoundNumber}
+          onChange={onRoundChange}
+          maxWidth="5rem"
+        >
+          {roundNumbers.map((roundNumber) => (
+            <RoundOption roundNumber={roundNumber} key={roundNumber} />
+          ))}
+        </Select>
+      </Flex>
+    </FormControl>
+  );
+};
 
 export default RoundSelect;

--- a/app/routes/_index.tsx
+++ b/app/routes/_index.tsx
@@ -15,8 +15,8 @@ import * as R from "ramda";
 import MetricsTable from "../components/MetricsTable";
 import PredictionsTable from "../components/PredictionsTable";
 import {
+  RoundMetrics,
   RoundPrediction,
-  fetchRoundMetrics,
   fetchSeasonMetrics,
 } from "../.server/predictionService";
 import {
@@ -56,27 +56,21 @@ export const loader = async ({ request }: LoaderFunctionArgs) => {
   const roundNumbers = await fetchPredictedRoundNumbers(currentSeasonYear);
 
   const metrics = await fetchSeasonMetrics(currentSeasonYear);
-  const roundMetrics = await fetchRoundMetrics(currentSeasonYear);
 
   return json({
     roundNumbers,
     metrics,
     currentSeasonYear,
     seasonYears,
-    roundMetrics,
   });
 };
 
 export default function Index() {
-  const {
-    roundNumbers,
-    metrics,
-    seasonYears,
-    currentSeasonYear,
-    roundMetrics,
-  } = useLoaderData<typeof loader>();
+  const { roundNumbers, metrics, seasonYears, currentSeasonYear } =
+    useLoaderData<typeof loader>();
   const submit = useSubmit();
   const predictionFetcher = useFetcher<RoundPrediction[]>();
+  const metricFetcher = useFetcher<RoundMetrics[]>();
 
   return (
     <div
@@ -101,10 +95,14 @@ export default function Index() {
               />
             </Form>
           )}
-          {roundMetrics && (
+          {currentSeasonYear && (
             <Card marginTop="1rem" marginBottom="1rem" width="100%">
               <CardBody>
-                <MetricsChart roundMetrics={roundMetrics} />
+                <MetricsChart
+                  loadData={metricFetcher.load}
+                  seasonYear={currentSeasonYear}
+                  roundMetrics={metricFetcher.data || []}
+                />
               </CardBody>
             </Card>
           )}

--- a/app/routes/seasons.$seasonYear.metrics.$name.tsx
+++ b/app/routes/seasons.$seasonYear.metrics.$name.tsx
@@ -1,0 +1,11 @@
+import { json, LoaderFunctionArgs } from "@remix-run/node";
+import { fetchRoundMetrics, isMetricName } from "~/.server/predictionService";
+
+export const loader = async ({ params }: LoaderFunctionArgs) => {
+  const { seasonYear, name } = params;
+
+  if (!seasonYear || !isMetricName(name)) return json([], { status: 422 });
+
+  const roundMetrics = await fetchRoundMetrics(parseInt(seasonYear), name);
+  return json(roundMetrics);
+};

--- a/app/routes/seasons.$seasonYear.rounds.$roundNumber.predictions.tsx
+++ b/app/routes/seasons.$seasonYear.rounds.$roundNumber.predictions.tsx
@@ -1,0 +1,14 @@
+import { json, LoaderFunctionArgs } from "@remix-run/node";
+import { fetchRoundPredictions } from "~/.server/predictionService";
+
+export const loader = async ({ params }: LoaderFunctionArgs) => {
+  const { seasonYear, roundNumber } = params;
+
+  if (!seasonYear || !roundNumber) return json([], { status: 422 });
+
+  const predictions = await fetchRoundPredictions(
+    parseInt(seasonYear),
+    parseInt(roundNumber)
+  );
+  return json(predictions);
+};

--- a/tests/.server/predictionService.test.ts
+++ b/tests/.server/predictionService.test.ts
@@ -9,6 +9,7 @@ import {
   fetchRoundPredictions,
   RoundMetrics,
   fetchRoundMetrics,
+  RoundMetricsResult,
 } from "../../app/.server/predictionService";
 import * as db from "../../app/.server/db";
 
@@ -114,23 +115,18 @@ describe("fetchRoundMetrics", () => {
         modelB: faker.number.float(),
       },
     ];
-    const fakeRoundMetrics = {
-      totalTips: fakeRoundModelMetrics,
-      accuracy: fakeRoundModelMetrics,
-      mae: fakeRoundModelMetrics,
-      bits: fakeRoundModelMetrics,
-    };
+    const fakeRoundMetrics = { value: fakeRoundModelMetrics };
 
     beforeAll(() => {
       const mockSqlQueryImplementation = (async () => [
         fakeRoundMetrics,
-      ]) as typeof db.sqlQuery<RoundMetrics[]>;
+      ]) as typeof db.sqlQuery<RoundMetricsResult[]>;
       mockSqlQuery.mockImplementation(mockSqlQueryImplementation);
     });
 
     it("returns a metrics object", async () => {
-      const metrics = await fetchRoundMetrics(2020);
-      expect(metrics).toMatchObject<RoundMetrics>(fakeRoundMetrics);
+      const metrics = await fetchRoundMetrics(2020, "totalTips");
+      expect(metrics).toMatchObject<RoundMetrics[]>(fakeRoundModelMetrics);
     });
   });
 
@@ -143,13 +139,8 @@ describe("fetchRoundMetrics", () => {
     });
 
     it("returns a blank metrics object", async () => {
-      const metrics = await fetchRoundMetrics(seasonYear);
-      expect(metrics).toMatchObject<RoundMetrics>({
-        totalTips: [],
-        accuracy: [],
-        mae: [],
-        bits: [],
-      });
+      const metrics = await fetchRoundMetrics(seasonYear, "totalTips");
+      expect(metrics).toEqual([]);
     });
   });
 });

--- a/tests/components/MetricsChart.test.tsx
+++ b/tests/components/MetricsChart.test.tsx
@@ -14,25 +14,28 @@ window.ResizeObserver =
   }));
 
 describe("MetricsChart", () => {
-  const fakeRoundModelMetrics = [
+  const fakeRoundMetrics = [
     {
       roundNumber: faker.number.int(),
       modelA: faker.number.float(),
       modelB: faker.number.float(),
     },
   ];
-  const fakeRoundMetrics = {
-    totalTips: fakeRoundModelMetrics,
-    accuracy: fakeRoundModelMetrics,
-    mae: fakeRoundModelMetrics,
-    bits: fakeRoundModelMetrics,
-  };
+  const mockLoadData = jest.fn();
+  const fakeSeasonYear = 2020;
 
-  it("renders the chart", async () => {
+  it("selects a different metric", async () => {
     const user = userEvent.setup();
-    render(<MetricsChart roundMetrics={fakeRoundMetrics} />);
+    render(
+      <MetricsChart
+        roundMetrics={fakeRoundMetrics}
+        loadData={mockLoadData}
+        seasonYear={fakeSeasonYear}
+      />
+    );
     const select = screen.getByLabelText<HTMLSelectElement>("Metric");
     await user.selectOptions(select, "Accuracy");
+    expect(mockLoadData).toHaveBeenCalled();
     expect(select.value).toEqual("accuracy");
   });
 });

--- a/tests/components/PredictionsTable.test.tsx
+++ b/tests/components/PredictionsTable.test.tsx
@@ -6,8 +6,9 @@ import PredictionsTable, {
 } from "../../app/components/PredictionsTable";
 
 describe("PredictionsTable", () => {
-  const currentRound = faker.number.int();
-  const currentSeason = faker.number.int();
+  const seasonYear = faker.number.int();
+  const roundNumbers = new Array(12).fill(null).map((_, idx) => idx + 1);
+  const fakeLoadData = jest.fn();
 
   describe("when all values are present", () => {
     const predictions = new Array(9).fill(null).map(() => ({
@@ -19,26 +20,30 @@ describe("PredictionsTable", () => {
         null,
     }));
 
-    it("displays the table title", () => {
+    it("displays the table title with year and max round", () => {
       render(
         <PredictionsTable
-          currentRound={currentRound}
-          currentSeason={currentSeason}
+          loadData={fakeLoadData}
           predictions={predictions}
+          seasonYear={seasonYear}
+          roundNumbers={roundNumbers}
         />
       );
 
       screen.getByText(
-        `Predictions for Round ${currentRound}, ${currentSeason}`
+        `Predictions for Round ${
+          roundNumbers[roundNumbers.length - 1]
+        }, ${seasonYear}`
       );
     });
 
     it("displays predictions", () => {
       render(
         <PredictionsTable
-          currentRound={currentRound}
-          currentSeason={currentSeason}
+          loadData={fakeLoadData}
           predictions={predictions}
+          seasonYear={seasonYear}
+          roundNumbers={roundNumbers}
         />
       );
 
@@ -71,9 +76,10 @@ describe("PredictionsTable", () => {
     it("displays NA for missing values", () => {
       render(
         <PredictionsTable
-          currentRound={currentRound}
-          currentSeason={currentSeason}
+          loadData={fakeLoadData}
           predictions={predictions}
+          seasonYear={seasonYear}
+          roundNumbers={roundNumbers}
         />
       );
 

--- a/tests/components/RoundSelect.test.tsx
+++ b/tests/components/RoundSelect.test.tsx
@@ -3,7 +3,7 @@ import { userEvent } from "@testing-library/user-event";
 
 import RoundSelect from "../../app/components/RoundSelect";
 
-const mockSubmit = jest.fn();
+const mockLoadPredictions = jest.fn();
 const roundNumbers = [1, 2, 3, 4, 5];
 const currentRoundNumber = 5;
 
@@ -13,7 +13,7 @@ describe("SeasonSelect", () => {
 
     render(
       <RoundSelect
-        submit={mockSubmit}
+        loadPredictions={mockLoadPredictions}
         roundNumbers={roundNumbers}
         currentRoundNumber={currentRoundNumber}
       />
@@ -21,6 +21,6 @@ describe("SeasonSelect", () => {
 
     const select = screen.getByLabelText<HTMLSelectElement>("Round");
     await user.selectOptions(select, "1");
-    expect(mockSubmit).toHaveBeenCalled();
+    expect(mockLoadPredictions).toHaveBeenCalled();
   });
 });


### PR DESCRIPTION
Fetching round predictions via `fetcher` rather than submitting a form makes for better UX, especially after moving the select down to the round predictions table. Using `fetcher` for the metrics data just saves us having to load all metrics data for a given season on page load.